### PR TITLE
docs(harness): PR #117 レトロ + B0 完了反映

### DIFF
--- a/docs/harness/learnings/2026-05-17-pr-117.md
+++ b/docs/harness/learnings/2026-05-17-pr-117.md
@@ -1,0 +1,100 @@
+---
+id: learning-pr-117
+title: PR #117 レトロスペクティブ (B0 ハーネス骨格)
+type: learning
+status: draft
+related_pr: 117
+related_plan: —
+related_epic: EPIC-000-harness-foundation
+generated_at: 2026-05-17T08:00:00Z
+generator: pr-retrospective Skill (B0 skeleton, 手動運用)
+---
+
+# PR #117 レトロスペクティブ
+
+> 生成: pr-retrospective Skill (B0 skeleton, 手動運用) at 2026-05-17T08:00:00Z
+> 関連 Plan: なし (B0 はブートストラップ単独 PR) / 関連 Epic: EPIC-000-harness-foundation
+> 対象 PR: [feat(harness): bootstrap B0 skeleton tree #117](https://github.com/subroh0508/colormaster/pull/117) (squash merged at 2026-05-17T07:53:18Z, commit `0256be9`)
+> 差分: 96 ファイル / +5408 / -4
+
+## ✅ Keep (継続したいこと)
+
+- **`docs/harness/plan.md` §6.1 と完全一致するスコープ規律**: 19 rules / 10 skills / 5 PR テンプレ / EPIC-000 を逸脱なく配置。code-reviewer 6 aspect で Critical 0、SSoT 競合・機密混入・実装コード regression いずれも未検出。
+- **code-reviewer Skill の 6 aspect 並列サブエージェント実行**: R-37 / ADR 0017 通り、ローカル Claude Code セッション内のサブエージェントで `spec-conformance` / `test-quality` / `architecture` / `security` / `performance` / `code-quality` を並列実行 (visual-regression / design-tokens は A10 後 enable 待ち)。Generator (実装セッション) と Evaluator (review) の分離 (R-13) も成立。
+- **GitHub MCP の不採用と `gh` CLI 採用の費用判断**: 90+ tool schema ロードで約 55k tokens / 10-32x のオーバーヘッド計測を踏まえた決定が、本 PR の gh ベース運用 (PR 作成 / マージ / コメント取得 / CI 監視) でそのまま再現性のある低コストで機能した。
+- **Skill = ディレクトリ + `SKILL.md` 規約**: B0 skeleton として 10 Skill すべて同形式で配置でき、Claude Code 側からも問題なく検出された。`status: skeleton` / `phase: B0` frontmatter で本格化フェーズ (A3) との責務境界も明示できた。
+- **計画フェーズ (docs/harness/plan.md) への先行投資**: B0 PR レビューで露見した課題は本質的に **ラベル / 文言ドリフト** に閉じており、構造的な作り直しはゼロ。設計を Markdown で書き切ってから骨格 PR を切る順序が機能した。
+- **`.gitignore` 完備**: `.env*` / `*-credentials.json` / `data/users.db*` 等を網羅し、本 PR・後続 PR の双方で機密混入リスクを縮減。
+- **worktree ベースの並行実装**: B0 (`feature-B0-harness-bootstrap`) と A1 (`feature-A1-adr-bootstrap`) を物理分離して並走可能であることを実機で確認 (本レトロ起票時点で A1 を別ペインで起動済み)。
+
+## ⚠️ Problem (詰まったこと / 制約)
+
+- **rules-index.md / CLAUDE.md lookup table の「既存」ラベル誤宣言** (consensus: spec-conformance + architecture + code-quality): `viewmodel.md` / `composable.md` / `epic.md` / `plan.md` (rule) / `commit-message.md` / `branch-naming.md` / `markdown.md` / `merge-readiness.md` / `gradle.md` / `kotlin-test.md` など **13 件以上**が「既存 (A2/A3/A6/A7 で本格化)」とラベルされているが `.claude/rules/` に実在しない。CLAUDE.md の lookup table は Read 時の自動ロード対象として参照するため、ドリフトの起点になりやすい。
+- **`.claude/rules/template-language.md` の `paths` 矛盾** (consensus: performance + architecture): rules-index.md / CLAUDE.md は「常時ロード (paths 未設定)」群に含めているが、実体は `paths: - "**/*.md"` で path-scoped。宣言と挙動が乖離。
+- **`code-reviewer/SKILL.md` に PII redaction 強制の本文明記なし** (security): 兄弟 Skill である `pr-retrospective/SKILL.md` は `pii.md` redaction 必須を Gotchas に明記している一方、`code-reviewer/SKILL.md` は `## 関連` で `pii.md` を参照するのみ。Coordinator が PR コメント post 前の redaction を強制する記述が欠落。
+- **PR テンプレ `harness.md` 種別欠落 / plan.md §4.8 と §6.1 の不整合** (spec-conformance): `branch-naming` / CLAUDE.md L83 が `harness/<purpose>` ブランチ種別を正式に認めている一方、PR テンプレは 5 種 (`feature` / `bugfix` / `refactor` / `dependency-upgrade` / `docs`) のみ。本レトロ PR (`harness/learnings-batch-*`) もデフォルトテンプレを流用せざるを得ない。
+- **CI Android 単一テストのフレーキー**: `:core:data:testDebugUnitTest > DefaultIdolColorsRepositorySpec > #search(by name): when lang = 'en'` が初回 CI で FAILED → 再実行で PASS。テスト本体はモック (`mockIdolSearch`) 基盤で外部依存なし。Flow 経由の emission ordering / `flowToList` のタイミング起因が疑わしい。マージ判断で 1 サイクル待たされた。
+- **pr-retrospective Skill 自体が skeleton (本格化は A3)**: 本レトロは手動で生成。retrospective-format.md と learnings/INDEX.md の構造は確立されているが、自動生成パイプライン (`pr-poller` → `pr-retrospective` → batch ブランチ集約 → 週次 PR) は未稼働。R-12 (learning ロスト対策) の運用上の課題が残る。
+- **roadmap-tracker の自動起動も未稼働**: B0 は `implementation-workflow` を経由せず手動マージしたため Phase 8 フックが発火していない。本レトロ PR で手動更新 (B0 行 `in-progress` → `completed` + 完了根拠追記) を実施。
+- **`.dockerignore` 未配置** (security): `db-protection.md` §Gotchas が「`.dockerignore` 規約を併用」と宣言するが本 PR では配置せず。Dockerfile 配置時 (A6 想定) に併せて整備する明示的 TODO が rules 側にない。
+- **`commit-msg` hook の subject 長 50 字制限**: `feat(roadmap-tracker): add concurrency-aware ranking` (51 字) など現実的に超過しやすい。Conventional Commits 公式は subject 長を規定しないため、将来 `commit-message.md` rule との整合確認が必要。
+- **ADR 0017-0027 dangling 参照**: 11 rule が `related_adrs` に ADR を記載するが実体は A1 で起草予定。本 PR は `status: skeleton` で許容しているが、`docs/adr/README.md` に予約一覧を索引化しないと A1 着手時の重複起草や ID 衝突を招くリスク。
+- **MCP HTTP 型 (`context7` / `cloudflare`) の外部障害影響**: `mcp.json` 起動時の到達性失敗が Claude Code セッション全体の起動 latency を増やす可能性。Gotchas として `mcp-usage.md` に書かれていない。
+- **B0 が 96 ファイル / +5408 行の単一巨大 PR**: スコープ規律はあったが review 負荷は高い。次回以降の A 系 PR は更に大きくなる前提で、aspect 並列 review の入力分割 (per-file or per-rule) を検討する余地。
+
+## 🚀 Try (次回からの改善案)
+
+- **A1 (ADR 起草) と並行 / 直後に小型フォロー PR**: rules-index.md / CLAUDE.md lookup table の「既存」ラベル 13+ 件を `planned (A2)` / `skeleton (B0)` に正規化。template-language.md の `paths` 整合も同時解消。
+- **`code-reviewer/SKILL.md` Gotchas に 1 行追加**: 「PR コメント post 前に `.claude/rules/pii.md` の redaction を必ず通す (R-26)」。A3 本格化を待たず即時修正可能。
+- **PR テンプレ `harness.md` の追加** (plan.md §4.8 と §6.1 の差分解消): `branch-naming` が `harness/<purpose>` を認めている前提を守る。本レトロ PR の経験を踏まえ、harness ブランチ用テンプレに「対象 PR / KPT 要約 / ハーネス改善提案件数」セクションを含める。
+- **DefaultIdolColorsRepositorySpec のフレーキー調査を A9 baseline に組み込む**: モック基盤なので Flow / coroutine のタイミング起因を疑い、`runTest` での仮想時間使用 or 待機条件の明示化を検討。再現条件のメモを `docs/harness/learnings/flaky-tests.md` (新規) に蓄積。
+- **pr-retrospective Skill 本格化を A3 から前倒し検討**: 手動運用は learning ロスト・フォーマットドリフト・週次集約遅延のリスク。A1 (ADR) と並列で着手できないか A3 着手前に再評価。
+- **roadmap-tracker の手動起動契機を rule 化**: 「`implementation-workflow` を経由しないマージ (B0 のような手動マージ) では、レトロ起票時に roadmap-tracker も同 PR で同時更新」を `.claude/rules/roadmap.md` に追記。
+- **docs/adr/README.md に ADR 0001-0027 の予約一覧 (タイトル + 関連 rule + 起票根拠)** を索引化: A1 着手時のドリフト・ID 衝突防止。
+- **`mcp-usage.md` Gotchas に HTTP 型 MCP の外部障害影響を追記**: `context7` / `cloudflare` の到達性失敗時の挙動 (起動 latency / fallback) と無効化手順を明文化。
+- **`.dockerignore` 配置の TODO を `db-protection.md` に明示**: 配置時期 (A6 / Dockerfile 配置時) と必須項目 (`data/users.db*` / `.env*` / `*-credentials.json`) を rule 化。
+- **巨大 PR の aspect 並列 review における入力分割**: A1 (ADR 27 本) / A2 (rules 全本格化 + docs 全面拡充) は B0 を超える差分量が想定される。code-reviewer Coordinator にて per-aspect の入力分割 (例: `spec-conformance` は frontmatter のみ / `code-quality` は本文のみ) を A3 本格化時に評価。
+- **pr-retrospective の自動 trigger を pr-poller に組み込む準備**: `gh pr list --state merged --since` ベースで未起票の merged PR を検出し、`harness/learnings-batch-YYYY-WW` ブランチに追記する MVP を A3 / A4 で実装。
+
+## 📊 指標
+
+B0 は実装コード差分ゼロ (`*.kt` / `*.kts` / `*.sq` / `Dockerfile` / `build.gradle*` 変更なし) であり、三層テスト品質基盤 (Kover / Konsist Spec / PITest) は A6 / A7 で導入予定のため、本 PR では指標 A/B/C の Before/After 差分は計測不能 (N/A)。
+
+| 指標 | Before | After | Δ | 備考 |
+|---|---|---|---|---|
+| Line coverage | N/A | N/A | — | Kover 未導入 (A7 で導入予定) |
+| Branch coverage | N/A | N/A | — | 同上 |
+| Spec coverage | N/A | N/A | — | Konsist `@Spec` 未導入 (A7 で導入予定) |
+| Mutation score | N/A | N/A | — | PITest 未導入 (A7 で導入予定) |
+| Lint 違反数 | N/A | N/A | — | Spotless / ktlint / detekt 未導入 (A6 で導入予定) |
+| Markdown 違反数 | N/A | N/A | — | markdownlint-cli2 未導入 (A6 で導入予定) |
+| ファイル数 (リポジトリ) | (B0 前) | +96 | +96 | 全て skeleton / 骨格 |
+| 行数 (リポジトリ) | (B0 前) | +5408/-4 | net +5404 | 全て docs / config / Skill 骨格 |
+| Skill 数 (`.claude/skills/`) | 0 | 10 | +10 | 全 `status: skeleton`、A3 で本格化 |
+| Rule 数 (`.claude/rules/`) | 0 | 19 | +19 | 13 件で誤「既存」ラベル要修正 |
+| PR テンプレ数 | 1 (default) | 6 (default + 5 種) | +5 | `harness.md` 欠落 (要追加) |
+| MCP server 数 (`mcp.json`) | 0 | 3 (`jetbrains` / `context7` / `cloudflare`) | +3 | `gh` CLI は MCP 不採用 |
+
+## 🤖 ハーネス改善提案
+
+<!-- harness-meta が parse する正規構造 -->
+
+- [ ] `[rule]` rules-index.md / CLAUDE.md lookup table の status 表記正規化: 13+ 件の「既存」誤宣言を `planned (A2)` / `skeleton (B0)` に統一。Markdown 機械検証 (A6) の前提崩れ防止
+- [ ] `[rule]` `code-reviewer/SKILL.md` Gotchas に「PR コメント post 前に `.claude/rules/pii.md` redaction を必ず通す (R-26)」を 1 行追加
+- [ ] `[rule]` `.claude/rules/template-language.md` の `paths` を削除して真の常時ロード化、または rules-index 側を「Markdown 全域」表記に分離して宣言と挙動を一致させる
+- [ ] `[template]` PR テンプレ `harness.md` を新規追加 (or plan.md §4.8 から `harness.md` を削除して §6.1 と整合)。`branch-naming` の `harness/<purpose>` 認定との整合を取る
+- [ ] `[rule]` `mcp-usage.md` Gotchas に HTTP 型 MCP (`context7` / `cloudflare`) の外部障害時のセッション起動影響と無効化手順を追記
+- [ ] `[rule]` `db-protection.md` に `.dockerignore` 配置の TODO (時期 = A6 / Dockerfile 配置時、必須項目 = `data/users.db*` / `.env*` / `*-credentials.json`) を明示
+- [ ] `[rule]` `commit-message.md` (A2/A6 起草予定) で subject 長を「制限なし or 72 字推奨」とし、現行 `scripts/install-git-hooks.sh` 配置の `commit-msg` hook (50 字) と整合
+- [ ] `[rule]` `.claude/rules/roadmap.md` に「`implementation-workflow` を経由しないマージ (手動マージ等) では、pr-retrospective の learning PR と同 PR で roadmap-tracker の手動更新も実施する」を追記
+- [ ] `[rule]` `docs/adr/README.md` に ADR 0001-0027 の予約一覧 (ID / タイトル / 起票根拠 §4.5 該当項目 / 関連 rule) を A1 着手前に索引化。ID 衝突・重複起草防止
+- [ ] `[rule]` `docs/harness/learnings/flaky-tests.md` を新規追加し、`DefaultIdolColorsRepositorySpec > #search(by name): when lang = 'en'` の再現条件・回避策・恒久対策メモを蓄積する場所を定義
+- [ ] `[skill]` `pr-retrospective` Skill の本格化を A3 から前倒し検討 (A1 / A2 並列実装)。手動運用での learning ロスト・フォーマットドリフト・週次集約遅延を縮減
+- [ ] `[skill]` `code-reviewer` Skill の visual-regression / design-tokens aspect を A10 完了後に enable する手順を `SKILL.md` Gotchas に明記
+- [ ] `[skill]` `pr-poller` Skill に「merged PR の未起票 learning 検出 → `harness/learnings-batch-YYYY-WW` ブランチへの自動追記」MVP を A3 / A4 で実装
+- [ ] `[template]` `feature.md` / `bugfix.md` PR テンプレの「三層指標差分」セクションが A7 までは空欄になる旨を注記 (誤った N/A 記入のばらつき防止)
+- [ ] `[template]` `docs/harness/learnings/template.md` を新規追加 (pr-retrospective Skill 本格化と同時、retrospective-format.md 準拠)
+
+## 📝 harness-meta フィードバック
+
+<!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->

--- a/docs/harness/learnings/INDEX.md
+++ b/docs/harness/learnings/INDEX.md
@@ -16,6 +16,7 @@ last_updated: 2026-05-17
 
 | 日付 | PR # | 関連 Plan | 関連 Epic | actionable 提案数 | 採用提案数 |
 |---|---|---|---|---|---|
+| 2026-05-17 | [#117](https://github.com/subroh0508/colormaster/pull/117) | — | EPIC-000-harness-foundation | 15 | 0 |
 
 ## ファイル運用
 

--- a/docs/harness/roadmap.md
+++ b/docs/harness/roadmap.md
@@ -17,7 +17,7 @@ source_plan: docs/harness/plan.md
 
 | ID | タイトル | status | expected_modules | 完了根拠 |
 |---|---|---|---|---|
-| **B0** | ブートストラップ PR | in-progress | `.claude/**`, `docs/**`, `.github/**`, `scripts/**` | (本 PR で更新) |
+| **B0** | ブートストラップ PR | completed | `.claude/**`, `docs/**`, `.github/**`, `scripts/**` | PR #117 (2026-05-17 マージ、commit `0256be9`) |
 | **A1** | ADR 0001-0027 一括起草 | proposed | `docs/adr/**` | — |
 | **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 | proposed | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | — |
 | **A3** | 専用 Skill 群実装 PR | proposed | `.claude/skills/**` | — |
@@ -43,8 +43,9 @@ source_plan: docs/harness/plan.md
 
 | ID | PR 番号 | マージ日 | 主要ファイル |
 |---|---|---|---|
+| B0 | [#117](https://github.com/subroh0508/colormaster/pull/117) | 2026-05-17 | `.claude/{rules,skills,mcp.json,settings.json}/**`, `docs/{adr,api,architecture,design,epics,harness,requirements,runbooks,security,specifications,README.md,glossary.md,codebase-map.md,traceability.md}`, `DESIGN.md`, `.github/{pull_request_template.md,PULL_REQUEST_TEMPLATE/**}`, `scripts/install-git-hooks.sh`, `CLAUDE.md`, `AGENTS.md` |
 
-(本 PR (B0) マージ時に `roadmap-tracker` Skill 起動 or 手動で B0 行を完了状態に更新する想定)
+(B0 は `implementation-workflow` を経由せず手動マージしたため `roadmap-tracker` の Phase 8 自動起動は発火せず、`pr-retrospective` の learning PR (`harness/learnings-batch-2026-W20`) で手動更新)
 
 ## 着手順とブロック関係
 


### PR DESCRIPTION
## 概要

`pr-retrospective` Skill (B0 skeleton、手動運用) で PR #117 (B0 ハーネス骨格) のレトロスペクティブを起票し、`roadmap-tracker` 未稼働分の手動更新を併せて実施する `harness/learnings-batch-2026-W20` バッチ PR。

## 変更内容

- **`docs/harness/learnings/2026-05-17-pr-117.md`** (新規)
  - `.claude/rules/retrospective-format.md` 準拠の構造化レトロ
  - **✅ Keep** 7 項目: スコープ規律 / code-reviewer 6 aspect 並列実行 / `gh` vs MCP 費用判断 / Skill = `SKILL.md` 規約 / 計画フェーズへの先行投資 / `.gitignore` 完備 / worktree 並行実装
  - **⚠️ Problem** 12 項目: rules-index の「既存」誤宣言 13+ 件 / `template-language.md` の `paths` 矛盾 / `code-reviewer/SKILL.md` PII redaction 強制欠落 / PR テンプレ `harness.md` 欠落 / `DefaultIdolColorsRepositorySpec` フレーキー / pr-retrospective skeleton 残課題 / 等
  - **🚀 Try** 11 項目: 小型フォロー PR / Skill 前倒し検討 / ADR 予約一覧索引化 / 等
  - **📊 指標**: 三層基盤 (Kover / Konsist / PITest) 未導入 (A6/A7 で導入予定) のため Before/After は N/A、ファイル / 行 / Skill / Rule / Template / MCP の数値は記録
  - **🤖 ハーネス改善提案** 15 件 (harness-meta が parse する `[rule]` / `[skill]` / `[template]` / `[remove]` プレフィックス形式)

- **`docs/harness/learnings/INDEX.md`**: 索引に PR #117 行 (actionable 提案数 15) を追加

- **`docs/harness/roadmap.md`**:
  - B0 行を \`in-progress\` → \`completed\`
  - 完了根拠テーブルに PR #117 / 2026-05-17 / commit \`0256be9\` を記録
  - 根拠コメント: B0 は `implementation-workflow` を経由せず手動マージしたため Phase 8 の `roadmap-tracker` 自動起動が発火しておらず、本 PR で手動補完する旨を明示

## なぜ今このタイミングか

- B0 マージ直後 (2026-05-17T07:53:18Z) のレトロを A1 (ADR 0001-0027 一括起草) 着手と並行で起票することで、A1 / A2 設計時にレトロの **🚀 Try** / **🤖 ハーネス改善提案** を反映可能にする
- 特に `rules-index.md` の 13+ 件「既存」誤宣言と `docs/adr/README.md` の ADR 0001-0027 予約一覧索引化は **A1 着手前に解消すべき**

## 関連

- マージ済 PR: #117 (`feat(harness): bootstrap B0 skeleton tree`, commit \`0256be9\`)
- 並行起動済 worktree: `feature-A1-adr-bootstrap` (別 cmux ペインで harness-bootstrap Skill が ADR 起草に着手)
- 規約: `.claude/rules/retrospective-format.md` / `.claude/rules/roadmap.md`
- Skill: `.claude/skills/pr-retrospective/SKILL.md` (B0 skeleton)、`.claude/skills/roadmap-tracker/SKILL.md` (B0 skeleton)

## 後続アクション (本 PR 範囲外、提案として記録)

- `harness-meta` Skill (A3 で配置予定) が本 learning ファイルの「ハーネス改善提案」セクションを parse し、`📝 harness-meta フィードバック` セクションに採否を追記する想定
- A1 / A2 完了時に再度同手順でレトロを起票
- `pr-poller` / `pr-retrospective` の自動化 (A3 / A4) で本手動運用を置き換える