### PR TITLE
docs(adr): scaffold ADR-0001-0027 (A1 / PLAN-001)

### DIFF
--- a/docs/adr/ADR-0001-adr-charter.md
+++ b/docs/adr/ADR-0001-adr-charter.md
@@ -1,0 +1,148 @@
+---
+id: ADR-0001
+title: ADR 運用基準と起票判断フローを定める
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0001: ADR 運用基準と起票判断フローを定める
+
+> **5 行以内 summary**: ADR は Michael Nygard 原則 ("Architecturally Significant Decisions"
+> のみ記録) に従い、§4.5 の起票基準 10 項目のうち 2 項目以上を満たすときに起こす。
+> 採番は 4 桁ゼロパディング、ステータスは MADR 4 状態 (`proposed → accepted →
+> deprecated | superseded`)、`accepted` 以降は immutable で変更時は新 ADR を起こす。
+> 詳細規約は `.claude/rules/adr.md`、判断フロー Mermaid は `docs/adr/README.md`。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster はこれまで ADR を運用していなかった。AI 駆動開発ハーネスを稼働させるには、
+アーキテクチャ決定を機械可読な形で蓄積し、Plan / Epic / Skill / `.claude/rules/*` から
+`related_adrs` 経由で逆引きできるようにする必要がある。
+
+しかし全ての判断を ADR にすると蓄積が肥大化し、本来コーディング規約 (`.claude/rules/`) や
+Plan ファイル、runbook、Epic の `open-questions.md` / `decisions.md` で扱うべき事柄も混在する。
+これは Michael Nygard が原型を提示した時に明確に意図した「Architecturally Significant
+Decisions」の趣旨から外れる。AWS / Microsoft / Google / Martin Fowler の ADR ガイドラインも、
+起票基準を明示し他の記録方法と使い分けることを推奨している。
+
+## 決定
+
+以下の運用基準を採用する:
+
+### 起票基準 — 10 項目のうち 2 項目以上を満たすときに ADR を起こす
+
+1. アーキテクチャパターン / 層分割 / モジュール構造に影響する
+2. 主要なライブラリ / フレームワークの採用または撤去
+3. 外部サービスの採用または変更 (DB / ホスティング / 認証 / CDN 等)
+4. データ永続化 / 同期戦略 / バックアップ方式
+5. テスト戦略・品質指標の中核方針
+6. セキュリティ・プライバシー・ライセンスに関する方針
+7. ハーネス本体の中核設計 (Skill 構成、ループ構造、ローカル vs サーバ実行)
+8. 複数の代替案を比較した結果としての判断
+9. 元に戻すコストが高い決定
+10. 長期的な制約 (今後 1 年以上の判断のベースになるもの)
+
+### 採番・命名
+
+- 連番、4 桁ゼロパディング (`0001`, `0002`, ...)
+- ファイル名: `ADR-NNNN-<kebab-case-title>.md` (kebab-case は英語)
+- タイトル: 日本語、簡潔・現在形・断定的 (ADR-0027 / `.claude/rules/template-language.md`)
+
+### ステータス遷移 (MADR 4 状態)
+
+`proposed` → `accepted` → `deprecated` | `superseded by ADR-NNNN`
+
+- `accepted` 以降は **immutable**。内容を改訂したい場合は新 ADR を起こし、
+  旧 ADR を `superseded_by` で指す。
+- 採番欠番は実装前なら整理可、運用後は番号を維持して `withdrawn` を許容。
+
+### 他の記録方法との使い分け
+
+| 種類 | 記録方法 |
+|---|---|
+| コーディング・命名・スタイル規約 | `.claude/rules/<rule>.md` |
+| 1 PR で完結する判断 | `docs/plans/PLAN-NNN-*.md` |
+| Epic 内の細粒度な保留 → 解決 | `docs/epics/<id>/{open-questions,decisions}.md` |
+| 運用手順 | `docs/runbooks/<name>.md` |
+| PR ごとの学び・改善案 | `docs/harness/learnings/YYYY-MM-DD-pr-N.md` |
+
+判断フロー Mermaid と「ADR にすべき例 / すべきでない例」の具体例は
+`docs/adr/README.md` および `.claude/rules/adr.md` に保持する。
+
+## 根拠
+
+- **Michael Nygard 原則準拠**: 業界で広く認知された ADR の原型に従うことで、外部から
+  参加する開発者の認知負荷を最小化できる。
+- **2 項目以上のルール化**: 単一基準 (例: 「重要だと感じたら起票」) は主観に依存して
+  揺れるため、複数基準の組み合わせで客観性を担保する。
+- **MADR 4 状態 + immutable 原則**: 過去の決定経緯を改ざんから守り、`superseded_by` で
+  決定の系譜を辿れるようにする。
+- **使い分けの明文化**: ADR / `.claude/rules/` / Plan / runbook / learning の 5 つの
+  記録媒体を判断フローで分離することで、起票漏れと過剰起票の両方を防ぐ。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| MADR (Markdown ADR) フル準拠 | テンプレが豊富で項目細分化 | 中小規模では over-engineered | テンプレ簡素版を採用、4 状態は MADR 由来 |
+| Nygard オリジナル (4 セクションのみ) | 軽量 | 起票基準 / 自己チェックを別途規約化する必要 | 本 ADR で起票基準と自己チェックを補足し採用 |
+| Any Decision Record (全決定を ADR 化) | 漏れがない | ノイズ蓄積で参照価値が下がる | 起票基準で重要度フィルタを必須化、不採用 |
+
+## 帰結
+
+### Positive
+
+- Plan / Epic / Skill / rule から `related_adrs` で機械的に逆引き可能。
+- 採番ルールが固定されているため `docs/traceability.md` (A6 で自動生成) の入力として
+  そのまま使える。
+- `accepted` 以降 immutable のため、過去の決定経緯が改ざんに対して構造的に守られる。
+
+### Negative / トレードオフ
+
+- 起票判断に毎回フローを通す必要があるため、人間 / AI 双方に若干の認知負荷がかかる。
+  → `.claude/rules/adr.md` と本 ADR 末尾の自己チェック表で機械化に近付ける。
+- 27 件もの初回起票 (PLAN-001) で 1 PR の差分が大きくなる。
+  → docs 中心の PR でコードロジック変更を含まないため、`code-reviewer` の負担は限定的。
+
+### Neutral / 将来の検討事項
+
+- 機械検証 (frontmatter JSON Schema、参照先実在チェック、5 行 summary 検証) は A6 で
+  Gradle カスタムタスクとして導入予定。それまでは手動 Self-Verification で運用する。
+- ADR 起票基準を満たさないが将来満たす可能性のある運用ルールが出てきた場合は、
+  まず `.claude/rules/` に書き、再評価で基準を 2 項目以上満たすと判断したら ADR に
+  格上げする (R-36)。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 7. ハーネス本体の中核設計 (ADR 運用そのものがハーネスのメタ設計)
+- [x] 8. 複数の代替案を比較した結果としての判断 (MADR フル / Nygard / Any Decision Record の比較)
+- [x] 9. 元に戻すコストが高い決定 (ADR 採番・命名・ステータス遷移は一度動かすと変更困難)
+- [x] 10. 長期的な制約 (今後 1 年以上、本リポジトリの全 ADR 起票に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR がコーディング規約 / Plan で済む話 / runbook で済む話 ではないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築)
+- `.claude/rules/adr.md` (起票基準・例リスト・採番ポリシーの Single Source of Truth)
+- `docs/adr/README.md` (判断フロー Mermaid、ADR 一覧)
+- `docs/adr/template.md` (ADR テンプレート)
+- `docs/harness/plan.md` §4.5 (起票基準と書式)
+- ADR-0027 (docs 構造 + 日本語化方針、ADR タイトル・本文の言語規約)

--- a/docs/adr/ADR-0002-compose-multiplatform-with-nav3.md
+++ b/docs/adr/ADR-0002-compose-multiplatform-with-nav3.md
@@ -1,0 +1,132 @@
+---
+id: ADR-0002
+title: Compose Multiplatform と共通 ViewModel と Navigation 3 を採用する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0002: Compose Multiplatform と共通 ViewModel と Navigation 3 を採用する
+
+> **5 行以内 summary**: UI / 状態管理 / Navigation を全 target で共通化するため、
+> Compose Multiplatform (CMP) + 共通 ViewModel + Navigation 3 を採用する。
+> 状態管理は `StateFlow<UiState>` + `onAction(UiAction)` + `Channel<UiEffect>` の軽量
+> UDF、DI は Koin 4.0.4 を継続。Android / iOS / desktop / wasmJs を単一実装で支える。
+> 詳細は `docs/harness/plan.md` §3.1 を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は Android / iOS / web (旧 js/app) / desktop の複数 target を持つ
+Kotlin Multiplatform プロジェクトであり、これまで UI 層は Compose Multiplatform を
+採用しつつもナビゲーションは Decompose に依存していた。状態管理パターンも
+feature ごとに揺れがあり、共通化されていない。
+
+近年の CMP エコシステムには以下の変化があった:
+
+- **CMP Navigation 3** が 1.10 以降で Android / iOS / desktop / web 全 target に
+  対応 (公式 Stable)。これまで「web 非対応」を理由に Decompose を残していた根拠が
+  消失した。
+- **共通 ViewModel** は `androidx.lifecycle:lifecycle-viewmodel` 経由で KMP 全 target に
+  提供され、`SavedStateHandle` も含めて共通化可能。
+- **Compose for iOS** が 1.8.0 で Stable 到達 (production-ready 表明)。
+- **Koin 4.0.4** が KMP 全 target を継続サポート、`koin-compose` で `@Composable` 内
+  注入も成熟。
+
+これらにより「UI / ViewModel / Navigation を 1 セットの共通コードで全 target に
+出す」が現実的になり、Decompose の独自抽象を維持するコストの方が大きくなった。
+
+## 決定
+
+以下の構成を採用する。
+
+- **UI**: Compose Multiplatform を全 target (Android / iOS / desktop / wasmJs) で採用。
+- **共通 ViewModel**: `androidx.lifecycle:lifecycle-viewmodel` の KMP target を採用、
+  `commonMain` に ViewModel を置く。
+- **Navigation**: CMP Navigation 3 を採用、`commonMain` で全 target 共通の Nav graph
+  を記述する。Decompose は撤去する (詳細 ADR-0005)。
+- **状態管理**: `StateFlow<UiState>` + `fun onAction(UiAction)` +
+  `Channel<UiEffect>` の軽量 UDF パターンを feature 単位で統一。
+- **DI**: Koin 4.0.4 を継続採用、ViewModel と Repository を Koin module で配線。
+
+ファイル配置と命名は ADR-0003 (feature-first モジュール構造) に従う。
+
+## 根拠
+
+- **全 target 1 実装で済む**: Navigation 3 + 共通 ViewModel の組合せで、Android/iOS/
+  desktop/wasmJs の各 target に固有のナビゲーション層を書く必要がなくなる。Decompose
+  の `ComponentContext` / `Router` 抽象を維持するメンテコストを丸ごと削除可能。
+- **公式 Stable に揃える**: Navigation 3 と Compose for iOS が共に Stable 到達した
+  タイミングで、サードパーティ抽象 (Decompose) より公式 API に賭ける方が将来の
+  破壊的変更に追随しやすい。
+- **UDF パターン統一**: `UiState` / `UiAction` / `UiEffect` の 3 つで責務を明確化、
+  AI 駆動のテスト生成・コードレビューが構造化された対象を扱える。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Decompose を継続 | 既存コードの変更最小 | web 対応を独自に維持、CMP Navigation 3 と機能重複 | 公式 Navigation 3 が全 target Stable になった以上、独自抽象を残す積極的理由なし |
+| Voyager (Compose 用 navigation lib) | API が簡潔 | Navigation 3 とエコシステム重複、公式サポートで劣後 | 公式 Navigation 3 に統一する方が長期保守性で有利 |
+| MVI フル実装 (Orbit / MVIKotlin) | 状態管理が形式化 | ボイラープレート過多、AI が読み解きにくい | 軽量 UDF (State + Action + Effect) で十分、フル MVI は over-engineered |
+| 全 target を Compose 化せず iOS は SwiftUI 維持 | iOS native UX 最大化 | 二重実装、デザイントークン同期コスト大 | Compose for iOS が Stable 到達、二重実装の理由は弱い |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- 全 target を単一の Composable + ViewModel + Nav graph で記述でき、feature の
+  追加コストが劇的に下がる。
+- UDF パターン統一により、テストパターン (`ViewModelSpec`, `ScreenSnapshotTest` 等)
+  が画一化、AI 自動生成テストの精度が上がる。
+- Decompose 依存撤去で `build.gradle.kts` の依存ツリーが簡素化、ビルド時間も短縮。
+
+### Negative / トレードオフ
+
+- 既存 Decompose 依存コードの撤去 (ADR-0005 / EPIC-001) が必要、大規模 refactor PR が
+  発生する。
+- iOS で Compose を採用するため、iOS ネイティブ UX (UIKit ベースの細部) を再現する
+  際にカスタム実装が必要なケースがある。
+- `androidx.lifecycle:lifecycle-viewmodel` の KMP target は依然として比較的新しく、
+  edge case の bug 報告が今後発生する可能性がある (公式 issue tracker を monitoring)。
+
+### Neutral / 将来の検討事項
+
+- Navigation 3 の API は 1.x のうちは互換性が保たれる前提だが、2.x で破壊的変更が
+  入る場合は本 ADR を改訂する。
+- Compose UI Test / Roborazzi のスナップショット基盤は ADR-0023 と連動して整備。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 1. アーキテクチャパターン / 層分割 / モジュール構造に影響する
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定
+- [x] 10. 長期的な制約 (今後 1 年以上、全 feature 実装に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (`.claude/rules/adr.md` の「ADR にすべき例」に「Compose Multiplatform +
+      共通 ViewModel + Navigation 3 を採用する (ADR 0002)」が明示されており、本 ADR
+      はその起票)
+
+## 関連
+
+- 関連 Plan: PLAN-001 (ADR 起草 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築)
+- ADR-0003 (feature-first モジュール構造、本 ADR と一体運用)
+- ADR-0005 (Decompose 撤去、本 ADR を受けた具体策)
+- ADR-0006 (i18n、CMP Resources を採用する根拠と連動)
+- `.claude/rules/{viewmodel,ui-state,composable,navigation}.md`
+- `docs/harness/plan.md` §3.1

--- a/docs/adr/ADR-0003-feature-first-module-structure.md
+++ b/docs/adr/ADR-0003-feature-first-module-structure.md
@@ -1,0 +1,132 @@
+---
+id: ADR-0003
+title: モジュール構造を feature-first にする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0003: モジュール構造を feature-first にする
+
+> **5 行以内 summary**: `feature/<name>/{ViewModel, UiState, UiAction, Screen, di}.kt`
+> の feature 単位フラット構造を採用する。横串の関心事 (network / data / di-core 等)
+> は `core/<concern>/` に集約。1 feature = 1 ディレクトリ = 1 責務単位とすることで、
+> Plan / PR の touch ファイルが最小化され、AI 駆動の差分レビューが容易になる。
+> 詳細は `docs/harness/plan.md` §3.1 を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster の既存モジュール構成は層別 (`presentation/` / `domain/` / `data/`) と
+feature 別が混在しており、1 つの機能を追加・変更する際に複数モジュール / 複数階層を
+横断する必要があった。これは以下の問題を生む。
+
+- 1 PR が触るファイルが分散し、`code-reviewer` (8 aspect 並列) の対象が広がる。
+- AI Agent が「この feature の責務はどこ?」を判断するためにグローバル grep が必要。
+- Plan の `expected_modules` 欄に書くパスが冗長になり、Spec ⇄ 実装の traceability も
+  分散する。
+
+ADR-0002 で Compose Multiplatform + 共通 ViewModel + Navigation 3 を採用したことに
+より、1 feature を構成するファイル群は次の 4-5 種に絞り込める:
+
+- `ViewModel.kt` (`commonMain`)
+- `UiState.kt` (`commonMain`)
+- `UiAction.kt` (`commonMain`)
+- `Screen.kt` (`commonMain`、Composable + Nav 接続)
+- `di.kt` (Koin module 定義、feature 内 DI が必要な場合のみ)
+
+これらを 1 ディレクトリにまとめる構造の方が、責務の locality が高く AI / 人間
+双方にとって読みやすい。
+
+## 決定
+
+以下のモジュール構造を採用する。
+
+- **feature 層**: `feature/<name>/{ViewModel, UiState, UiAction, Screen, di}.kt` の
+  feature 単位フラット構造。1 feature = 1 ディレクトリ = 1 責務単位。
+- **core 層**: 横串の関心事は `core/<concern>/` に集約。具体例:
+  - `core/network/` (`colormaster-api` クライアント等)
+  - `core/data/` (Repository / DataSource)
+  - `core/di/` (アプリ全体の Koin module 配線)
+  - `core/model/` (ドメインモデル)
+  - `core/resources/` (画像・色などの共有資源)
+- **navigation**: 各 feature の `Screen.kt` から `Route.kt` を export し、上位の
+  Nav graph 組立て (`composeApp` 相当の entry point) で集約する。
+
+ファイル命名と feature の責務分解の詳細は `.claude/rules/{viewmodel,ui-state,composable,navigation}.md`
+を Single Source of Truth とする。
+
+## 根拠
+
+- **責務の locality**: 1 feature を触る PR が 1 ディレクトリ内で完結し、`git log`
+  / `git diff` / `code-reviewer` の対象範囲が直感的に把握できる。
+- **AI の context 効率**: Skill が feature 単位に glob 絞り込み可能、`feature/<name>/**`
+  だけ読めば足りるケースが増え、context window 圧迫が減る。
+- **Plan の touch 範囲が明確**: Plan / Epic の `expected_modules` に
+  `feature/<name>/` 1 行だけ書けば済むケースが多くなり、機械検証 (A6) が単純化する。
+- **横串の関心事は core に隔離**: Repository / Network / DI は複数 feature から
+  共通参照されるため `core/` に集約、循環依存を構造的に避ける。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 層別構造 (`presentation` / `domain` / `data` 別モジュール) | 層境界が物理分離 | 1 feature 変更で複数モジュール touch、AI の context 圧迫 | feature の locality を優先 |
+| feature/ をさらに `feature/<name>/{ui,vm,domain}/` 等の階層化 | 役割境界が明示的 | 階層が深く、ファイル名重複時の grep が面倒、ボイラープレート増 | フラット構造の方が AI / 人間双方で扱いやすい |
+| Multi-module Gradle で feature ごと別モジュール | ビルドキャッシュ最適化 | モジュール数爆発、Gradle 設定の保守コスト大 | KMP + Compose の規模ではフラット 1 モジュールで十分 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- PR の touch 範囲が `feature/<name>/` に局所化、`code-reviewer` の aspect 並列が
+  小さい入力で済む。
+- AI Skill (`plan-author` / `implementation-workflow`) が `expected_modules` を
+  予測しやすく、Spec ⇄ 実装の traceability が単純化する。
+- 新 feature 追加時のテンプレ展開が `feature/<name>/` 1 ディレクトリのコピーで
+  済む。
+
+### Negative / トレードオフ
+
+- ファイル名が短く (`ViewModel.kt` 等)、feature 名がパスに依存するため、IDE の
+  「ファイル名で開く」検索では `<feature>/ViewModel.kt` の検索が必要。
+  → `.claude/rules/naming.md` でクラス名は `<Feature>ViewModel` 等、prefix 付きを
+    強制し、検索性を担保。
+- feature をまたぐ共通 UI コンポーネントは `core/ui-components/` 相当に切り出す
+  運用判断が随時必要。
+
+### Neutral / 将来の検討事項
+
+- feature 数が 30 を超えた場合、`feature/` 配下にカテゴリディレクトリ (例:
+  `feature/onboarding/`, `feature/library/`) を導入する余地を残す。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 1. アーキテクチャパターン / 層分割 / モジュール構造に影響する
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (一度全 feature を移行すると逆戻りコスト大)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 feature 実装に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (モジュール構造は §4.5 の項 1「アーキテクチャパターン / 層分割 /
+      モジュール構造」に直接該当、`.claude/rules/` で済む話ではない)
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0002 (Compose Multiplatform + Navigation 3、本 ADR の前提)
+- `.claude/rules/{viewmodel,ui-state,composable,navigation,repository,network-client,naming}.md`
+- `docs/harness/plan.md` §3.1

--- a/docs/adr/ADR-0004-test-strategy-overview.md
+++ b/docs/adr/ADR-0004-test-strategy-overview.md
@@ -1,0 +1,139 @@
+---
+id: ADR-0004
+title: テスト戦略は三層指標 (line/branch と Spec と mutation) の併用とする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0004: テスト戦略は三層指標 (line/branch と Spec と mutation) の併用とする
+
+> **5 行以内 summary**: テスト品質を 3 つの独立した指標で多層検証する。指標 A
+> (line/branch coverage) はテスト存在保証、指標 B (Spec coverage) は仕様適合性、
+> 指標 C (mutation score) は意味的強度をそれぞれ別軸で担う。互いに代替不可、
+> いずれも別 ADR で詳細化する。本 ADR は総論 index として位置付け、詳細は
+> ADR-0013 (指標 A) / ADR-0016 (指標 B) / ADR-0015 (指標 C) を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は AI 駆動テスト生成を前提とするため、テスト品質を 1 つの指標
+(例: line coverage 100%) で測ろうとすると、AI が「指標を満たすだけのテスト」を
+生成し、Goodhart's law (測定が目標化されて指標としての意味を失う) に陥る危険が
+高い。実際、coverage 100% / mutation score 4% のような無意味テスト群は AI 駆動
+開発のアンチパターンとして既知。
+
+一方で、これら 3 つの指標は **互いに代替不可能**:
+
+- line / branch coverage は「テストが存在するか?」しか測れない (仕様適合・意味的
+  強度を保証しない)。
+- Spec coverage は「仕様 ⇄ テスト対応」を保証するが、テストの中身が tautological
+  でも通る。
+- mutation score は「テストが意味的に効くか?」を測るが、計測コストが高く CI ゲート
+  にすると AI が gaming する余地が大きい。
+
+そのため、テスト戦略の総論として「3 指標を別軸で運用、それぞれが別アウトカムを
+担う」ことを ADR で明示する必要がある。詳細な指標ごとの運用 (除外対象 / CI ゲート
+条件 / 段階達成) は各論 ADR に委譲する。
+
+## 決定
+
+テスト戦略の中核として **三層指標 (指標 A / B / C) の併用** を採用し、本 ADR を
+総論 index として位置付ける。各論は別 ADR で詳細化する。
+
+- **指標 A — Line / Branch Coverage** (テスト存在保証): 段階達成。Phase A 完了時点
+  で Kover 計測可能、Phase C 各 PR で差分 100%、Phase C 完了で全体 100%。詳細は
+  ADR-0013。
+- **指標 B — Spec Coverage** (仕様適合性): 新規機能で必達 CI ゲート、既存機能は
+  Phase C 段階達成。`@Spec("SPEC-NNN-N")` annotation + Konsist で機械検証。詳細は
+  ADR-0016。
+- **指標 C — Mutation Score** (意味的強度): PR コメントで可視化のみ、必達 CI ゲート
+  にしない (Goodhart's law 回避)。PITest + pitest-kotlin + gradle-pitest-plugin、
+  JVM target 経由。詳細は ADR-0015。
+
+3 指標はそれぞれが独立したアウトカムを担い、相互代替不可。指標 A だけで通る PR は
+仕様 (B) / 意味 (C) を担保しない、指標 B だけで通る PR は実行範囲 (A) / 意味 (C) を
+担保しない、という非可換性を運用前提とする。
+
+## 根拠
+
+- **Goodhart's law 回避**: 1 指標で測ると AI が gaming する。3 指標で多層化すると、
+  どの軸でも gaming するコストの方がまっとうに書くコストを上回るため、自然と「意味
+  ある」テストに向かう。
+- **アウトカムの分担**: テスト存在 (A) / 仕様適合 (B) / 意味的強度 (C) は本質的に
+  異なるアウトカム。1 指標で代替不可能。
+- **CI ゲートの強度を分ける**: 計測コストと gaming リスクに応じて、指標 A は段階達成
+  ゲート、指標 B は必達ゲート、指標 C は可視化のみ、と強度を変える。これにより
+  Goodhart's law の影響を最小化しつつ、必要箇所での強制力を保つ。
+- **総論を ADR 化する理由**: 個別指標 (A/B/C) の各論だけ ADR 化すると、3 つの間の
+  関係性 (代替不可、CI ゲート強度の差) が明文化されない。総論 ADR を index として
+  置くことで、各論を参照する Skill / Plan が一貫した文脈で扱える。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| line coverage のみで運用 | 設定が単純、ツール成熟 | 仕様適合・意味的強度を担保せず、AI による gaming が容易 | 1 指標で AI 駆動の品質保証は不可 |
+| Spec coverage のみで運用 | 仕様 ⇄ テスト対応が明示 | 仕様 ID が振られない箇所を機械検出できず、tautological テストも通る | 仕様外の実装パスをカバーできない |
+| mutation score を必達 CI ゲートにする | 意味的強度を強制 | 計測コスト大 + AI が mutation を回避するテストを書く gaming リスク | シグナル可視化に留め、強制は B 側で行う |
+| coverage を「指標」ではなく「制約」と再定義 | Goodhart's law 回避の理論基盤 | 単体では仕様 / 意味を担保しない | 本 ADR で「制約 A + 指標 B + 指標 C」の総論として採用 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- 1 指標 gaming の構造的回避。AI が 3 指標を同時に満たそうとすると、自然と「意味
+  ある」テストを書くインセンティブが働く。
+- 各論 ADR (0013 / 0015 / 0016) との関係性が index として明確化、Skill が一貫した
+  文脈で指標を扱える。
+- KPT (learning) で「mutation score が低い領域」「Spec coverage gap」等を 3 軸で
+  別個に蓄積でき、改善方向が分散ノイズにならない。
+
+### Negative / トレードオフ
+
+- 3 指標の計測基盤 (Kover / Konsist + `@Spec` / PITest + pitest-kotlin) を全部
+  整備する必要があり、Phase A の A7-A9 でまとめて投入するコストがある。
+- 3 指標を AI に同時意識させると、PR description / レビューコメントで触れる項目が
+  増え、`code-reviewer` 8 aspect の入力サイズも増える。
+
+### Neutral / 将来の検討事項
+
+- 将来 **MutFlow** (K2 compiler plugin ベース、KMP 全 target 適合の可能性) が
+  Stable 化したら、指標 C の実装を PITest から MutFlow に置換する余地を残す
+  (別 ADR で評価)。
+- Phase A 完了時点では既存コードの未カバー分が指標 A の除外リストに含まれるが、
+  Phase C で段階解消する (詳細 ADR-0013)。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 5. テスト戦略・品質指標の中核方針
+- [x] 7. ハーネス本体の中核設計 (AI 駆動テスト生成と gaming 防止の構造)
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 10. 長期的な制約 (今後 1 年以上、全テスト規約の前提)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (`.claude/rules/adr.md` の「ADR にすべき例」に「Line/Branch coverage
+      を段階達成にする (ADR 0013)」が明示、本 ADR は各論を束ねる総論 index として
+      §4.5 項 5 / 7 / 8 / 10 を満たす)
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0013 (指標 A: Line / Branch Coverage 段階達成の詳細)
+- ADR-0016 (指標 B: Spec Coverage の詳細)
+- ADR-0015 (指標 C: Mutation Score の詳細)
+- `.claude/rules/{coverage-100,spec-traceability,mutation-testing,kotlin-test,test-paired-class}.md`
+- `docs/harness/plan.md` §3.10

--- a/docs/adr/ADR-0005-decompose-removal.md
+++ b/docs/adr/ADR-0005-decompose-removal.md
@@ -1,0 +1,125 @@
+---
+id: ADR-0005
+title: Decompose を撤去する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0005: Decompose を撤去する
+
+> **5 行以内 summary**: CMP Navigation 3 が全 target 対応となり、Decompose の独自
+> ナビゲーションを残す積極的理由が消失した。Decompose 依存と関連コードを撤去し、
+> Navigation 3 + 共通 ViewModel (ADR-0002) に統一する。撤去作業の実装は Phase C
+> (EPIC-001) で実施。撤去後の構造は ADR-0003 (feature-first) に従う。
+> 詳細は `docs/harness/plan.md` §3.1 / §3.6 を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster はこれまで Decompose を採用し、`ComponentContext` / `Router` の独自
+抽象でナビゲーションを実装してきた。これは Compose Multiplatform の公式 navigation
+が当時 web 非対応だったための妥当な選択だった。
+
+しかし以下の変化により、Decompose を残す積極的理由が消失した:
+
+- **CMP Navigation 3 が 1.10 以降で全 target (Android / iOS / desktop / wasmJs)
+  対応となり Stable 化** (ADR-0002 で採用決定)。
+- 共通 ViewModel が `androidx.lifecycle:lifecycle-viewmodel` で KMP 全 target 提供。
+- Decompose と Navigation 3 の機能重複により、両者を併存させるとナビゲーション層が
+  2 種類の抽象に分断される (新規 feature は Nav 3、既存は Decompose という混在)。
+- Decompose の依存とビルド設定 (`com.arkivanov.decompose:*` 各種) が `build.gradle.kts`
+  に残り続けると、依存解決とビルド時間が悪化する。
+
+`docs/harness/plan.md` §3.6 で「Decompose 撤去」が撤去対象として明示されており、
+本 ADR で正式に判断記録を残す。
+
+## 決定
+
+以下を採用する。
+
+- **Decompose 依存を撤去する**: `com.arkivanov.decompose:*` および関連の essenty 等
+  サブモジュール依存を `build.gradle.kts` から削除する。
+- **Decompose 関連コードを撤去する**: `ComponentContext` / `Router` / `RootComponent`
+  / 各 feature の `*Component.kt` 等の Decompose 由来コードを撤去し、ADR-0002 で
+  採用した CMP Navigation 3 + 共通 ViewModel + feature-first 構造 (ADR-0003) に
+  置き換える。
+- **実装時期**: 撤去作業は **Phase C (EPIC-001)** で実施。Phase A / B では本 ADR
+  による方針確定のみを行い、コードベース改修は Phase C で計画的に進める。
+
+`navigation` パッケージや `Route.kt` 等の Navigation 3 移行先の構造は ADR-0003
+(feature-first) および `.claude/rules/navigation.md` を参照。
+
+## 根拠
+
+- **公式 Stable に揃える** (ADR-0002 の判断と一体): Navigation 3 が全 target Stable
+  化した時点で、サードパーティ抽象を残す理由は公式 API より将来安定するという
+  根拠が必要だが、Decompose にその優位性はない。
+- **混在の回避**: Nav 3 と Decompose を併存させると、新規 feature と既存 feature で
+  ナビゲーション層が分断され、`code-reviewer` / Skill / 人間レビュー全てに認知負荷
+  が乗る。撤去で「全 feature が同じパターン」を実現できる。
+- **依存ツリーの簡素化**: `build.gradle.kts` から Decompose 関連依存を削除すること
+  で、ビルド時間 / 依存解決の複雑度が下がる。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Decompose を継続採用 | 既存コードの変更ゼロ | 公式 Nav 3 との機能重複、依存維持コスト、混在発生 | ADR-0002 で公式 Nav 3 採用を決定済みで、両立する積極的理由なし |
+| Decompose と Nav 3 を併存 (新規のみ Nav 3) | 段階移行が緩やか | 2 種類の抽象が永続的に残る、AI / 人間双方の認知負荷増 | 中長期で必ず統一が必要、先延ばしの利点が乏しい |
+| Voyager 等の別 navigation lib に乗り換え | 既存 Decompose 撤去とほぼ同コスト | 結局サードパーティ依存、公式 Nav 3 より将来性で劣る | 公式 Nav 3 が Stable 化した以上、別ライブラリを選ぶ理由なし |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- ナビゲーション層が CMP Navigation 3 1 種に統一、AI / 人間双方の認知負荷が下がる。
+- `build.gradle.kts` の依存リストが簡素化、ビルド時間 / 依存解決コストが減る。
+- ADR-0003 (feature-first) の `Screen.kt` / `Route.kt` 構造に統一でき、Plan の
+  `expected_modules` も予測しやすくなる。
+
+### Negative / トレードオフ
+
+- Phase C で大規模 refactor PR が発生する。EPIC-001 として段階的に進める計画が
+  必要 (1 PR で全撤去は危険、feature 単位で順次移行)。
+- Decompose 由来のテスト (Component の単体テスト等) は ViewModel ベースに書き直し
+  が必要。
+- 撤去途中の Phase B 期間中は Decompose と Nav 3 が一時的に併存する可能性があり、
+  その期間の規約は EPIC-001 内 `decisions.md` で個別管理する。
+
+### Neutral / 将来の検討事項
+
+- Decompose 撤去の実装 PR は EPIC-001 内 Plan で feature 単位に分割。
+- 撤去完了後、`.claude/rules/navigation.md` を Nav 3 単独前提に書き直す。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 1. アーキテクチャパターン / 層分割 / モジュール構造に影響する
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (一度撤去するとコードベースから完全に消える)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (`.claude/rules/adr.md` の「ADR にすべき例」に「Decompose を撤去する
+      (ADR 0005)」が明示されており、本 ADR はその起票)
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤) / EPIC-001 (撤去作業の実装 Epic、Phase C で起票)
+- ADR-0002 (CMP + Navigation 3 採用、本 ADR の前提)
+- ADR-0003 (feature-first モジュール構造、撤去後の到達構造)
+- `.claude/rules/navigation.md`
+- `docs/harness/plan.md` §3.1 / §3.6

--- a/docs/adr/ADR-0006-i18n-compose-resources.md
+++ b/docs/adr/ADR-0006-i18n-compose-resources.md
@@ -1,0 +1,131 @@
+---
+id: ADR-0006
+title: i18n には compose-multiplatform-resources を採用する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0006: i18n には compose-multiplatform-resources を採用する
+
+> **5 行以内 summary**: wasmJs 対応の必要性から、i18n は
+> `composeResources/values-<locale>/strings.xml` (compose-multiplatform-resources) を
+> 採用する。JS/Wasm でも非同期に resource を読める設計が公式に明示されており、
+> Lyricist / i18n4k は wasmJs 公式対応の言及なし。
+> 詳細は `docs/harness/plan.md` §3.1 を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は Android / iOS / desktop / wasmJs の複数 target を持つ KMP プロジェクト
+であり、Web 配信は ADR-0012 で js/app を撤去後、wasmJs に移行する方針が決まっている。
+これにより i18n (国際化) の実装方式は **wasmJs 公式対応** を必須要件とする。
+
+KMP 向け i18n ライブラリの選択肢:
+
+- **compose-multiplatform-resources**: JetBrains 公式、`composeResources/values-<locale>/strings.xml`
+  形式。JS/Wasm でも非同期に resource を読める設計が公式に明示されている。
+- **Lyricist**: Android 中心の DSL ベース i18n、KMP 対応はあるが wasmJs 公式対応の
+  言及なし。
+- **i18n4k**: KMP 対応の i18n ライブラリ、 wasmJs 公式対応の言及なし。
+
+加えて、ADR-0002 で Compose Multiplatform 全 target 採用が決定しているため、
+CMP 公式が提供する resource システムに合わせる方が以下の点で有利:
+
+- Compose で `stringResource(Res.string.<key>)` の統一 API を全 target で使える。
+- CMP のバージョンアップに自動追随、外部ライブラリのメンテナンスリスクなし。
+- Wasm 対応の非同期 resource ロードが組み込み済み (suspend / async API を意識せず
+  使える)。
+
+## 決定
+
+i18n に **compose-multiplatform-resources** を採用する。
+
+- **配置**: `<module>/src/commonMain/composeResources/values-<locale>/strings.xml`
+  形式で各ロケールの文字列を定義する。
+- **アクセス**: Composable 内では `stringResource(Res.string.<key>)`、非 Composable
+  からは生成された `Res` クラス経由で suspend 関数を呼ぶ。
+- **対象 target**: Android / iOS / desktop / wasmJs 全 target で同一の resource
+  ファイルを共有する。
+
+文字列キー命名規約 / locale fallback / pluralization 等の運用詳細は
+`.claude/rules/i18n.md` を Single Source of Truth とする。
+
+## 根拠
+
+- **wasmJs 公式対応**: JS / Wasm でも非同期に resource を読める設計が JetBrains
+  公式 docs に明示されており、Lyricist / i18n4k に対して明確な差別化要因となる。
+- **CMP との一体化**: ADR-0002 で CMP 全 target 採用を決めた以上、CMP 公式が提供する
+  resource システムに乗る方が依存ツリーが小さく、CMP のメジャーアップにも追随しやすい。
+- **`stringResource()` API の統一**: 全 target で同じ Composable 内 API を使えるため、
+  AI Skill / 人間レビューの認知負荷が下がる。
+- **Lyricist / i18n4k は wasmJs 公式対応の言及なし**: 採用するとリスクとして
+  wasmJs 移行時に置換が必要になる可能性がある。先回りで CMP Resources に統一する
+  方が長期保守性で有利。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Lyricist (DSL ベース) | DSL が型安全で使いやすい | wasmJs 公式対応の言及なし、サードパーティ依存 | wasmJs 必須要件を満たさない |
+| i18n4k | KMP 対応、コード生成あり | wasmJs 公式対応の言及なし、サードパーティ依存 | 同上 |
+| 自前実装 (`Map<String, String>` を locale 別に保持) | 依存ゼロ、シンプル | locale fallback / pluralization / 大規模時のメンテで荒れる | CMP Resources で十分賄える |
+| Android resources (`strings.xml`) + iOS Strings 別管理 | 各 native の慣習に従う | 同一文字列を二重管理、wasmJs 対応コードを別途書く必要 | CMP Resources で全 target 統一できるため不要 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- 全 target で同一の resource ファイル + 同一 API (`stringResource`) を使えるため、
+  AI / 人間双方の認知負荷が最小化される。
+- wasmJs 移行時 (ADR-0012 後) に i18n 実装を書き直す必要なし、Wasm 対応が組み込み
+  済み。
+- locale 追加が `composeResources/values-<locale>/strings.xml` 1 ファイルの追加で
+  完結し、Plan の `expected_modules` も予測しやすい。
+
+### Negative / トレードオフ
+
+- Compose Multiplatform のバージョンアップに依存するため、resource システムの破壊
+  的変更があった場合は全 target に影響する。
+- 文字列のホット reload が CMP の resource 生成タイミングに依存し、開発時の DX
+  はネイティブ Android resources よりわずかに劣る場合がある。
+
+### Neutral / 将来の検討事項
+
+- 翻訳ワークフロー (Crowdin / Lokalise 等の外部サービス連携) は将来別途検討。
+  現時点は owner 単独運用のため、`strings.xml` 直接編集で十分。
+- Pluralization (`plurals.xml`) / 引数フォーマット (`%s` / `%d`) の運用規約は
+  `.claude/rules/i18n.md` で確定する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (resource ファイルの形式変更は全文字列に波及)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 feature の文字列定義に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (i18n ライブラリ選定は §4.5 項 2「主要なライブラリの採用」に直接
+      該当、`.claude/rules/i18n.md` のコーディング規約だけでは依存選定の判断記録に
+      ならない)
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0002 (CMP 採用、本 ADR の前提)
+- ADR-0012 (js/app 撤去後の wasmJs 移行、本 ADR の wasmJs 要件根拠)
+- `.claude/rules/i18n.md`
+- `docs/harness/plan.md` §3.1

--- a/docs/adr/ADR-0007-imasparql-upstream-driven-sync.md
+++ b/docs/adr/ADR-0007-imasparql-upstream-driven-sync.md
@@ -1,0 +1,131 @@
+---
+id: ADR-0007
+title: im@sparql は upstream-driven 同期で更新する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0007: im@sparql は upstream-driven 同期で更新する
+
+> **5 行以内 summary**: アイドル情報マスタを最新化する手段として、im@sparql の公開
+> endpoint を毎回叩く schedule 駆動ではなく、upstream リポジトリ (`imas/imasparql`) の
+> latest commit SHA を 1 日 1 回 GitHub Actions cron で取得し、`data/.imasparql-sync-state.json`
+> の `upstream_sha` と比較して差分時のみ Gradle タスクで同期 + PR 作成する
+> upstream-driven 方式を採用する。自動 merge は禁止 (人間 or AI レビュー必須)。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster はアイドル情報マスタ (色 / ブランド / 所属) を im@sparql という外部 SPARQL
+endpoint から取得し、リポジトリ内に `data/idols.db` (SQLite) と `data/idols.json` として
+コミットして利用している (ADR-0010)。マスタを最新化する同期戦略には次の制約がある:
+
+- im@sparql の公開 endpoint は個人運営であり、稼働率は GitHub と比較して不安定。
+  毎時 SPARQL クエリを投げると、サーバ側に負荷をかけるうえ 5xx で同期が失敗する確率も
+  上がる。
+- アイドル情報の更新頻度は高くなく、`imas/imasparql` リポジトリの commit 自体が
+  数日〜数週間に 1 度程度のペース。schedule 駆動で毎日全件取得し直すのは過剰。
+- 同期結果は repo commit (`data/idols.db` の更新) として残るため、誤った同期を
+  そのまま master に取り込むと historical な汚染になる。レビューを必須化する手段が要る。
+
+加えて、ハーネスでは GitHub Actions の Claude API 直接呼び出しを禁止しており
+(ADR-0017)、同期 workflow も人間 / AI のレビュー後にマージする運用と整合させる必要がある。
+
+## 決定
+
+im@sparql の同期は **upstream-driven sync** で実装する。
+
+1. 1 日 1 回の GitHub Actions cron が `gh api repos/imas/imasparql/commits/master` で
+   upstream の latest commit SHA を取得する。
+2. リポジトリにコミットされた `data/.imasparql-sync-state.json` の `upstream_sha`
+   フィールドと比較する。
+3. 一致した場合は no-op で正常終了する (API 呼び出し 1 回のみ)。
+4. 不一致の場合のみ `./gradlew :backend:cli:fetchIdolColorsFromImasparql` を実行し、
+   `data/idols.db` / `data/idols.json` / `data/.imasparql-sync-state.json` を更新する。
+   レコード数の前回比 ±X% を超える変動を異常検知として fail させる。
+5. 正常完了したら `chore/sync-imasparql-<short-sha>` ブランチを切って PR を作成する。
+   **自動 merge は禁止**、人間または AI レビュー (`code-reviewer`) の approve を経て
+   squash merge する。
+6. im@sparql サーバが 5xx を返すなどの異常時は Issue を自動起票し、次回 cron で
+   リトライする。
+
+## 根拠
+
+- **コスト**: upstream が更新されていない大半のケースで API 呼び出しは 1 回のみで済み、
+  GitHub Actions の無料枠 / im@sparql 公開 endpoint の負荷ともに最小化できる。
+- **可用性の分離**: 変更検知は GitHub API にのみ依存するため、im@sparql 公開 endpoint
+  の稼働状況に同期トリガが影響されない。im@sparql がダウンしていても upstream SHA は
+  取得可能であり、同期不要と即座に判定できる。
+- **レビュー可能性**: 同期結果が必ず PR 経由で master に取り込まれるため、レコード数の
+  大幅な増減・スキーマ変化・不正データ混入を人間 / AI レビューでブロックできる。
+- **ハーネス整合**: 自動 merge 禁止 / 人間 approve 必須 (R-15) という ColorMaster の
+  ハーネス原則に同期 workflow をそのまま乗せられる。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| schedule 駆動 (毎日 SPARQL を全件再取得) | 実装単純、im@sparql 公開 endpoint だけで完結 | im@sparql 5xx 時に常に失敗、更新の有無に関わらず重い query を毎回投げる | コスト / 負荷 / 可用性すべてで劣後 |
+| webhook 駆動 (`imas/imasparql` の push を受信) | 即時性が最も高い | upstream リポジトリ管理者ではないため webhook を仕込めない | 仕組み上不可能 |
+| 手動同期のみ (CLI を owner が叩く) | 不要な PR を生まない | 同期忘れが発生し古いデータで稼働するリスク | 自動化価値が大きい、cron + PR 必須 |
+| 自動 merge 付き同期 | 完全自動化、手間ゼロ | 異常データが PR レビューを経ずに master に入る | R-15 の auto-merge 禁止原則に違反、不採用 |
+
+## 帰結
+
+### Positive
+
+- upstream が変わらない限り GitHub Actions の実行時間は 1 API 呼び出し分のみ。
+  Actions 無料枠を圧迫しない。
+- 同期 PR が必ずレビューを通るため、im@sparql 側の予期せぬスキーマ変更や巨大な差分が
+  master に流入するのを構造的に防げる。
+- `data/.imasparql-sync-state.json` に upstream SHA / 前回同期日時 / レコード数を
+  残すため、再現性のあるトレーサビリティが得られる。
+
+### Negative / トレードオフ
+
+- upstream の commit から最大で約 1 日の同期遅延が発生する。アイドル情報マスタの
+  更新頻度を考えると許容範囲。
+- レコード数 ±X% の閾値設定が運用上必要 (初期値は別途 runbook で定義)。
+- PR レビューが滞ると同期 PR が積み上がる可能性がある → 1 日 1 PR の上限で運用、
+  ハーネスの `pr-poller` が滞留を検知できる。
+
+### Neutral / 将来の検討事項
+
+- im@sparql 側にスキーマバージョン情報があれば、SHA 比較に加えてスキーマ互換性
+  チェックも導入できる (将来検討)。
+- レコード数異常検知の閾値 X% は実運用ログから調整 (Phase A8 以降の runbook で確定)。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 3. 外部サービスの採用または変更 (im@sparql 公開 endpoint の利用方式を定める)
+- [x] 4. データ永続化 / 同期戦略 / バックアップ方式 (アイドル情報マスタ同期戦略の中核)
+- [x] 8. 複数の代替案を比較した結果としての判断 (schedule / webhook / 手動 / 自動 merge 付きと比較)
+- [x] 10. 長期的な制約 (今後 1 年以上、アイドル情報マスタ更新の中核ベース)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR が単なる sync workflow の設定 (workflow YAML + runbook で済む話) に
+      留まらず、外部データ同期戦略の中核方針として ADR 化すべきと確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0010 (アイドル情報マスタ SQLite を repo commit、本 ADR の同期対象)
+- ADR-0014 (im@sparql のローカル Fuseki 環境、開発時の代替 endpoint)
+- ADR-0009 (Cloud Run、同期結果のデプロイ先)
+- `docs/harness/plan.md` §3.3 (upstream-driven sync)
+- `.claude/rules/adr.md`

--- a/docs/adr/ADR-0008-user-data-backend-sqlite-litestream-r2.md
+++ b/docs/adr/ADR-0008-user-data-backend-sqlite-litestream-r2.md
@@ -1,0 +1,132 @@
+---
+id: ADR-0008
+title: ユーザーデータは Backend 内蔵 SQLite と Litestream で R2 にレプリケートする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0008: ユーザーデータは Backend 内蔵 SQLite と Litestream で R2 にレプリケートする
+
+> **5 行以内 summary**: ユーザーデータ (担当 / 推し) の永続化は Backend (Cloud Run)
+> 内蔵 SQLite `users.db` に行い、Litestream で Cloudflare R2 に WAL ストリーミング
+> レプリケート + 起動時 restore する。リポジトリには絶対 commit しない (`.gitignore`
+> で強制)。DB スキーマには `uid` (Google sub claim) のみ保存し、display name / email /
+> picture は GIS userinfo endpoint から都度取得 + memory cache TTL 15 分で扱う (PII 最小化)。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は担当 / 推しといったユーザー固有データを保存する必要がある。ユーザーデータ
+には Google アカウント由来の PII (display name / email / picture) が紐づく可能性があり、
+永続化戦略は以下を同時に満たさなければならない:
+
+- 個人プロジェクトとして **完全無料運用** を目指す (Cloud Run + Cloudflare R2 のハイブリッド)。
+- Cloud Run の **ephemeral container** 特性に耐える (コンテナ再生成で local SQLite が
+  失われる)。
+- **PII 最小化** (ADR-0020) — DB が万一漏洩した場合に個人特定が困難な状態を維持。
+- Firebase Auth / Firestore を **完全廃止** する方針 (ADR-0011) と整合させ、Firebase
+  Storage 系の代替を別途用意する必要がある。
+
+候補としては (a) Cloud Run + 内蔵 SQLite + Litestream で R2 にレプリケート、
+(b) Cloud SQL / 外部 Postgres、(c) Firestore 継続、(d) Cloudflare D1、が挙がった。
+
+## 決定
+
+ユーザーデータの永続化を以下の構成で採用する。
+
+- Backend (Cloud Run、Ktor / Kotlin/JVM) は内蔵 SQLite `users.db` をプロセスローカルに
+  持つ。リポジトリには `users.db*` を絶対 commit せず、`.gitignore` で強制する
+  (`data/users.db` / `users.db-shm` / `users.db-wal` / `data/*.db-journal`)。
+- **Litestream** で `users.db` の WAL を Cloudflare R2 に **ストリーミングレプリケート**
+  する (S3 互換 endpoint、egress 無料)。
+- コンテナ起動時に Litestream の `restore` を実行して最新の WAL から `users.db` を
+  復元する。これにより Cloud Run の ephemeral container 性をカバーする。
+- DB スキーマには **`uid` (Google sub claim) のみ保存**。display name / email /
+  picture は GIS userinfo endpoint から **都度取得 + memory cache TTL 15 分** で扱う
+  (PII 最小化、ADR-0020)。
+- Container イメージに `users.db` を焼き込むことは禁止 (`Dockerfile` 内の
+  `COPY data/users.db` を Konsist で機械検証)。
+
+## 根拠
+
+- **無料運用**: Cloud Run Free tier + Cloudflare R2 (zero egress) の組み合わせで
+  完全無料運用が成立する。Cloud SQL / Firestore は無料枠が薄い、または有料化リスクが
+  ある (Firestore は 3,000 DAU 制限)。
+- **ephemeral 耐性**: Litestream は v0.5.0 で R2 endpoint 自動検出に対応しており、
+  WAL ストリーミング + 起動時 restore で Cloud Run の container 揮発性を実用上問題ない
+  レベルで吸収できる。実例多数で本番運用レベルが確立済。
+- **PII 最小化との整合**: SQLite スキーマを `uid` のみに絞ることで、万一 `users.db`
+  または R2 backup が漏洩しても個人特定情報が出てこない構造になる。userinfo は
+  GIS endpoint から都度取得し memory cache に短時間しか置かない (TTL 15 分) ことで、
+  プロセス再起動で揮発する。
+- **Firebase 廃止との整合**: ADR-0011 で GIS 統一・Firestore 撤去を決めており、本 ADR の
+  Backend SQLite + Litestream + R2 はその代替永続化レイヤとして自然に成立する。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Cloud SQL (Postgres / MySQL) | 高可用性、運用知見豊富 | 無料枠なし、最低 $9/月程度の固定費 | 完全無料運用要件に反する |
+| Firestore 継続 | 既存資産流用可、ephemeral 耐性問題なし | wasmJs 非対応、無料枠 3,000 DAU 制限、ADR-0011 で全廃 | Firebase 全廃方針に矛盾 |
+| Cloudflare D1 | 同じ Cloudflare 上で完結、無料枠あり | Backend が Cloud Run (GCP) との往復で latency 増、JVM 直結のドライバが未成熟 | Backend と同居 SQLite + Litestream の方が単純で堅牢 |
+| Cloud Run + Volume mount (Filestore / GCS Fuse) | 起動時 restore 不要 | コスト発生、ハイブリッド構成の旨味喪失 | egress 無料の R2 を活かせず劣後 |
+
+## 帰結
+
+### Positive
+
+- 完全無料運用が成立し、個人プロジェクトの維持コストがゼロに近付く。
+- DB スキーマが `uid` のみのため、漏洩時の個人特定リスクが構造的に低い。
+- Litestream + R2 の組み合わせで、Cloud Run の ephemeral 性を意識せずアプリ実装に集中できる。
+- Firebase 撤去 (ADR-0011) と一貫した方針が取れる。
+
+### Negative / トレードオフ
+
+- userinfo を毎リクエストで GIS から取得 (memory cache hit 時を除く) するため、
+  認証経路にネットワーク往復が増える。memory cache TTL 15 分で十分緩和可能。
+- Litestream の運用には R2 token (TTL 90 日) のローテーション運用が必要 (ADR-0021)。
+- container 起動時の restore 時間が cold start に加算される (許容範囲、実例ベンチで数秒)。
+
+### Neutral / 将来の検討事項
+
+- ユーザー数が数万 DAU を超えた場合、SQLite 単一 instance の書き込みスループットが
+  ボトルネック化する可能性がある。その時点で Cloud SQL / D1 への移行を再評価する。
+- R2 backup の geo redundancy / 暗号化方針は別 ADR (ADR-0022) で詳述。
+- userinfo memory cache の TTL は実運用負荷から再調整可能。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 3. 外部サービスの採用または変更 (Cloudflare R2 を採用、Firestore を撤去)
+- [x] 4. データ永続化 / 同期戦略 / バックアップ方式 (Backend SQLite + Litestream + R2)
+- [x] 6. セキュリティ・プライバシー・ライセンスに関する方針 (DB スキーマ `uid` のみ、PII 最小化)
+- [x] 9. 元に戻すコストが高い決定 (永続化レイヤの選択は移行コストが大きい)
+- [x] 10. 長期的な制約 (今後 1 年以上、ユーザーデータ保管の中核)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR がデータ永続化戦略の中核方針
+      として ADR 化すべき (`runbook` / Plan で済む話ではない) ことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0009 (Backend ホスティング: Cloud Run)
+- ADR-0011 (認証スタックを Firebase から GIS に統一)
+- ADR-0020 (PII 保護と権限ロール、`uid` のみ保存の SSoT)
+- ADR-0021 (Secrets 管理、R2 token のローテーション)
+- ADR-0022 (Cloudflare R2 採用、Litestream バックアップ先)
+- `docs/harness/plan.md` §3.2 / §3.7
+- `.claude/rules/{db-protection,pii,secrets}.md`

--- a/docs/adr/ADR-0009-backend-hosting-cloud-run.md
+++ b/docs/adr/ADR-0009-backend-hosting-cloud-run.md
@@ -1,0 +1,134 @@
+---
+id: ADR-0009
+title: Backend は Google Cloud Run でホストする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0009: Backend は Google Cloud Run でホストする
+
+> **5 行以内 summary**: ColorMaster の Backend (Ktor / Kotlin/JVM) は Google Cloud Run に
+> ホストする。Cloud Run は request-based billing で idle 課金が発生せず、無料枠
+> (月 200 万 req / 360,000 vCPU-sec / 180,000 GiB-sec) が同等の PaaS と比較して最も
+> 厚いため、個人プロジェクト規模で完全無料運用が成立する。既存 Dockerfile
+> (`amazoncorretto:22`) がそのまま流用でき、移行コストも最小。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster Backend は Ktor + Kotlin/JVM で実装され、im@sparql から同期した
+`data/idols.db` (read-only / Container 焼き込み、ADR-0010) とユーザーデータ
+`users.db` (Litestream で R2 へレプリケート、ADR-0008) を扱う。配信先は個人開発の
+無料運用が前提で、月数百〜数千 req 規模・cold start は許容される。Firebase は完全
+廃止方針 (ADR-0011) のため Firebase Hosting / Cloud Functions は選択肢から外れる。
+
+PaaS 業界では 2024 年後半以降、無料枠の縮小・廃止が相次いだ (Fly.io / Heroku /
+Railway)。Cloudflare は 2026/4/13 に Containers を GA したが、Workers Paid plan
+($5/月) が必須で完全無料運用に整合しない。一方 Google Cloud Run は 2024〜2026 を
+通じ無料枠が安定して提供されており、JVM サポートも成熟している。
+
+## 決定
+
+Backend (Ktor / Kotlin/JVM) のホスティング先として **Google Cloud Run** を採用する。
+
+- ランタイム: `amazoncorretto:22` ベースの Dockerfile を流用
+- リージョン: `asia-northeast1` (Tokyo) を第一候補
+- スケール: `min-instances=0` (idle 課金回避)、`max-instances` は無料枠内で運用
+- 認証: 公開エンドポイント、リクエスト本体の Bearer (Google ID Token) を Backend で検証
+- 静的配信 (wasmJs バンドル等) は Cloud Run ではなく **Cloudflare Pages** に分離 (ADR-0022)
+- ユーザーデータ永続化 (Litestream バックアップ先) は **Cloudflare R2** (ADR-0022)
+- Backend / 静的配信 / バックアップ先を分けたハイブリッド構成で運用する
+
+代替候補としての **Koyeb** は ADR 本文の比較表に記録のみ留め、現時点では採用しない。
+
+## 根拠
+
+- **無料枠の厚さ**: Cloud Run の Free tier (月 200 万 req / 360,000 vCPU-sec /
+  180,000 GiB-sec) は同価格帯 PaaS で最大級。ColorMaster の想定トラフィック
+  (個人開発、月数百〜数千 req) では確実に無料枠に収まる。
+- **idle 課金なし**: request-based billing により `min-instances=0` 時の保持コストが
+  ゼロ。cold start (数秒) は許容できる仕様。
+- **既存 Dockerfile 流用**: 現行の `amazoncorretto:22` Dockerfile が Cloud Run の
+  Container Contract をそのまま満たすため、移行コストが最小。
+- **JVM サポートの成熟度**: Cloud Run は Kotlin/JVM の本番運用事例が豊富で、ログ
+  集約・メトリクス・トレースが Google Cloud Operations Suite と統合済み。
+- **Cloudflare との組合せやすさ**: 静的配信を Cloudflare Pages、Litestream 先を R2
+  に振ることで、egress 課金の発生しないハイブリッド構成が成立する (ADR-0022)。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| **Google Cloud Run (採用)** | 無料枠最大、idle 課金なし、Dockerfile 流用可、JVM 成熟 | GCP アカウントとプロジェクト設定が必要 | 全項目で最も無料運用に整合、本 ADR で採用 |
+| Cloudflare Containers | 2026/4/13 GA、Kotlin/JVM 動作可、Pages / R2 と同一プラットフォーム | **Workers Paid plan $5/月 必須**で完全無料運用不可、年 $60 の固定費 | 個人プロジェクトに固定費は重い、不採用 |
+| Fly.io | 軽量、グローバル分散、設定が直感的 | **無料枠廃止 (2024 後半)**、最低でも月数ドル発生 | 無料運用の前提を満たさない、不採用 |
+| Render | UI が分かりやすく Git 連携が容易 | **無料 plan は sleep する**、初回リクエストで数十秒の cold start | cold start が許容範囲を超える、不採用 |
+| Railway | 開発者体験が良好、Postgres 等の一体提供 | **実質有料化** (Free plan の制約が運用に耐えない) | 無料運用の前提を満たさない、不採用 |
+| Koyeb | Free tier あり、Kotlin 動作実績あり | Cloud Run より無料枠が薄い、JVM サポートの実績情報が限定的 | 代替候補として記録、現時点では Cloud Run が優位 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- 月額固定費ゼロで Backend が稼働可能。
+- `min-instances=0` により無トラフィック時は完全に課金されない。
+- 既存 Dockerfile / Gradle ビルド成果物がそのまま使用でき、移行リスクが小さい。
+- Google Cloud Logging / Monitoring を Backend 観測の基盤として活用できる。
+- ADR-0022 (Cloudflare Pages + R2) と組み合わせ、egress 課金が発生しない構成が
+  実現できる。
+
+### Negative / トレードオフ
+
+- cold start による初回レスポンス遅延 (数秒) が発生する → 個人開発用途では許容。
+  必要に応じて `min-instances=1` へ切替できるが、その時点で月額課金が発生する点に
+  注意する。
+- GCP 単一ベンダーロックインが Backend に残る → Cloudflare 側 (Pages / R2) と
+  役割分担しているためフロント・バックアップ層は影響を受けない。
+- Cloud Run の上限 (request timeout 60 分、メモリ最大 32 GiB) に依存する設計と
+  なる → 現状の Backend ワークロードでは余裕。
+
+### Neutral / 将来の検討事項
+
+- トラフィック増 / SLO 要求変化に応じて `min-instances` 引き上げ、もしくは
+  Cloud Run for Anthos / GKE Autopilot への移行を検討する。
+- 代替候補 Koyeb は Cloud Run の無料枠が縮小された場合の退避先として継続観測する。
+- リージョン (`asia-northeast1`) と Cloudflare edge との物理距離による latency は、
+  実トラフィックで観測してから ADR を改訂する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 3. 外部サービスの採用または変更 (Backend ホスティング先の選定)
+- [x] 4. データ永続化 / 同期戦略 / バックアップ方式 (Cloud Run + R2 のハイブリッド構成の Backend 側)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Cloudflare Containers / Fly.io / Render / Railway / Koyeb との比較)
+- [x] 9. 元に戻すコストが高い決定 (一度本番稼働すると移行コストが大きい)
+- [x] 10. 長期的な制約 (今後 1 年以上、Backend デプロイ・観測・課金に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+`.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+本 ADR がコーディング規約 / Plan で済む話 / runbook で済む話 ではなく、Backend
+ホスティング先という外部サービス採用判断であることを確認した。`min-instances` 等の
+個別パラメータ調整は runbook + Plan で扱う。
+
+- [x] 確認済み
+
+## 関連
+
+- 関連 ADR: ADR-0008 (ユーザーデータ永続化 + Litestream)、ADR-0010 (`data/idols.db` を read-only で焼き込み)、ADR-0011 (Firebase 完全廃止 / GIS 統一)、ADR-0022 (Cloudflare Pages + R2 ハイブリッド)
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- `.claude/rules/cloud-run-deploy.md`
+- `.claude/rules/db-protection.md`
+- `docs/harness/plan.md` §3.4 (ホスティング採用根拠)

--- a/docs/adr/ADR-0010-idol-master-sqlite-in-repo.md
+++ b/docs/adr/ADR-0010-idol-master-sqlite-in-repo.md
@@ -1,0 +1,122 @@
+---
+id: ADR-0010
+title: アイドル情報マスタ SQLite をリポジトリに commit する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0010: アイドル情報マスタ SQLite をリポジトリに commit する
+
+> **5 行以内 summary**: アイドル情報マスタ (`data/idols.db` + `data/idols.json` +
+> `data/.imasparql-sync-state.json`) を Git にコミットし、Container イメージに焼き込んで
+> read-only でデプロイする。Litestream の対象外。利点は Cloud Run コンテナのステートレス
+> 維持、im@sparql ダウン時もアプリは前回正常データで稼働可能、同期失敗を PR レビューで
+> ブロック可能、予期せぬデータ消失の防止。ユーザーデータ (ADR-0008) とは保管方式を分離する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster はアイドル情報マスタ (色 / ブランド / 所属 / 名前) を外部 SPARQL endpoint
+im@sparql から取得して利用する。マスタの保管方式には次の制約がある:
+
+- アイドル情報は **read-only かつ全ユーザー共有** のデータであり、ユーザー固有データ
+  (ADR-0008 の `users.db`) とは性質が異なる。
+- im@sparql 公開 endpoint は個人運営で稼働率に不安があり、ランタイムで毎回問い合わせる
+  と im@sparql ダウン時にアプリが機能不全になる。
+- Cloud Run は ephemeral container のため、ランタイムでマスタを生成する設計だと
+  コンテナ再起動のたびに同期コストが発生する。
+- 同期処理に不具合があった場合 (レコード数の異常変動 / スキーマずれ等) を、運用前に
+  検出できる仕組みが必要。
+
+候補としては (a) Git commit + Container 焼込み、(b) Litestream で R2 にレプリケート、
+(c) ランタイム同期 + memory cache、(d) 別途 read-only ストレージ、が挙がった。
+
+## 決定
+
+アイドル情報マスタを以下の構成で扱う。
+
+- `data/idols.db` (SQLite)、`data/idols.json` (snapshot)、`data/.imasparql-sync-state.json`
+  (同期 state) を **Git リポジトリにコミット** する。
+- Container イメージビルド時に焼き込み、ランタイムは **read-only** で参照する。
+- **Litestream の対象外** とする (ユーザーデータ `users.db` とは保管方式を分離)。
+- マスタの更新は ADR-0007 の upstream-driven sync で行い、PR レビューを経て master に
+  取り込む。ランタイムでの DB 書き換えは行わない。
+
+## 根拠
+
+- **ステートレス維持**: Cloud Run コンテナは `data/idols.db` を read-only で参照する
+  だけで済み、起動時 restore / runtime fetch が一切不要。コンテナのステートレス性を
+  完全に保てる。
+- **im@sparql 可用性の分離**: im@sparql 公開 endpoint がダウンしていても、アプリは
+  前回 master 同期時点のデータで通常通り稼働できる。可用性の境界が明確。
+- **PR レビューによる安全網**: アイドル情報マスタの更新は必ず PR を経るため、レコード数
+  の異常変動 / スキーマ崩れ / 不正データ混入を人間 / AI レビューでブロックできる。
+- **データ消失耐性**: Git history に全更新が残るため、誤った同期も `git revert` で
+  即座に戻せる。Litestream / R2 のような外部依存ゼロ。
+- **ユーザーデータとの分離**: read-only マスタと書き込み頻度の高いユーザーデータを
+  別保管にすることで、それぞれに最適なバックアップ戦略を選択できる。マスタは Git、
+  ユーザーデータは Litestream + R2 (ADR-0008)。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Litestream で R2 にレプリケート | ユーザーデータと同方式で統一 | read-only マスタに WAL レプリケート不要、R2 token / endpoint への余分な依存 | read-only / 共有 / 不変履歴の特性に Git の方が適合 |
+| ランタイム同期 + memory cache | コンテナイメージサイズ小 | im@sparql ダウン時に機能不全、cold start でクエリ実行 | 可用性とコスト両面で劣後 |
+| 外部 read-only ストレージ (GCS / R2) | コンテナイメージサイズ小 | ストレージ依存、PR レビューで止められない | レビューの安全網が失われ不採用 |
+| Git commit + ランタイム書き換え可 | 部分修正容易 | コンテナ間で状態不一致、ステートレス性喪失 | Cloud Run の ephemeral 性と矛盾 |
+
+## 帰結
+
+### Positive
+
+- Cloud Run コンテナはステートレスを保ち、cold start が高速。
+- im@sparql 公開 endpoint がダウンしても、アプリは前回正常データで稼働継続可能。
+- 同期失敗 / 異常データを PR レビューで構造的にブロックできる。
+- 過去の全マスタ状態が Git history として保存され、`git revert` で即座にロールバック可能。
+
+### Negative / トレードオフ
+
+- `data/idols.db` のサイズが Git リポジトリに加算される (現状数 MB 想定、許容範囲)。
+- マスタ更新のたびに PR と Container イメージリビルドが発生する (ADR-0007 の同期 PR
+  経由で自動化済み)。
+
+### Neutral / 将来の検討事項
+
+- マスタサイズが数百 MB クラスに肥大化した場合、Git LFS や別配信方式を再評価する。
+- アイドル情報以外の read-only マスタ (例: 楽曲データ) を追加する際は、同方式を踏襲できる。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 4. データ永続化 / 同期戦略 / バックアップ方式 (read-only マスタの保管方式の中核)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Git / Litestream / ランタイム同期 / 外部 read-only を比較)
+- [x] 9. 元に戻すコストが高い決定 (一度方式を採用すると Container ビルド / 同期 workflow / レビュー体制が依存する)
+- [x] 10. 長期的な制約 (今後 1 年以上、アイドル情報マスタ保管の中核)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR がデータ保管方式の中核方針として
+      ADR 化すべき (`runbook` / Plan で済む話ではない) ことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0007 (im@sparql upstream-driven 同期、本 ADR の更新トリガ)
+- ADR-0014 (im@sparql のローカル Fuseki 環境、開発時の同期テスト)
+- ADR-0009 (Backend ホスティング: Cloud Run、焼き込み先)
+- ADR-0008 (ユーザーデータの Litestream 保管、本 ADR とは分離)
+- `docs/harness/plan.md` §3.2 / §3.3
+- `.claude/rules/{db-protection,sqlite-data-file}.md`

--- a/docs/adr/ADR-0011-auth-stack-firebase-to-gis.md
+++ b/docs/adr/ADR-0011-auth-stack-firebase-to-gis.md
@@ -1,0 +1,140 @@
+---
+id: ADR-0011
+title: 認証スタックを Firebase から Google Identity Services に統一する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0011: 認証スタックを Firebase から Google Identity Services に統一する
+
+> **5 行以内 summary**: Firebase Auth / Firestore / firebase-admin SDK を完全廃止し、
+> 全 target (Android / iOS / wasmJs) で Google Identity Services (GIS) に統一する。
+> フロントで GIS から ID Token を取得 → Backend に Bearer 送信 → Backend で Google JWKS
+> 検証 → uid 抽出。`dev.gitlive:firebase-{app,auth,firestore}` を依存から削除し、
+> `core/network/{auth,firestore}` / `firebase.json` / `.firebaserc` を撤去する (Phase A5)。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster はこれまで Firebase Auth + Firestore + firebase-admin SDK の構成で
+認証とユーザーデータを扱ってきた。Compose Multiplatform への移行を進める中で、
+次の制約が顕在化した:
+
+- **Firebase Auth / Firestore は wasmJs 非対応**。`dev.gitlive:firebase-*` 系も
+  wasmJs ターゲットを公式サポートしない。Web 配信を Cloudflare Pages + wasmJs で再開
+  する方針 (ADR-0022) と矛盾する。
+- **Firebase 無料枠の縮小傾向**: Cloud Storage が Spark plan から除外され、Firestore
+  の Spark plan は 3,000 DAU 上限が課されるなど、長期的に個人プロジェクトの完全無料
+  運用が困難になりつつある。
+- フロントは Android / iOS / wasmJs の 3 ターゲットで、Firebase SDK の expect/actual
+  切替が wasmJs 不可なため共通化が破綻する。
+- Backend ホスティングを Cloud Run (ADR-0009)、ユーザーデータを Backend SQLite +
+  Litestream + R2 (ADR-0008) に移す決定により、Firebase に残る役割が認証のみとなった。
+
+本 ADR は、本リポジトリの草案段階に存在した 2 つの先行決定 (旧 "firebase-removal-complete"
+と旧 "gis-unified-authentication") を **統合した経緯** で起票する。前身 ADR は物理化
+されていないため `supersedes` には記載しないが、認証撤去と GIS 採用は同一の撤去 PR で
+扱う方が一貫した移行計画になるため、本 ADR で一本化する。
+
+## 決定
+
+認証スタックを以下の構成で統一する。
+
+- **Firebase Auth / Firestore / firebase-admin SDK を完全廃止**。`dev.gitlive:firebase-app`
+  / `dev.gitlive:firebase-auth` / `dev.gitlive:firebase-firestore` を依存から削除する。
+- 全 target (Android / iOS / wasmJs) で **Google Identity Services (GIS)** に統一。
+  フロントは GIS から ID Token を取得し、Backend へ Bearer Authorization ヘッダで送信する。
+- Backend は Google JWKS endpoint (`https://www.googleapis.com/oauth2/v3/certs`) で
+  ID Token を検証し、`sub` claim を `uid` として抽出する (ADR-0020)。
+- `core/network/auth` / `core/network/firestore` モジュールは撤去または
+  `core/network/colormaster-api` に統合する。
+- ルート設定ファイル `firebase.json` / `.firebaserc` も撤去する。
+- 撤去作業は **Phase A の A5** で実施する (`docs/harness/plan.md` §3.6)。
+- 撤去対象モジュールの保護規約は `.claude/rules/removed-modules.md` / `no-firebase.md`
+  (旧 `firebase-boundary.md` を改名予定) で機械検証する。
+
+## 根拠
+
+- **wasmJs 全 target 統一**: GIS は Web (wasmJs 含む) / Android / iOS 全てで使える
+  唯一の Google 認証選択肢であり、expect/actual 切替不要で SDK 依存が激減する。
+- **Firebase 無料枠の縮小回避**: Firestore 3,000 DAU 制限 / Cloud Storage Spark
+  除外などの制約から、個人プロジェクトの長期無料運用に Firebase は適さない。
+- **Backend 認証パスの単純化**: ID Token を Bearer で送り JWKS で検証する流れは標準的な
+  OIDC パターンで、firebase-admin SDK 依存を避けられる。Kotlin/JVM の `nimbus-jose-jwt`
+  等で実装可能。
+- **PII 最小化との整合**: ADR-0020 で「DB に保存するのは `uid` のみ」と決めた方針が
+  GIS の `sub` claim 抽出にそのまま乗る。
+- **撤去 PR の一貫性**: Firebase 撤去と GIS 採用を別 ADR にすると、撤去後 GIS 移行
+  完了前の中間状態が生まれてしまう。同一 ADR で扱うことで「撤去 = 移行完了」を表現する。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Firebase Auth を残し Firestore のみ撤去 | 認証移行コストゼロ | wasmJs 非対応問題が残る、SDK 依存も残存 | Web ターゲットで破綻、不採用 |
+| 自前 OAuth 2.0 サーバ (Keycloak / Ory) | 認証ベンダー非依存 | 運用コスト膨大、無料運用不可 | 個人プロジェクト規模に過剰 |
+| Auth0 / Clerk 等の SaaS | フロント SDK が wasmJs サポート進展中 | 無料枠ユーザー数制限あり、ベンダーロックイン | GIS と比較してコスト劣後 |
+| Sign in with Apple 等の併用 | ユーザー選択肢拡張 | 認証経路が複数化、管理コスト増 | 初期は Google 単一で十分、必要なら別 ADR で追加 |
+
+## 帰結
+
+### Positive
+
+- wasmJs ターゲット含む全 target で認証経路が統一され、共通 ViewModel から
+  expect/actual 切替なしで利用可能。
+- Firebase 無料枠縮小リスクから完全に解放される。
+- Backend が firebase-admin SDK 依存ゼロになり、Kotlin/JVM 標準ライブラリ群で完結。
+- DB スキーマが `uid` のみ (ADR-0020) と整合し、PII 最小化が成立。
+
+### Negative / トレードオフ
+
+- 既存ユーザー (Firebase Auth 上のアカウント) の uid と GIS `sub` claim は同じ値の
+  はずだが、移行時にデータ整合性の検証が必要 (Plan で確認手順を整備)。
+- Firestore からユーザーデータを移行する作業が一時的に発生する (ADR-0008 の
+  Backend SQLite + Litestream に移行)。
+- 認証経路が GIS 単一ベンダー依存になる (Google アカウントなしのユーザーは利用不可) →
+  個人プロジェクトの想定ユーザー層では許容、必要時に別 ADR で追加プロバイダ検討。
+
+### Neutral / 将来の検討事項
+
+- GIS の deprecation 動向 (例: One Tap の API 変更) を監視し、影響時は別 ADR で対応。
+- ID Token の clock skew 許容秒数や JWKS キャッシュ TTL は Backend の runbook で
+  運用調整可能。
+- マルチプロバイダ対応 (Apple / GitHub 等) が必要になった場合は別 ADR で追加。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去 (Firebase SDK 群を撤去、GIS を採用)
+- [x] 3. 外部サービスの採用または変更 (Firebase Auth / Firestore 廃止 → GIS)
+- [x] 6. セキュリティ・プライバシー・ライセンスに関する方針 (認証経路の根幹)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Firebase 部分残存 / 自前 OAuth / SaaS と比較)
+- [x] 9. 元に戻すコストが高い決定 (認証スタック移行は全 target に波及)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 target の認証経路を規定)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「Firebase を完全廃止して GIS に統一する」例と一致し、
+      本 ADR がコーディング規約 / Plan で済む範囲を超える方針転換であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0008 (ユーザーデータを Backend SQLite + Litestream + R2、本 ADR と表裏)
+- ADR-0009 (Backend ホスティング: Cloud Run、JWKS 検証の実行先)
+- ADR-0020 (PII 保護、`uid` 抽出と userinfo 都度取得)
+- ADR-0012 (js/app 撤去、本 ADR と同時期に Phase A5 で実施)
+- `docs/harness/plan.md` §3.2 / §3.6
+- `.claude/rules/{removed-modules,no-firebase,backend-auth}.md`

--- a/docs/adr/ADR-0012-js-app-removal.md
+++ b/docs/adr/ADR-0012-js-app-removal.md
@@ -1,0 +1,133 @@
+---
+id: ADR-0012
+title: js/app と関連 Web 配信構成を撤去する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0012: js/app と関連 Web 配信構成を撤去する
+
+> **5 行以内 summary**: wasmJs ターゲット移行の方向性が決定済みのため、`js/app`、
+> `js/material`、`kotlin-js-store/`、`.github/workflows/web-build-and-deploy.yml`、
+> `public/` 内の js 専用ファイルを **即時撤去** する。後続リファクタが clean になる。
+> Web 配信は wasmJs 完成後に Cloudflare Pages (ADR-0022) で再開。撤去作業の実装は
+> Phase A の A5 で実施。詳細は `docs/harness/plan.md` §3.6 を Single Source of Truth とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は従来 Kotlin/JS (`js/app`) で Web 版を提供してきた。Compose
+Multiplatform の Web 対応が wasmJs に主軸を移し、JetBrains 公式も wasmJs を推奨
+ターゲットとして発信している現状で、`js/app` を残し続けると以下の問題が生じる。
+
+- **二重メンテナンス**: 同一 feature を `commonMain` と `jsMain` の両方で動作確認
+  する必要があり、撤去まで存続させると Phase B (リファクタ) / Phase C (機能拡張)
+  の作業ボリュームが純増する。
+- **依存ツリーの汚染**: `kotlin-js-store/` (`yarn.lock` 相当) と `js/app` 専用の
+  npm 依存が `build.gradle.kts` に残り、ビルド依存解決の複雑度が上がる。
+- **CI workflow の冗長**: `.github/workflows/web-build-and-deploy.yml` が JS ビルド
+  と Firebase Hosting デプロイを実行しているが、Firebase Hosting は ADR (0011 系)
+  で全廃方針が確定しており、撤去対象と整合しない。
+- **wasmJs 移行を阻害**: js/app の存在は wasmJs 実装と機能重複を起こし、新規 wasmJs
+  feature を書く際に「どっちに書く?」の判断が必要になる。
+
+Web 配信そのものは将来 Cloudflare Pages (ADR-0022) + wasmJs バンドルで再開する
+予定だが、移行期間中の Web 配信は **一時停止** することを許容する (ADR-0022 で記録
+予定)。
+
+## 決定
+
+以下を **Phase A の A5 で即時撤去** する。
+
+- **コードベース**:
+  - `js/app/` ディレクトリ全体
+  - `js/material/` ディレクトリ全体 (`js/app` 専用)
+  - `kotlin-js-store/` ディレクトリ (wasmJs 移行時に再生成)
+  - `public/` 内の js 専用ファイル (共有資源は `core/resources/` 等に退避)
+- **CI / インフラ**:
+  - `.github/workflows/web-build-and-deploy.yml` の workflow ファイル
+  - `firebase.json` / `.firebaserc` (Firebase Hosting 全廃方針と一体)
+- **依存**:
+  - `js/app` 関連の `build.gradle.kts` ターゲット定義
+  - Kotlin/JS 専用 npm 依存
+
+撤去後の Web 配信再開は **wasmJs ターゲット完成後**、ADR-0022 (Cloudflare Pages)
+に従って再構築する。本 ADR と ADR-0022 の間の期間、Web 版は提供しない。
+
+## 根拠
+
+- **後続リファクタが clean になる**: Phase B / C で feature-first 移行 (ADR-0003)
+  / Decompose 撤去 (ADR-0005) を進める際、js/app を残したまま行うと「js/app に
+  対しても同じ変更を当てるか?」の判断が毎 PR 発生する。先に撤去すると判断不要。
+- **即時撤去の合理性**: Web 配信を一時停止するコストより、二重メンテで Phase B/C
+  全体が遅延するコストの方が大きい。owner 単独運用で Web 版の利用統計が限定的な
+  現状では、一時停止のユーザー影響は許容範囲。
+- **Firebase 全廃と一体**: `web-build-and-deploy.yml` は Firebase Hosting 前提
+  であり、Firebase 全廃方針 (ADR-0011 系) と整合させるためにも本撤去で同時に消す。
+- **撤去 → 再開先が決まっている**: ADR-0022 (Cloudflare Pages) で Web 配信再開先
+  が確定しているため、本撤去は「永続的な Web 配信中止」ではなく「移行のための一時
+  停止」と位置付けられる。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| js/app を wasmJs 完成まで残す | Web 版が継続提供される | Phase B/C の作業ボリューム純増、二重メンテ | リファクタの妨げになるコストが、一時停止コストを上回る |
+| js/app を段階的に撤去 (feature 単位) | リスク分散 | 段階移行中の状態が長期化、判断回数増 | 即時撤去の方が判断単純、Phase A 内で完結 |
+| 撤去せず wasmJs と並行運用 | 移行リスク最小化 | 同上、依存ツリー汚染が永続化 | wasmJs 完成までの一時停止で十分 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- Phase B / C のリファクタ・新規実装が `commonMain` + 4 target (Android / iOS /
+  desktop / wasmJs) に集中でき、二重メンテの認知負荷がゼロになる。
+- `kotlin-js-store/` 撤去で `yarn.lock` 相当の依存管理が不要になり、ビルドが軽くなる。
+- Firebase Hosting 関連ファイル (`firebase.json`, `.firebaserc`) を同時撤去でき、
+  Firebase 全廃方針との整合が取れる。
+
+### Negative / トレードオフ
+
+- **Web 版が wasmJs 完成まで一時停止** する。owner 単独運用 + Web 利用統計が限定的
+  な状況なら許容範囲だが、ユーザー影響をゼロにはできない。
+- 既存 js/app に固有の bug fix / feature が残っていた場合、それを wasmJs 移行時に
+  改めて実装する必要がある (撤去前に未マージ branch がないことを確認する)。
+
+### Neutral / 将来の検討事項
+
+- wasmJs 実装は Phase B 以降で着手、ADR-0022 (Cloudflare Pages) と連動して進める。
+- 撤去 PR で削除されたファイル一覧は EPIC-000 / PLAN-001 系の Plan に
+  `expected_modules` で記録、後日の archeology を容易にする。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 1. アーキテクチャパターン / 層分割 / モジュール構造に影響する (js target 撤去)
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去 (Kotlin/JS target の撤去)
+- [x] 3. 外部サービスの採用または変更 (Firebase Hosting 関連の同時撤去)
+- [x] 9. 元に戻すコストが高い決定 (撤去後の復活はコード削除を巻き戻す必要)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] 確認済み (主要ターゲット (Kotlin/JS) の撤去は §4.5 項 1 / 2 に直接該当、
+      Plan 単独で済む単発バグ修正ではない)
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR、撤去の実装は別 Plan)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築、Phase A の一部として A5 で撤去実施)
+- ADR-0022 (Cloudflare Pages、Web 配信再開先)
+- ADR-0006 (wasmJs i18n、撤去後の移行先で利用)
+- `.claude/rules/removed-modules.md`
+- `docs/harness/plan.md` §3.6

--- a/docs/adr/ADR-0013-coverage-stepwise-100.md
+++ b/docs/adr/ADR-0013-coverage-stepwise-100.md
@@ -1,0 +1,168 @@
+---
+id: ADR-0013
+title: Line と Branch coverage は段階達成で 100% を目指す
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0013: Line と Branch coverage は段階達成で 100% を目指す
+
+> **5 行以内 summary**: テスト存在保証の指標として line / branch coverage を採用する。
+> 既存コード一斉 100% 化は非現実的なため、段階 1 (Phase A 完了: Kover 計測可能)、
+> 段階 2 (Phase C 各 PR: 差分 100% 必達ゲート)、段階 3 (Phase C 完了: 全体 100%) の
+> 3 段階で達成する。除外対象は本 ADR で限定列挙し、追加は ADR 改訂必須。
+> 詳細規約は `.claude/rules/coverage-100.md`、計測基盤は A7 で Kover 導入。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は AI Coding Agent によるテスト自動生成を前提とするため、「テストが存在しない
+コード」を機械的に検出する 1 次フィルタが必要になる。一方で、coverage 単体では仕様適合性
+(指標 B / ADR-0016) もテストの意味的強度 (指標 C / ADR-0015) も担保できない。Goodhart's law
+を避けるためにも、coverage は「指標」ではなく「テスト存在を保証する制約」として位置付ける
+必要がある (`docs/harness/plan.md` §3.10)。
+
+既存コード規模では一斉 100% 化は現実的でなく、Phase A 開始時点で line / branch 双方を
+即時 100% 強制するとマージ不能 PR が大量発生する。Kover は計測基盤として ColorMaster の
+KMP 構成と相性が良いが、差分カバレッジゲートを CI に乗せる方式は複数候補がある。
+
+## 決定
+
+line / branch coverage を **段階達成** で 100% に到達させる。以下 3 段階を採用する。
+
+### 段階 1 — Phase A 完了時点
+
+Kover プラグインを導入し、`./gradlew check` の延長で `koverHtmlReport` / `koverXmlReport`
+が出力できる状態を達成する。既存コードの未カバー分は本 ADR の除外リストで一時的に逃がす。
+CI は計測結果を artifact 化するに留め、ゲートは設けない。
+
+### 段階 2 — Phase C 各 PR
+
+当該 PR で **新規追加・変更された Kotlin 行に対して line / branch ともに 100%** を必達
+ゲートとする。差分カバレッジを満たさない PR はマージ不可。差分カバレッジゲートの実装方式
+は A7 で次の 3 候補から確定する。
+
+- (a) `koverVerify` の Coverage Rule に PR diff 由来の includes を渡す Gradle カスタム
+  タスク
+- (b) `codecov` の patch coverage
+- (c) GitHub Actions の独自スクリプト
+
+### 段階 3 — Phase C 完了時点
+
+全体で line / branch ともに 100% を達成する。除外は本 ADR で限定列挙した対象のみとし、
+段階 1 で一時的に許容していた「既存コードの未カバー分」は Phase C の各 Epic / Plan で
+段階的に解消する。
+
+### 除外対象 (最終達成 100% でも除外し続ける)
+
+- 自動生成コード (Compose Compiler / KSP / SQLDelight 生成クラス、kotlinx.serialization
+  生成クラス)
+- `@Composable` Preview / `@PreviewParameter` のみのコード
+- `fun main()` を含む CLI entrypoint (`MainKt` / `Application` / `MainActivity` 等)
+- DI モジュール定義 (Koin の `module {}` ブロック)
+- `expect` / `actual` declaration の片側 (テスト不能な合成宣言)
+- 純粋な値クラス / sealed marker (テスト不可能な合成 toString / equals のみ)
+
+除外対象を追加するには ADR 改訂が必須。Skill が勝手に除外を増やせないよう
+`.claude/rules/coverage-100.md` で禁止規約として明文化する。
+
+## 根拠
+
+カバレッジ単体を「品質指標」と位置付けると Goodhart's law を招き、書式上はカバレッジを
+満たすが assertion が薄いテスト (tautological テスト) を量産する力学が働く。一方で
+カバレッジを廃止すると「テスト書き忘れ」「デッドコード」を機械的に検出する手段を失う。
+よって本 ADR は coverage を **「テスト存在を保証する制約」** に再定義し、仕様適合性
+(指標 B) と意味的強度 (指標 C) は別 ADR で担当する分担構造を採用する。
+
+段階達成にする理由は、既存コードを一斉に 100% 化する PR は (1) 差分が肥大化し
+`code-reviewer` が機能しない、(2) AI が低品質テストを大量に生成するリスクが高い、
+(3) 仕様 ID 不在のテストが追加されると指標 B との整合性が崩れる、の 3 点による。
+
+### 達成するアウトカム
+
+- O1. テスト書き忘れの機械的検出 (特に AI 駆動で重要)
+- O2. デッドコード / 到達不能コードの検出
+- O3. リファクタリング時のセーフティネット
+- O4. AI が「テストゼロのコード」を生成することの 1 次フィルタ
+- O5. CI 上の欠陥検出効果との統計的相関 (statement coverage と mutation kill
+  effectiveness の有意な正の相関)
+- O6. コードレビュー支援 (新規行で未テストの箇所を CI が指摘)
+- O7. 使用例ドキュメントとしての最低保証
+- O8. テスト容易性を要求する設計圧
+- O9. 新規モジュール導入時の基準明示
+
+### 達成しないアウトカム
+
+- 仕様適合性 (→ ADR-0016 / 指標 B)
+- エッジケース・例外パスの網羅 (→ ADR-0016 / ADR-0015)
+- テストの意味的強度 (→ ADR-0015 / 指標 C)
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 全体 100% 即時必達 | シンプル | 既存コードで PR がマージ不能、AI が低品質テストを量産 | 段階達成を採用 |
+| 80% 等の閾値固定 | 目標がぶれない | Goodhart's law、未テスト 20% の品質保証が出来ない | カバレッジを「制約」に再定義 |
+| カバレッジ廃止 | Goodhart's law 完全回避 | テスト書き忘れの 1 次フィルタを失う | 制約として最小限採用 |
+| JaCoCo 採用 | 業界標準 | KMP の `commonMain` を直接計測できない | Kover が KMP と相性良 |
+
+## 帰結
+
+### Positive
+
+- AI が生成したテストの「書き忘れ」を CI で機械的に検出可能。
+- 差分カバレッジゲート (段階 2) により、PR 単位で確実にカバレッジを底上げできる。
+- 除外対象が ADR で限定列挙されるため、Skill が勝手に除外を増やすことを構造的に防止。
+
+### Negative / トレードオフ
+
+- 段階 2 の差分カバレッジゲートは AI に対し「テスト書け」の圧力を生むため、tautological
+  テストが増えるリスクがある。→ ADR-0015 (mutation) と ADR-0016 (Spec) で別軸の抑制効果。
+- 既存コードの除外リストは Phase C 末まで残存し、その間「全体カバレッジ」表示は誤読を
+  招きうる。→ 段階 3 達成時点で除外リストが ADR 0013 列挙分のみになっていることを確認。
+- 差分カバレッジゲートの実装方式が A7 内で未確定 (3 候補)。→ A7 内で確定する。
+
+### Neutral / 将来の検討事項
+
+- 差分カバレッジゲートの実装方式は A7 で確定後、本 ADR は不変、選択結果は
+  `.claude/rules/coverage-100.md` および runbook (`docs/runbooks/testing.md`) で記録。
+- Compose UI モジュールの coverage は screenshot test との組合せで担保 (ADR 0023 と
+  併読)。Compose UI Test + Roborazzi での到達範囲は §3.10 / §3.9 を参照。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 5. テスト戦略・品質指標の中核方針
+- [x] 8. 複数の代替案を比較した結果としての判断 (全体即時 / 閾値固定 / 廃止 / JaCoCo の比較)
+- [x] 9. 元に戻すコストが高い決定 (段階達成計画は全 Phase C Plan に影響)
+- [x] 10. 長期的な制約 (Phase C 完了まで効力を持つ判断)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR が単なるカバレッジ閾値設定 (Plan / runbook で済む話) ではなく、テスト戦略
+      の中核方針として ADR にふさわしい決定であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0004 (テスト戦略総論、三層指標のインデックス)
+- ADR-0015 (Mutation testing / 指標 C)
+- ADR-0016 (Spec coverage / 指標 B)
+- ADR-0023 (UI 凍結三本柱、Roborazzi baseline)
+- `.claude/rules/coverage-100.md` (Line/Branch 段階達成規約、A7 で導入)
+- `.claude/rules/kotlin-test.md`
+- `docs/harness/plan.md` §3.10 指標 A / §1.2 / §6.2 A7
+- `docs/runbooks/testing.md` (三層指標の運用、Phase A で本格化)

--- a/docs/adr/ADR-0014-imasparql-local-fuseki.md
+++ b/docs/adr/ADR-0014-imasparql-local-fuseki.md
@@ -1,0 +1,132 @@
+---
+id: ADR-0014
+title: im@sparql のローカル環境を Fuseki Docker で構築する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0014: im@sparql のローカル環境を Fuseki Docker で構築する
+
+> **5 行以内 summary**: Backend integration test とローカル開発を im@sparql 公開
+> endpoint 依存から切り離すため、Apache Jena Fuseki Docker でローカル SPARQL endpoint を
+> 立ち上げる。`docker-compose.yml` と RDF 初期データ投入スクリプト、Testcontainers
+> 統合の規約を整備し、`docs/runbooks/local-imasparql.md` で運用手順を定める。
+> 本格実装は Phase A の A8。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は im@sparql の公開 SPARQL endpoint からアイドル情報マスタを同期する
+(ADR-0007 / ADR-0010)。Backend の integration test とローカル開発で公開 endpoint を
+直接叩く構成には次の問題がある:
+
+- im@sparql 公開 endpoint は個人運営のため、稼働率と応答速度に揺れがある。
+  test が外部稼働状況に依存して flaky 化する。
+- ローカル開発で大量の SPARQL クエリを試行すると、公開 endpoint に余分な負荷を
+  かける。
+- オフライン環境 (移動中等) で integration test を回せない。
+- test fixture を im@sparql スキーマに固定したい場合、公開 endpoint のスキーマ変更が
+  test を破壊しうる。
+
+候補としては (a) Apache Jena Fuseki Docker、(b) im@sparql 公開 endpoint 直接利用、
+(c) インメモリ TripleStore (RDF4J 等) を test 内で起動、が挙がった。
+
+## 決定
+
+ローカル SPARQL endpoint を以下の構成で構築する。
+
+- **Apache Jena Fuseki** の公式 Docker イメージを採用し、`docker-compose.yml` で
+  起動できるようにする。
+- 起動時に RDF 初期データ (im@sparql の主要 dataset の subset または full snapshot)
+  を投入するスクリプトを `scripts/seed-imasparql.sh` 等で用意する。
+- Backend の integration test は **Testcontainers** を経由して Fuseki コンテナを
+  起動し、test 内から `http://localhost:<port>/sparql` 形式でアクセスする。
+- ローカル開発者向け運用手順は `docs/runbooks/local-imasparql.md` に整備する
+  (起動 / 停止 / 初期データ再投入 / 公開 endpoint との切替方法)。
+- 本格実装は **Phase A の A8** で行う (`docs/harness/plan.md` §6.2)。
+- 公開 endpoint との切替は環境変数 (例: `IMASPARQL_ENDPOINT_URL`) で行い、
+  default はローカル Fuseki にする。
+
+## 根拠
+
+- **test の安定化**: 公開 endpoint の稼働揺れから完全に切り離せるため、CI / ローカル
+  ともに integration test が deterministic になる。
+- **Apache Jena Fuseki の成熟度**: Fuseki は SPARQL 1.1 完全準拠の公式実装で、
+  Docker イメージも公式提供されている。im@sparql 本家も Jena 系 stack のため、
+  クエリの方言差異が最小。
+- **Testcontainers との親和性**: Kotlin/JVM の test framework から Testcontainers
+  経由でコンテナライフサイクルを管理でき、test 並列実行も問題ない。
+- **オフライン開発**: ローカル Fuseki により、移動中などオフライン環境でも開発と test
+  が継続可能。
+- **公開 endpoint への負荷軽減**: 開発時の試行錯誤クエリを公開 endpoint に飛ばさず、
+  個人運営の im@sparql に負担をかけない倫理的姿勢。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| im@sparql 公開 endpoint 直接利用 | セットアップ不要 | test が flaky 化、稼働依存、オフライン不可、外部負荷 | 上記制約で実用不可 |
+| インメモリ TripleStore (RDF4J 等) を test 内で起動 | Docker 不要、起動高速 | im@sparql の dataset / 方言再現性に難、prod と差異が大 | 再現性とスキーマ互換性で劣後 |
+| Mock HTTP server で SPARQL レスポンスを返す | test 単独で完結 | SPARQL クエリ実行ロジックを test できない | integration test の意義を損なう |
+| クラウド上に共有 Fuseki を立ち上げ | チーム全体で共有可能 | 個人プロジェクトに過剰、コスト発生 | 個人プロジェクト規模に不適合 |
+
+## 帰結
+
+### Positive
+
+- integration test が公開 endpoint 状況から独立し、deterministic に動作する。
+- ローカル開発でオフライン作業可能、クエリ試行錯誤の自由度が高まる。
+- 公開 endpoint への余分なアクセスを構造的に避けられる。
+- Testcontainers 経由で test 並列実行 / CI 統合が容易。
+
+### Negative / トレードオフ
+
+- 開発者は Docker 環境のセットアップが必要 (`docs/runbooks/local-imasparql.md` で
+  手順整備)。
+- ローカル Fuseki と公開 endpoint のデータ鮮度に乖離が出るため、ADR-0007 の同期 PR
+  経由で定期的に snapshot を更新する運用が必要。
+- Fuseki Docker イメージのバージョン管理が増える (Renovate で自動 PR、A9 で本格化)。
+
+### Neutral / 将来の検討事項
+
+- 初期データ投入スクリプトのフォーマット (`.ttl` / `.nq` / SPARQL UPDATE 等) は
+  Phase A8 の runbook で確定。
+- CI で Fuseki コンテナを並列起動する際のリソース使用量を計測し、必要に応じて
+  test profile を分割する。
+- 将来 im@sparql の方言差異が拡大した場合は、custom function などの設定を Fuseki
+  Docker に追加する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 3. 外部サービスの採用または変更 (im@sparql 公開 endpoint を test/開発から切り離し)
+- [x] 5. テスト戦略・品質指標の中核方針 (integration test の安定化と Testcontainers 統合)
+- [x] 8. 複数の代替案を比較した結果としての判断 (公開 endpoint / インメモリ / Mock / 共有 Fuseki と比較)
+- [x] 10. 長期的な制約 (今後 1 年以上、test と開発の SPARQL endpoint 構成を規定)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR が単なるローカル開発手順
+      (`docs/runbooks/local-imasparql.md` で済む話) ではなく、test 戦略と開発環境
+      の中核方針として ADR 化すべきことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0007 (im@sparql upstream-driven 同期、本 ADR のローカル test 対象)
+- ADR-0010 (アイドル情報マスタ SQLite、ローカル同期 test の入力)
+- `docs/harness/plan.md` §6.2 (Phase A8)
+- `docs/runbooks/local-imasparql.md` (運用手順、Phase A8 で整備)
+- `.claude/rules/kotlin-test.md`

--- a/docs/adr/ADR-0015-mutation-testing-pitest.md
+++ b/docs/adr/ADR-0015-mutation-testing-pitest.md
@@ -1,0 +1,151 @@
+---
+id: ADR-0015
+title: テスト意味的強度を PITest による mutation testing で計測する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0015: テスト意味的強度を PITest による mutation testing で計測する
+
+> **5 行以内 summary**: line / branch 100% でも assertion 不足の tautological テストが
+> 残るリスクを構造的に検出するため、PITest + pitest-kotlin + gradle-pitest-plugin を
+> 採用する。KMP の JVM target 経由で `commonMain` / `jvmMain` / `androidMain` を mutate
+> し、PR コメントで mutation score を可視化する。**CI ゲートにはせず**、改善は KPT 起点で
+> 継続課題化する。A7 で本格化、A9 で baseline を記録する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ADR-0013 で line / branch coverage を段階達成 100% に到達させる方針を採用したが、
+カバレッジは「テストが存在すること」しか保証しない。実際には以下の劣化パターンが残る:
+
+- assertion を持たないテスト (`fun test() { service.run() }` のみ等)
+- mock 過多で実装を全く呼ばないテスト
+- catch 節を握り潰すテスト
+- ハッピーパス偏重で分岐の意味を検証しないテスト
+
+これらは line / branch 上は 100% でも、実装の意味的な変更を検出できない (= tautological)。
+AI 駆動で大量にテストが生成される環境では、生成テストが「カバレッジを満たすが意味的に
+効かない」状態に陥るリスクが特に高い。Meta JiTTests 研究では mutation testing 併用で
+欠陥検出効果が約 4x になることが示されており、coverage と独立した「意味の指標」が必要。
+
+Kotlin 対応の mutation testing ツールには複数候補があるが、本格運用に耐える mature な
+選択肢は PITest + pitest-kotlin に限られる。Stryker は Kotlin 未対応で TS 中心、Pitest
+フォークは実験的、手動レビューは機械化されない。
+
+## 決定
+
+ColorMaster のテスト意味的強度の計測手段として **PITest + pitest-kotlin +
+gradle-pitest-plugin** を採用する。
+
+### 計測対象
+
+- KMP の **JVM target 経由** で `commonMain` + `jvmMain` (backend) + `androidMain` の
+  クラスを mutate
+- `jsMain` / `wasmJsMain` / `iosMain` の actual 実装は PITest 対象外。これらは Konsist
+  + 通常単体テストで担保する
+
+### 運用方針
+
+- PR コメントで mutation score を可視化
+- **CI ゲートにはしない** (Goodhart's law を避け、シグナル可視化に留める)
+- mutation score が低い領域は KPT で learning に蓄積し、`.claude/rules/kotlin-test.md`
+  を強化していくフォールバックループで対処
+- Phase A の A7 で本格化、A9 で baseline 記録 (将来比較の基準点)
+
+### 達成するアウトカム
+
+- assertion 不足の検出 (line / branch coverage では捕捉不可能)
+- テストの意味的強度シグナル (PR レビューの参考情報)
+- 明らかな tautological テストの learning 蓄積による、ルール側の改善ループ起動
+
+### 達成しないアウトカム
+
+- テスト存在の保証 (→ ADR-0013 / 指標 A)
+- 仕様適合性 (→ ADR-0016 / 指標 B)
+
+## 根拠
+
+mutation testing を **CI 必達ゲートにしない** 判断は、Goodhart's law (測定が目標化される
+と指標としての意味を失う) を避けるため。mutation score を必達にすると AI は mutation を
+殺すだけの assertion を量産し、仕様適合性と無関係な「形だけの強化」が増える。
+仕様適合性は ADR-0016 (指標 B) が直接担当し、本 ADR は「無意味テストのシグナル可視化」と
+ルール改善ループの起点に責務を限定する。
+
+PITest を選定した理由は Kotlin 対応 mature ツールが事実上 PITest のみで、JVM target
+経由で `commonMain` を mutate する経路が確立しているため。MutFlow (2026 年登場の K2
+compiler plugin ベース、KMP 全 target 適合の可能性) は将来別 ADR で評価する余地として
+記録する。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Stryker | mutation testing の有名実装 | Kotlin 未対応、TS 中心 | 言語適合性が無い |
+| PITest フォーク | Kotlin 特化 | 実験的、メンテ不安定 | mature な PITest 本体を採用 |
+| 手動コードレビューのみ | 導入コストゼロ | 機械化されない、AI 駆動と非整合 | 機械シグナルが必須 |
+| mutation testing 必達ゲート化 | 強い強制力 | Goodhart's law、assertion 水増しを誘発 | シグナル可視化に留める |
+| MutFlow (将来候補) | KMP 全 target 適合の可能性 | 2026 年新規、評価データ不足 | 将来別 ADR で評価 |
+
+## 帰結
+
+### Positive
+
+- line / branch 100% でも残る tautological テストを構造的に検出可能。
+- AI 生成テストの assertion 不足を mutation score で可視化、KPT 起点で
+  `.claude/rules/kotlin-test.md` 改善ループに接続できる。
+- CI ゲート化を回避するため、Goodhart's law を構造的に防止。
+
+### Negative / トレードオフ
+
+- 必達ゲートでないため、mutation score が低いまま放置されるリスクがある。→ KPT で
+  learning 蓄積 + ルール強化のフォールバックループで対処。
+- PITest 実行時間が長い (commonMain + jvmMain + androidMain を JVM 経由で mutate)。
+  → PR 毎ではなく週次バッチや changed-files limited 実行など、A7 で運用方式を確定。
+- `jsMain` / `wasmJsMain` / `iosMain` は計測対象外。→ Konsist + 通常単体テストで補完。
+
+### Neutral / 将来の検討事項
+
+- A9 で baseline mutation score を記録し、Phase C 各 PR の傾向比較に用いる。
+- MutFlow が安定化すれば KMP 全 target 対応に向けて別 ADR で再評価。
+- mutation score 低下が継続的に観測される領域は `harness-meta` 経由でルール強化提案を
+  起票する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 2. 主要なライブラリ / フレームワークの採用 (PITest + pitest-kotlin +
+      gradle-pitest-plugin)
+- [x] 5. テスト戦略・品質指標の中核方針 (三層指標の指標 C)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Stryker / PITest フォーク / 手動 /
+      必達ゲート化 / MutFlow の比較)
+- [x] 10. 長期的な制約 (Phase A 以降のテスト評価軸として継続)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR が単なるツール導入手順
+      (runbook で済む話) ではなく、テスト戦略の意味的強度指標として ADR にふさわしい
+      決定であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0004 (テスト戦略総論、三層指標のインデックス)
+- ADR-0013 (Line / Branch coverage 段階達成 / 指標 A)
+- ADR-0016 (Spec coverage / 指標 B)
+- `.claude/rules/mutation-testing.md` (PITest 運用規約、A7 で導入)
+- `.claude/rules/kotlin-test.md`
+- `docs/harness/plan.md` §3.10 指標 C / §6.2 A7 / A9
+- `docs/runbooks/testing.md` (三層指標の運用)

--- a/docs/adr/ADR-0016-spec-coverage-annotation.md
+++ b/docs/adr/ADR-0016-spec-coverage-annotation.md
@@ -1,0 +1,165 @@
+---
+id: ADR-0016
+title: 仕様適合性を @Spec annotation と Konsist で追跡する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0016: 仕様適合性を @Spec annotation と Konsist で追跡する
+
+> **5 行以内 summary**: 仕様適合性 (Acceptance criteria の充足) は line / branch
+> coverage でも mutation score でも担保不能なため、テストに `@Spec(SpecId)` annotation を
+> 付与し、Konsist で「全 Acceptance criteria に対応する `@Spec` 付きテストが存在する」
+> ことと「実装 ⇄ テスト ⇄ 仕様 ID の双方向トレーサビリティ」を機械検証する。
+> 新規機能は Spec coverage 100% を必達ゲート、既存機能は Phase C 段階達成とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ADR-0013 (line / branch coverage 段階達成 / 指標 A) と ADR-0015 (mutation testing /
+指標 C) を組合せても、テストが **仕様に対応しているか** は担保できない。具体的には:
+
+- 全行をテストしているがユーザー要件と無関係なケースのみ検証している
+- mutation を殺せているが Acceptance criteria を 1 つも反映していない
+- 仕様変更時に「どのテストを修正すれば影響範囲を網羅できるか」が grep に依存
+
+AI による自動テスト生成では、coverage / mutation を満たすが仕様 ID と紐付かないテストを
+量産するリスクが特に高い。`docs/harness/plan.md` §3.10 では、これを「仕様の指標」として
+分離し、ユーザーモチベーションの直接実現を保証する独立指標 (指標 B) に位置付ける必要が
+あると整理されている。
+
+加えて、ColorMaster は `docs/traceability.md` を A6 で自動生成する計画があり、その入力源
+として実装 / テスト / 仕様の 3 者を機械可読な ID で接続する仕組みが要る。
+
+## 決定
+
+仕様適合性を **`@Spec(SpecId)` annotation と Konsist 検証** で担保する。
+
+### `SpecId` の形式
+
+`SPEC-<entity>-<seq>-<criterion>` 形式 (例: `SPEC-IDOL-001-3`)。
+
+- `<entity>`: ドメインエンティティ (`IDOL` / `BRAND` / `AUTH` 等)
+- `<seq>`: 同一エンティティ内の連番 (3 桁)
+- `<criterion>`: 当該基本設計内の Acceptance criteria 連番
+
+基本設計 (`docs/specifications/basic/SPEC-<entity>-<seq>-<slug>.md`) の Acceptance
+criteria に `SPEC-<entity>-<seq>-<criterion>` 形式で ID を付与し、`SpecId` と一意対応
+させる。
+
+### テスト側の `@Spec` 付与
+
+各テスト関数に `@Spec("SPEC-IDOL-001-3")` 形式で annotation を付与する。1 テストが
+複数の criterion を検証する場合は複数 ID を列挙する。
+
+### Konsist 検証 (2 系統)
+
+(a) **Spec coverage**: 各 Acceptance criteria に対応する `@Spec` 付きテストが少なくとも
+1 つ存在することを Konsist で機械検証。**新規機能は Spec coverage = 100% を必達ゲート**
+とする。既存機能は Phase C で段階的に達成する。
+
+(b) **双方向トレーサビリティ**: 実装側で参照される `SpecId` と、テスト側 `@Spec` で参照
+される `SpecId` の両方向の存在を検証し、`docs/traceability.md` を Gradle カスタムタスク
+で自動生成する。
+
+### 達成するアウトカム
+
+- 仕様 ⇄ テスト ⇄ 実装の双方向リンク
+- 要件変更時の影響範囲特定 (`SpecId` から実装とテストの両方を逆引き可能)
+- `docs/traceability.md` 自動生成の入力源
+- AI が「カバレッジを満たすだけのテスト」を書いても価値が出ない構造 (仕様 ID が振れない
+  限り meaningful にならない)
+
+### 達成しないアウトカム
+
+- テスト存在保証 (→ ADR-0013 / 指標 A)
+- テストの意味的強度 (→ ADR-0015 / 指標 C)
+
+## 根拠
+
+カバレッジは「実行したか」を計測し、mutation score は「意味的に効くか」を計測する。
+しかし「ユーザーが要件として表明した動作と一致しているか」はどちらにも含まれない。
+仕様適合性は本来、要件定義 / 基本設計の Acceptance criteria と直接結ばれて初めて意味を
+持つ。`@Spec(SpecId)` annotation は、テスト関数を機械可読な仕様 ID にバインドする最も軽量
+かつ言語非依存に近い手法であり、Konsist の lint で網羅性を強制できる。
+
+新規機能のみ Spec coverage を必達ゲートにする理由は、既存コードを一斉に対応させると差分
+肥大化で `code-reviewer` が機能しないため。Phase C の各 Epic / Plan で対象モジュールを
+段階的に attach する運用とする。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 仕様 ID をテスト関数名に埋め込む | 追加ライブラリ不要 | 関数名が長くなる、複数 ID 持てない、機械検証が grep 頼り | annotation 方式が堅牢 |
+| `@DisplayName` のメタデータで管理 | JUnit 標準 | KMP 全 target 対応に難、検証ツール独自 | `@Spec` 自前定義の方が KMP 横断 |
+| Gherkin / Cucumber 等の BDD | 仕様駆動の業界実例多数 | DSL 学習コスト、Kotlin Multiplatform 適合性低 | 既存 kotlin-test スタックを維持 |
+| coverage / mutation のみで運用 | 指標が 2 つで済む | 仕様適合性が担保されない | 仕様適合性を独立指標 (指標 B) として導入 |
+
+## 帰結
+
+### Positive
+
+- 要件変更時に `SpecId` 一発で影響範囲 (実装 / テスト) を逆引き可能。
+- `docs/traceability.md` の自動生成が成立し、Plan ⇄ Epic ⇄ ADR ⇄ Spec ⇄ 実装の
+  クロスリンクが機械維持される。
+- AI が「カバレッジだけ稼ぐテスト」を書いても、仕様 ID と紐付かない限り Konsist で
+  検出されるため、無意味テストへの抑制圧が働く。
+
+### Negative / トレードオフ
+
+- 全テスト関数に `@Spec` 付与の手間が発生する。→ 新規機能のみ必達、既存は Phase C 段階
+  達成。
+- 基本設計の Acceptance criteria に ID 採番運用が要る。→ `.claude/rules/docs-structure.md`
+  と spec template でフォーマット強制。
+- 仕様 ID が変わると影響範囲が広い。→ ID は immutable 運用 (旧 ID は廃止せず deprecated
+  として残す)、変更が必要なら新 ID を採番。
+
+### Neutral / 将来の検討事項
+
+- `@Spec` annotation 自体の定義配置 (`commonMain` の共通 testing util モジュール想定)
+  および Konsist 検証ロジックの実装詳細は A7 で確定し、`.claude/rules/spec-traceability.md`
+  に明文化する。
+- `docs/traceability.md` 自動生成 (Konsist + frontmatter parser join) は A6 で導入予定。
+- 仕様 ID の renaming 機械支援 (IDE refactoring) が将来必要になったら JetBrains MCP
+  経由のカスタム inspection を検討する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 5. テスト戦略・品質指標の中核方針 (三層指標の指標 B)
+- [x] 8. 複数の代替案を比較した結果としての判断 (関数名埋め込み / `@DisplayName` /
+      Gherkin / coverage と mutation のみの 4 案比較)
+- [x] 9. 元に戻すコストが高い決定 (`@Spec` annotation は全 spec / テスト / 実装に波及)
+- [x] 10. 長期的な制約 (`docs/traceability.md` 自動生成の前提として継続)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR が単なる annotation 命名規約
+      (`.claude/rules/spec-traceability.md` で済む話) に留まらず、仕様 ⇄ テスト ⇄ 実装
+      の中核トレーサビリティ機構として ADR にふさわしい決定であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0004 (テスト戦略総論、三層指標のインデックス)
+- ADR-0013 (Line / Branch coverage 段階達成 / 指標 A)
+- ADR-0015 (Mutation testing / 指標 C)
+- ADR-0027 (docs 構造 / 命名規約 / 仕様 ID の採番方針)
+- `.claude/rules/spec-traceability.md` (`@Spec` annotation / Spec coverage 規約、
+  A7 で導入)
+- `.claude/rules/docs-structure.md`
+- `docs/harness/plan.md` §3.10 指標 B / §6.2 A7
+- `docs/traceability.md` (A6 で自動生成導入)

--- a/docs/adr/ADR-0017-local-claude-code-polling.md
+++ b/docs/adr/ADR-0017-local-claude-code-polling.md
@@ -1,0 +1,141 @@
+---
+id: ADR-0017
+title: ハーネスループはローカル Claude Code ポーリングで駆動する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0017: ハーネスループはローカル Claude Code ポーリングで駆動する
+
+> **5 行以内 summary**: ハーネスループ (`pr-poller` / `pr-retrospective` / `harness-meta` /
+> `dependency-upgrade`) の起動は **ローカル Claude Code 内のポーリング** で駆動し、
+> GitHub Actions 上では Claude API を一切呼ばない。`pr-poller` Skill が `CronCreate`
+> 日次起動と `ScheduleWakeup` ループを組み合わせ、`gh` CLI で未処理 PR / Renovate ラベル
+> PR を検出して下流 Skill を起動する。コスト・rate limit・PII 漏洩経路を構造的に排除する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster の AI 駆動ハーネスは Spec Gen → Implementation → Evaluation → Merge →
+Retrospection → Meta の 6 段ループを継続稼働させる必要がある。ループ駆動には大別して
+3 案がある:
+
+1. GitHub Actions 上で Claude API を直接呼ぶ (workflow_run トリガ等)
+2. ローカル Claude Code 内でポーリング駆動し、API 呼び出しは Claude Code の既存利用枠内に閉じる
+3. 別途サーバ (Cloud Run 等) を立ててエージェントを常駐させる
+
+GitHub Actions 上で Claude API を呼ぶ方式は、PR 件数の増加に従って API トークン消費が
+線形に膨らみ、Anthropic 側 rate limit と GitHub Actions 同時実行枠の両方を圧迫する。
+また、PR 本文 / diff / CI ログを Claude API に送る経路が CI 上に常設されるため、PII
+redaction の責務が CI / Skill / API 三層に分散し、漏洩検出が難しくなる。
+
+別サーバ常駐方式は Cloud Run / Cloudflare Workers いずれも導入コストが大きく、個人
+プロジェクト規模 (owner 1 名、ADR 0020) では over-engineered。
+
+一方、Claude Code は `CronCreate` と `ScheduleWakeup` をローカル提供しており、これを
+組み合わせれば cron 駆動ポーリング + イベント駆動ループをローカル完結で実現できる。
+GitHub 操作は `gh` CLI で実行できる (ADR 0024)。
+
+## 決定
+
+ハーネスループの駆動を **ローカル Claude Code ポーリング** に統一する。具体的には:
+
+- **`pr-poller` Skill が起点**。3 系統の起動経路 (手動起動 / `CronCreate` 日次 09:00 JST /
+  `ScheduleWakeup` ループ) を持ち、`.claude/locks/pr-poller.lock` で排他制御する
+  (`.claude/rules/pr-poller.md`)
+- **検出ロジック**: `gh pr list --state merged,closed` で未処理 PR を取得 →
+  `docs/harness/learnings/` 配下に対応 learning ファイルが無いものを抽出 →
+  `pr-retrospective` を起動。open PR で `labels:renovate` が付くものは `dependency-upgrade`
+  を起動
+- **`harness-meta` 起動閾値**: 未処理 learning 10 件 or 前回実行から 7 日経過で自動起動
+  (`.claude/rules/harness-meta-criteria.md` で上書き可能)
+- **`harness-evolution` は cron 不採用**。手動起動のみ (ADR-0026)
+- **GitHub Actions では Claude API を呼ばない**。Actions 上で稼働させるのは Claude API
+  不要な workflow (CI 検証 / trufflehog / upstream-driven sync / markdownlint) のみ
+
+## 根拠
+
+- **コスト構造**: Claude API トークン消費は Claude Code の既存利用枠内で完結し、Actions
+  実行時間 (有料分) と API トークン (有料) の二重課金を回避できる
+- **rate limit 分離**: Anthropic API rate limit と GitHub Actions 同時実行枠が独立に
+  消費されるため、CI 詰まりと AI 遅延が連鎖しない
+- **PII 漏洩経路の限定**: PR diff / CI ログを Claude API に送る経路をローカル 1 ヶ所に
+  集約することで、redaction 責務が Skill 側だけで完結する (`.claude/rules/pii.md` /
+  R-26)
+- **ハーネス再帰性**: ローカル駆動は Claude Code の Skill ループ全体と整合し、
+  `implementation-workflow` Phase 8 で `pr-poller` を即時起動する設計 (ADR-0018) と一致
+- **`gh` CLI で十分**: GitHub MCP は token 効率で `gh` CLI に劣る (ADR-0024)、ローカル
+  ポーリングと相性が良い
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| GitHub Actions 上で Claude API 直接呼び出し | CI トリガ即時、owner 不在でも稼働 | API コスト二重、rate limit 競合、PII 漏洩面拡大 | コスト・セキュリティの両面で不利、本 ADR で不採用 |
+| 別サーバ (Cloud Run) 常駐エージェント | スケーラブル、owner 不在対応 | インフラ運用負荷、Backend と責務混在 | 個人プロジェクト規模で over-engineered |
+| ローカル Claude Code ポーリング (採用) | コスト枠内完結、PII 経路集約、Skill ループと整合 | owner 不在時はループ停止 | owner 1 名運用 (ADR-0020) と整合、許容 |
+| webhook + ローカル listener | 即時性が高い | port forwarding / 認証 / 常駐 listener が必要 | Claude Code の `ScheduleWakeup` で代替可能 |
+
+## 帰結
+
+### Positive
+
+- API コストが Claude Code 既存利用枠内に収まり、Actions 課金との二重コスト回避
+- PII redaction 責務が Skill 側 1 ヶ所に集約され、漏洩検出が単純化
+- `pr-poller` / `harness-meta` / `dependency-upgrade` がローカル統合され、Skill ループ
+  全体 (ADR-0018 / ADR-0019) と一貫した実行モデルになる
+
+### Negative / トレードオフ
+
+- **owner 不在時はループが停止**: 出張・長期休暇中は learning ファイル蓄積が遅れる →
+  `pr-poller` のキャッチアップ動作 (R-11) で「最後の処理から N 日経過した PR を最優先」
+  ロジックで補う
+- **3 系統の起動経路で重複起動リスク**: `.claude/locks/pr-poller.lock` で排他制御し、
+  N 分以内の既存ロックは no-op で終了 (`.claude/rules/pr-poller.md`)
+- **CI 上での即時 AI レビューができない**: ローカル `code-reviewer` 起動まで遅延が発生
+  → Draft PR で先行 lint/test を回し、AI レビューは Phase 6 で集約 (ADR-0019)
+
+### Neutral / 将来の検討事項
+
+- owner が複数人体制になった場合、別 ADR でハイブリッド方式 (Actions 側に軽量 trigger +
+  ローカル fan-out) を再評価する
+- Anthropic 側で Cloud Code エージェント常駐機能が公式提供されたら採用余地を見直す
+  (`harness-evolution` で月次確認、ADR-0026)
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 6. セキュリティ・プライバシー (PII 漏洩経路を限定)
+- [x] 7. ハーネス本体の中核設計 (ループ駆動方式の決定)
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (Skill 設計と CI workflow 双方に影響)
+- [x] 10. 長期的な制約 (今後 1 年以上、ハーネス稼働モデル全体に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」リスト (「ハーネスループをローカル Claude
+      Code ポーリングで駆動する」) と一致。コーディング規約 / Plan / runbook で済む話では
+      ないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0018 (`implementation-workflow` 10 フェーズ、Phase 8 で `pr-poller` 即時起動)
+- ADR-0019 (`code-reviewer` 8 aspect、サブエージェント並列、API 直接呼び出し禁止)
+- ADR-0024 (MCP サーバ採用、GitHub 操作は `gh` CLI)
+- ADR-0026 (`harness-evolution` は手動起動のみ、cron 不採用)
+- `.claude/rules/pr-poller.md` (3 系統起動経路 + 排他制御 + 検出ロジック)
+- `.claude/rules/harness-meta-criteria.md` (起動閾値の上書き)
+- `docs/harness/plan.md` §5.4 / R-17 / R-26 / R-37

--- a/docs/adr/ADR-0018-implementation-workflow-10-phases.md
+++ b/docs/adr/ADR-0018-implementation-workflow-10-phases.md
@@ -1,0 +1,153 @@
+---
+id: ADR-0018
+title: implementation-workflow Skill を 10 フェーズ構成にする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0018: implementation-workflow Skill を 10 フェーズ構成にする
+
+> **5 行以内 summary**: Plan / Epic 確定後の実装着手から Lint/Test、AI レビュー、人間
+> approve、squash merge、レトロ起動、worktree クリーンアップまでを **10 フェーズ
+> (Phase 0-9)** で統合管理する Generator として `implementation-workflow` Skill を採用する。
+> Phase 0 で `git worktree add`、Phase 9 で `git worktree remove` をペア化し、複数
+> Claude Code セッションの並行実装を物理的に分離する。fix loop は上限 3 回、超過時は
+> Plan を `status: blocked` にして人間に通知する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster の Spec Gen フェーズ (`feature-request` / `bug-fix` / `refactor` /
+`dependency-upgrade`) は Plan / Epic 起票までで責務が完結する。その後の実装着手 →
+Lint/Test → AI レビュー → マージ → レトロ → 後始末は別フェーズで担当する必要がある。
+
+これまでは Skill が個別に呼ばれる前提で、フェーズ間の引き継ぎ・lint 失敗時の
+fix loop・worktree 管理・`code-reviewer` 起動契機が暗黙だった。複数 Claude Code
+セッションを並行起動する場合 (例: PLAN-007 と EPIC-001 PR-03 を同時進行) に、
+同じ作業ディレクトリで複数セッションが衝突する事故が起きやすい。
+
+加えて、Anthropic の Planner / Generator / Evaluator パターンに照らすと、Generator
+側の責務 (実装してコミットして Draft PR を作る) と Evaluator 側の責務 (レビューする)
+は **別 Skill で独立** させる必要があり、両者を統合する **オーケストレーター** が
+求められる。
+
+## 決定
+
+`implementation-workflow` Skill を **オーケストレーター** とし、10 フェーズ
+(Phase 0-9) で全工程を統合管理する。
+
+- **Phase 0**: Worktree 作成 (`git worktree add ../<repo-name>-worktrees/<branch-slug>
+  -b <branch-name>`、`.claude/rules/branch-naming.md` 準拠、以降の全 Phase はこの
+  worktree 内で実行)
+- **Phase 1**: 要件 / 基本設計 / 詳細設計 Markdown を Read (frontmatter `related_*` を
+  辿って ADR / Epic / Plan を再帰 Read)
+- **Phase 2**: Spec 整合性チェック (SPEC-ID 採番重複なし、`related_basic` /
+  `related_detail` 双方向リンク有効、frontmatter 必須キー検証)
+- **Phase 3**: rules-index → 実装 + `./gradlew check` + Lint + Test (fix loop **上限
+  3 回**、超過時は Plan を `status: blocked` にして人間に通知)
+- **Phase 4**: Self-Verification (三層指標 / rules 違反自己チェック / PII / secrets /
+  設計書コード断片混入の検出)
+- **Phase 5**: Draft PR 作成 (`gh pr create --draft --template <type>.md
+  --body-file <draft>`、type は feature / bugfix / refactor / dependency-upgrade /
+  harness / docs のいずれか)
+- **Phase 6**: `code-reviewer` 呼出 (8 aspect 並列、Coordinator、ADR-0019)
+- **Phase 7**: CI green + 全 aspect pass + **人間 approve** の 3 条件で `gh pr merge
+  --squash`。**auto-merge は禁止** (GitHub Agentic Workflows 原則、R-15)
+- **Phase 8**: `pr-poller` 即時起動 (learning ファイル生成) + `roadmap-tracker` で完了
+  根拠登録 (Epic 配下 PR / B-A-C フェーズ項目のみ、Plan 単体は対象外)
+- **Phase 9**: `git branch --merged main` 確認 → `git worktree remove` + `git branch
+  -d`。**未マージなら停止して人間に通知** (worktree / branch を残す)
+
+Phase 0 と Phase 9 はペア (worktree 作成と削除)。Phase 6 の Critical findings あり時は
+Phase 3 に戻り fix loop を回す (上限 3 回)。
+
+## 根拠
+
+- **並行実装の物理分離**: 複数 Claude Code セッションが別々の worktree で動けば、
+  作業中のファイル衝突 / index 競合 / branch 切り替え事故が構造的に排除される。
+  `roadmap-tracker` の「並行実装容易性に基づく次の推奨着手 (top-N)」(`expected_modules`
+  の重複が少ない順) と組み合わせて、安全な並行ループを成立させる
+- **Generator / Evaluator 分離 (Anthropic 原則)**: Phase 6 で `code-reviewer` を独立
+  Skill として呼ぶ。Generator 自身がレビューしないことで bias を回避 (R-13)
+- **fix loop 上限 3 回**: 際限ない自動修正は失敗パターン蓄積につながる → 3 回で諦めて
+  Plan を `blocked` にし、人間判断にエスカレーション (R-14)
+- **auto-merge 禁止**: GitHub Agentic Workflows の human-in-the-loop 原則。AI の判断を
+  最終承認する人間ゲートを必ず保持 (R-15)
+- **Phase 8 の roadmap 更新条件**: Plan は 1 PR で完結するためロードマップ追跡対象外
+  (R-34)、Epic 配下 PR や B-A-C フェーズ項目のみが進捗ビューに値する
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 単一 Skill で実装 + レビュー一体化 | 起動回数が少ない | Generator バイアス、Anthropic Evaluator 独立性原則違反 | bias 構造化のため不採用 |
+| worktree なし、`git checkout` 切り替え | 単純 | 並行 Claude Code セッションで衝突 | 並行性が成立しないため不採用 |
+| fix loop 無制限 | 自動修復力高い | 無限ループリスク、cost 暴走 | 上限 3 回で打ち切り、blocked エスカレーション採用 |
+| auto-merge 有効化 | 高速 | 人間ゲート喪失、GitHub Agentic Workflows 原則違反 | R-15 で禁止、不採用 |
+| 5 フェーズ統合 (実装 / レビュー / merge / retro / cleanup) | 軽量 | worktree / Self-Verification / Draft 昇格の境界が曖昧 | 10 フェーズで責務分離、採用 |
+
+## 帰結
+
+### Positive
+
+- 複数 Claude Code セッションが安全に並行実行可能 (worktree 物理分離)
+- 各 Phase の責務が明確で、Skill 実行ログ (`.claude/logs/`) からフェーズ別に進捗追跡可能
+- Generator / Evaluator が独立し、Anthropic 原則に準拠 (ADR-0019 と整合)
+
+### Negative / トレードオフ
+
+- **10 フェーズはステップ数が多い**: 単純な 1 行修正 PR でも全フェーズを通す必要 →
+  Skill 内でフェーズスキップ判定を持たない代わりに、各 Phase の処理が軽量なら 1 ループ
+  あたりのオーバーヘッドは限定的
+- **worktree 削除忘れリスク**: Phase 9 を飛ばすと worktree が肥大化 → fix loop 上限超過 /
+  人間中断時の停止条件を明示し、Phase 9 をスキップしない設計
+- **fix loop 上限 3 回の打ち切り**: AI が自力解決できない複雑バグは人間判断にエスカレ →
+  blocked 通知から人間が拾うフローが必須
+
+### Neutral / 将来の検討事項
+
+- fix loop 上限 (デフォルト 3 回) は `harness-meta` の learning 集計で再評価する余地
+  あり (例: 3 回打ち切り率が高すぎたら 5 回に拡張)
+- Phase 8 の roadmap 更新条件 (Plan 除外) は `roadmap-tracker` 規約 (`.claude/rules/
+  roadmap.md`) と整合性を保つ
+- IDE 統合 (JetBrains MCP) を Phase 3 の Lint / 構造解析に組み込む余地は ADR-0024 で
+  別途扱う
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 1. アーキテクチャパターン (Generator / Evaluator 分離、worktree 物理分離)
+- [x] 7. ハーネス本体の中核設計 (実装ワークフローの 10 フェーズ構成)
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (`implementation-workflow` Skill 全体に依存)
+- [x] 10. 長期的な制約 (今後 1 年以上、全実装 PR の駆動方式に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」(「implementation-workflow + code-reviewer
+      の Generator/Evaluator 二段構成」) と一致。Plan / runbook / コーディング規約で済む
+      話ではないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0017 (ローカル Claude Code ポーリング駆動、Phase 8 で `pr-poller` 即時起動)
+- ADR-0019 (`code-reviewer` 8 aspect + Coordinator、Phase 6 で呼出)
+- ADR-0024 (MCP サーバ、Phase 3 で JetBrains MCP / Context7 MCP を利用)
+- ADR-0025 (Skill 作成は `example-skills:skill-creator` 経由)
+- `.claude/rules/implementation-workflow.md` (10 フェーズ手順の Single Source of Truth)
+- `.claude/rules/branch-naming.md` / `.claude/rules/merge-readiness.md` /
+  `.claude/rules/pr-draft-policy.md` / `.claude/rules/spec-living-sync.md`
+- `docs/harness/plan.md` §5.3 / §5.4.2 / R-13 / R-14 / R-15 / R-34

--- a/docs/adr/ADR-0019-code-reviewer-8-aspects.md
+++ b/docs/adr/ADR-0019-code-reviewer-8-aspects.md
@@ -1,0 +1,156 @@
+---
+id: ADR-0019
+title: code-reviewer Skill を 8 aspect と Coordinator 構成にする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0019: code-reviewer Skill を 8 aspect と Coordinator 構成にする
+
+> **5 行以内 summary**: Generator (`implementation-workflow`) と独立した **Evaluator**
+> として、`code-reviewer` Skill を **8 aspect** (spec-conformance / test-quality /
+> architecture / security / performance / code-quality / visual-regression /
+> design-tokens) の binary eval checklist + Coordinator で構成する。各 aspect は
+> ローカル Claude Code のサブエージェントで並列実行し、Claude API は直接呼び出さない。
+> visual-regression と design-tokens は A10 (DESIGN.md + Roborazzi baseline 完成) 後に
+> enable し、それまでは残り 6 aspect で稼働する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+Anthropic の Planner / Generator / Evaluator パターン、Cloudflare の specialized
+reviewer + coordinator 構成、GitHub Agentic Workflows の human-in-the-loop 原則を
+組み合わせると、AI 自身が書いたコードを **同じ Skill が評価する** 構造は Generator
+バイアスを生む。
+
+ColorMaster ではこれまで AI レビューを統合運用していなかったため、本ハーネス起動と
+同時に独立 Evaluator を設計する必要がある。観点は以下の 8 軸に分解可能で、いずれも
+binary yes/no eval checklist (最低 5 項目) に落とし込めば再現性を確保できる:
+
+1. spec-conformance (仕様 ⇄ 実装の整合性)
+2. test-quality (三層指標差分、tautological テスト検出)
+3. architecture (層分割、依存方向、JetBrains MCP IDE indexing 活用)
+4. security (PII / Secrets redaction)
+5. performance (N+1 / 重い同期 IO / 不要な recomposition)
+6. code-quality (Konsist / detekt / ktlint、Kotlin idiomatic)
+7. visual-regression (Roborazzi diff)
+8. design-tokens (DESIGN.md token 参照、hex / sp / dp ハードコード検出)
+
+ただし visual-regression と design-tokens は DESIGN.md + UI Inventory + Roborazzi
+baseline (A10) が揃わないと稼働不能。
+
+加えて、Claude API への直接呼び出しを各 aspect が行うとコスト・rate limit の両方を
+圧迫する (ADR-0017)。Claude Code のサブエージェント機能 (Agent ツール) を使えば、
+ローカル Claude Code 内で並列実行できる (R-37)。
+
+## 決定
+
+`code-reviewer` Skill を Generator から独立した **Evaluator** として以下のように構成
+する:
+
+- **8 aspect**: spec-conformance / test-quality / architecture / security / performance
+  / code-quality / **visual-regression** / **design-tokens** (末尾 2 つは A10 完了後に
+  enable、それまで 6 aspect で稼働)
+- **各 aspect は独立した system prompt** で動作 (Generator バイアス回避、R-13)。binary
+  yes/no eval checklist を最低 5 項目持つ (`.claude/rules/code-reviewer-aspects.md`)
+- **ローカル Claude Code のサブエージェント** で並列実行 (Claude API への直接呼び出しは
+  禁止、ADR-0017 / R-37)
+- **Coordinator** が同セッション内で重複指摘を排除し、Critical / Improvement に整理 →
+  日本語の構造化レビューコメントを `gh pr comment` で post
+- **Merge readiness 判定**: **Critical findings = 0** で Ready。Improvement は
+  non-blocking
+- **PII redaction を aspect ごとに必須化** (R-26)。PR 本文 / diff / CI ログを Skill 出力
+  に含める場合は redaction フェーズを通過させる
+
+A10 完了までは visual-regression / design-tokens を skip し、残り 6 aspect で稼働する。
+A10 完了時に SKILL.md の status を更新する。
+
+## 根拠
+
+- **Anthropic Evaluator 独立性原則**: Generator バイアス回避には Skill そのものを分離
+  するのが最も構造的。同一 system prompt 内で Self-Review させる方式は bias を持ち込む
+- **aspect 単位の分割**: 8 軸に分解することで、各 aspect の system prompt を独立化でき、
+  改善 PR も aspect 単位で打てる (例: security aspect だけ改修)
+- **サブエージェント並列実行**: Claude Code の Agent ツールはローカル Claude Code 利用枠
+  内で動作するため、Claude API 直接呼び出し (Actions 経由) と比べてコスト効率が高い
+  (ADR-0017)
+- **Critical = 0 の単一判定基準**: Improvement を non-blocking にすることで「指摘が多すぎて
+  PR が永久に Ready に上がらない」事故を回避
+- **段階的 enable**: visual-regression / design-tokens は A10 で前提資産 (DESIGN.md /
+  Roborazzi baseline) を揃えてから稼働、それまでは 6 aspect 稼働で実用性を担保
+- **PII redaction の aspect 内強制**: Skill が PR にコメント post する経路すべてに
+  redaction を通すことで漏洩経路を構造的に限定 (`.claude/rules/pii.md`)
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Generator 内 Self-Review | Skill 数最小 | バイアス、Anthropic 原則違反 | 構造的に不採用 |
+| 単一 aspect (汎用レビュー) | system prompt 1 つで済む | 軸ごとの専門性が落ち、改善 PR の粒度が粗くなる | 8 aspect 分割で採用 |
+| 各 aspect が Claude API 直接呼び出し | 並列度高い | コスト二重、ADR-0017 と矛盾 | サブエージェント並列で代替 |
+| Critical / Improvement の閾値を Critical > 0 で merge 不可、Improvement > 5 で警告 | 改善促進 | Improvement で永久に block されるリスク | Critical = 0 単一判定で簡素化 |
+| visual-regression / design-tokens を初期から enable | UI 品質の早期検出 | 前提資産未整備で false positive 連発 | A10 完了後 enable に遅延 |
+
+## 帰結
+
+### Positive
+
+- Generator / Evaluator 分離により Anthropic 原則準拠、bias 構造化排除
+- aspect 単位で改善 PR を打てるため、`harness-meta` / `harness-evolution` からの
+  Skill 改修提案が aspect 粒度に整理される
+- サブエージェント並列実行でコスト枠内完結 (ADR-0017 と整合)
+
+### Negative / トレードオフ
+
+- **aspect ごとに system prompt を維持する設計コスト**: A3 で各 aspect ファイルに分割
+  予定 (`.claude/rules/code-reviewer-aspects/<aspect>.md`)。B0 時点では単一ファイル
+- **visual-regression / design-tokens の遅延**: A10 完了まで UI 品質レビューが手動運用
+  → A10 で前提資産が揃った時点で SKILL.md status を `active` に更新
+- **Critical / Improvement 判定の境界**: `code-reviewer-aspects.md` でチェックリストを
+  確定する。曖昧判定は `harness-meta` の learning 集計で再評価
+
+### Neutral / 将来の検討事項
+
+- aspect 追加 (例: i18n 完備チェック、accessibility) は `harness-evolution` の提案
+  経由で別 ADR 化を検討
+- 人間レビュアーへの「code-reviewer の指摘で十分か?」文言の自動付与は
+  `code-reviewer-aspects.md` の Coordinator 形式に組込済 (R-15)
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 5. テスト戦略・品質指標の中核方針 (test-quality / spec-conformance / mutation 等)
+- [x] 6. セキュリティ・プライバシー (security aspect の PII redaction 強制)
+- [x] 7. ハーネス本体の中核設計 (独立 Evaluator の構成)
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 9. 元に戻すコストが高い決定 (Skill 全体に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」(「implementation-workflow +
+      code-reviewer の Generator/Evaluator 二段構成」) と一致。Plan / runbook /
+      コーディング規約で済む話ではないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0017 (ローカル Claude Code ポーリング、サブエージェント並列の前提)
+- ADR-0018 (`implementation-workflow` Phase 6 から呼出)
+- ADR-0023 (UI 凍結三本柱、visual-regression / design-tokens の前提資産)
+- ADR-0020 (PII 保護、security aspect の redaction 強制)
+- ADR-0024 (MCP サーバ、architecture aspect が JetBrains MCP の IDE indexing を活用)
+- `.claude/rules/code-reviewer-aspects.md` (8 aspect の eval checklist + Coordinator 形式)
+- `.claude/rules/pii.md` (redaction 規約)
+- `docs/harness/plan.md` §5.3 / §5.4.2 ③ / R-13 / R-15 / R-26 / R-37

--- a/docs/adr/ADR-0020-pii-protection-and-roles.md
+++ b/docs/adr/ADR-0020-pii-protection-and-roles.md
@@ -1,0 +1,183 @@
+---
+id: ADR-0020
+title: PII 保護を最小化原則と単一 owner ロールで構造化する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0020: PII 保護を最小化原則と単一 owner ロールで構造化する
+
+> **5 行以内 summary**: ColorMaster は Google アカウント由来の個人情報 (PII) を扱うため、
+> DB スキーマには `uid` (sub claim) のみを保存し、display name / email / picture は
+> GIS userinfo endpoint から都度取得 + memory cache TTL 15 分で揮発させる。13 種の
+> 漏洩経路を `.gitignore` / Konsist / detekt / trufflehog / redaction で多層に塞ぎ、
+> 権限ロールは当面 owner 単一、複数人体制への拡張は別 ADR で再評価する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は Google Identity Services (GIS、ADR-0011) で認証し、ユーザーごとの
+担当アイドル・推し情報を Backend SQLite (`users.db`、ADR-0008) に永続化する。
+GIS は userinfo endpoint からメールアドレス・display name・プロフィール画像 URL を
+返却するため、これらを無造作に保存すると `users.db` の漏洩が即座に個人特定可能な
+PII 流出に発展する。
+
+加えて、AI 駆動ハーネス (Spec Gen → Implementation → Evaluation → Merge →
+Retrospection → Meta) では `pr-retrospective` / `code-reviewer` / `harness-meta` が
+CI ログ・PR diff・GitHub コメントを横断して解析し、生成物として learning や
+PR コメントを出力する。これらの経路は CI ログ中の Stack Trace や fixture 由来の
+ダミーが混入する余地があり、構造的に redaction を要する。
+
+漏洩経路は単一の防御では塞げず、リポジトリ commit・Container 焼込み・R2 バケット
+直読・token 流出・API 越境取得・ログ出力・エラー応答漏洩・GIS 過剰保存・コンソール
+直接アクセス・Skill 出力混入と多岐にわたる。本 ADR でこれらを 13 経路に正規化し、
+それぞれに防御層を割り当てる。
+
+## 決定
+
+### PII 最小化原則
+
+- `users.db` に保存する PII は **`uid` (Google sub claim) のみ**。
+- display name / email / picture は **GIS userinfo endpoint から都度取得**、
+  Backend memory cache TTL **15 分** に揮発保持。永続化しない。
+- `users.db` が万一漏洩しても、`uid` 単体では Google アカウントの個人特定は
+  困難な状態を構造的に維持する。
+
+### PII の定義
+
+| 項目 | PII 扱い | DB 保存 |
+|---|---|---|
+| メールアドレス | PII | ❌ |
+| Google Account ID (sub claim = `uid`) | 内部識別子、PII 同等取扱 | ✅ (`users.db` の `uid` カラムのみ) |
+| Display Name | PII | ❌ |
+| プロフィール画像 URL | PII | ❌ |
+| IP アドレス | PII | ❌ |
+
+ダミーデータは `@example.com` ドメイン (RFC 2606 予約) と `test-uid-001` 等の連番
+文字列に限定する。実 PII の fixture commit はインシデント扱いとし、history 除去 +
+R2 token 即時ローテーションで対応する。
+
+### 13 漏洩経路と多層防御
+
+| # | 漏洩経路 | 防御 |
+|---|---|---|
+| 1 | リポジトリへの直接 commit | `.gitignore` で `data/users.db*` を除外 + Konsist で追跡禁止検証 |
+| 2 | Container イメージへの焼込み | Dockerfile で `COPY data/users.db` 禁止 + Konsist で文字列検証 |
+| 3 | R2 バケットからの直接読出し | バケットを private、Backend Container の R2 token のみ allow |
+| 4 | R2 token の流出 | Secrets 管理 + TTL 90 日で定期ローテーション (ADR-0021) |
+| 5 | リポジトリ内の credentials コミット | trufflehog による CI スキャン + `.gitignore` |
+| 6 | PR diff からの credentials 漏洩 | trufflehog secret-scan workflow を全 PR に発火 |
+| 7 | Backend API 経由で他人のデータ取得 | ID Token 検証 + `uid` フィルタ、Konsist で `/api/me/*` ハンドラの `requireUid()` 呼出を強制 |
+| 8 | ログ / モニタリングへの PII 出力 | `.claude/rules/logging.md` + `.claude/rules/pii.md` で禁止、detekt カスタムルールで `Logger` 系への PII フィールド渡しを検出 |
+| 9 | エラー応答に PII を含める | エラー schema に PII フィールド禁止 + Konsist 検証 |
+| 10 | GIS から取得した userinfo の過剰保存 | DB スキーマは `uid` のみ、display name / email / picture は memory cache TTL 15 分 |
+| 11 | GCP / Cloudflare コンソールへの不正アクセス | owner 単一ロール、Secrets ローテーション運用 (ADR-0021) |
+| 12 | `pr-retrospective` / KPT learning への PII 混入 | Skill 出力前の redaction 強制、テスト fixture の非 `@example.com` を Konsist で検出 |
+| 13 | `code-reviewer` が CI ログから PII を漏らす | aspect ごとに PII redaction の前処理を必須化 (ADR-0019) |
+
+### 権限ロール
+
+- 当面 **owner 1 名のみ** で運用する (個人プロジェクト想定)。
+- owner の権限: 全権限、Secrets ローテーション、GCP / Cloudflare コンソール
+  operator、master ブランチへのマージ権限。
+- 複数人体制になったら `developer` / `releaser` ロールを **別 ADR で改訂・追加**
+  する。本 ADR は単一 owner 前提でのみ有効。
+
+### Skill ループにおける redaction 必須
+
+- `pr-retrospective` / `code-reviewer` / `harness-meta` は、CI ログ・diff・PR
+  コメントから PII を間接的に拾う可能性があるため、出力前に必ず redaction
+  フェーズを通す。
+- redaction 対象とプレースホルダ: メールアドレス (除く `@example.com`) →
+  `[REDACTED-EMAIL]`、`https://lh*.googleusercontent.com/...` →
+  `[REDACTED-AVATAR-URL]`、sub claim 値 → `[REDACTED-UID]`、IP アドレス →
+  `[REDACTED-IP]`。
+- テスト fixture は `@example.com` ドメインのみ使用。Konsist で機械検証する。
+
+## 根拠
+
+- **最小化原則の構造的優位**: 「保存しなければ漏れない」が最強の防御。GIS が
+  userinfo を都度返却する仕様を活用し、`users.db` を `uid` だけのテーブルに
+  圧縮することで漏洩時の被害を構造的に限定する。
+- **多層防御の必然性**: 単一防御 (例: `.gitignore` のみ) では Container 焼込み /
+  ログ出力 / Skill 出力 を塞げない。経路ごとに防御層を割り当てて初めて全経路を
+  カバーできる。
+- **owner 単一の暫定化**: ロール設計は実装コストが高く、撤回も難しい。複数人
+  体制の必要性が出てから別 ADR で増やすことで、初期の YAGNI を維持する。
+- **Skill 出力 redaction の機械化**: 人間レビューに依存すると見落としが
+  避けられない。プレースホルダ置換のパターンマッチを Skill 内で自動化する。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Firebase Auth + Firestore に依存し続ける | PII 管理を Google に委譲、実装コスト低 | Firebase 廃止方針 (ADR-0011) と矛盾、Firestore のスキャン料金が個人プロジェクトでも顕著 | ADR-0011 で Firebase 完全廃止を決定済み、PII 最小化と独立して撤去 |
+| display name / email も DB 保存 (キャッシュ用) | API 呼出減で性能良 | 漏洩時の被害が個人特定可能まで拡大、最小化原則と矛盾 | 性能要件は memory cache TTL 15 分で十分、永続化しない |
+| 単一防御 (`.gitignore` のみ) | 実装最小 | Container 焼込み / ログ / Skill 出力を塞げない | 多層防御を採用、Konsist + detekt + trufflehog + redaction を組合せ |
+| owner / developer / releaser を初期から定義 | 将来拡張に備える | 個人プロジェクトでは over-engineered、ロール RBAC 実装コスト | owner 単一で開始、複数人体制時に別 ADR で追加 |
+
+## 帰結
+
+### Positive
+
+- `users.db` 漏洩時も `uid` のみで個人特定が困難、被害が構造的に限定される。
+- 13 漏洩経路の対応が明文化され、CI / Konsist / detekt / trufflehog で機械検証
+  可能。レビュー負荷が低減する。
+- Skill 出力の redaction が必須化され、learning / レビューコメントへの PII 混入
+  が構造的に塞がれる。
+
+### Negative / トレードオフ
+
+- userinfo 取得が都度 API call となり、Backend のレイテンシが微増する
+  → memory cache TTL 15 分で大半をヒットさせ実害を抑える。
+- redaction パターンマッチは正規表現ベースで完全網羅は困難
+  → A6 で `trufflehog` 同等の汎用パターンを追加導入し、Skill 単位の網羅率を
+  継続的に改善する。
+- owner 単一は bus factor 1、owner が稼働不能になると運用停止
+  → 個人プロジェクト前提で許容、複数人体制移行時に別 ADR で再評価。
+
+### Neutral / 将来の検討事項
+
+- 機械検証 (Konsist で `users.db*` 追跡禁止 / Dockerfile 内 `COPY data/users.db`
+  禁止 / `requireUid()` 呼出強制 / fixture の `@example.com` 限定 / エラー
+  schema の PII フィールド禁止) は A6 で本格化する。
+- detekt カスタムルール (Logger 系への PII フィールド渡し検出) も A6 で導入。
+- 複数人体制移行時の `developer` / `releaser` 追加は別 ADR で対応。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 6. セキュリティ・プライバシー・ライセンスに関する方針 (PII 最小化と redaction が中核)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Firebase 継続 / 保存方式 / 防御層 / ロール設計の比較)
+- [x] 9. 元に戻すコストが高い決定 (DB スキーマ・ロール設計・防御層構成は一度動かすと撤回困難)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 PII 取扱コードと Skill 出力に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR がコーディング規約 (`.claude/rules/pii.md` で済む話) や Plan で済む話 ではなく、
+      PII 保護のアーキテクチャ全体方針であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築)
+- ADR-0001 (ADR 運用基準)
+- ADR-0008 (ユーザーデータ Backend SQLite + Litestream + R2)
+- ADR-0011 (認証スタック転換、Firebase 廃止 + GIS 統一)
+- ADR-0019 (`code-reviewer` 8 aspect + Coordinator)
+- ADR-0021 (Secrets 管理ポリシー、本 ADR と同時防御)
+- `.claude/rules/pii.md` (PII 最小化と redaction の Single Source of Truth)
+- `.claude/rules/secrets.md` / `.claude/rules/db-protection.md` / `.claude/rules/logging.md`
+- `docs/harness/plan.md` §3.7 / §3.8

--- a/docs/adr/ADR-0021-secrets-management-policy.md
+++ b/docs/adr/ADR-0021-secrets-management-policy.md
@@ -1,0 +1,197 @@
+---
+id: ADR-0021
+title: Secrets を場所別管理と定期ローテーションで運用する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0021: Secrets を場所別管理と定期ローテーションで運用する
+
+> **5 行以内 summary**: API キー / token / 認証情報は用途別に保管場所を分離し、
+> ローカル開発は `.env`、CI/CD は GitHub Secrets、本番 Backend は Google Cloud
+> Secret Manager、Cloudflare 用は dashboard + GitHub Secrets、MCP OAuth は
+> Claude Code 安全領域に保管する。R2 token は TTL 90 日で定期ローテーション、
+> 全 PR 差分を trufflehog でスキャンし、Skill 出力は redaction 必須とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は GIS client secret / R2 access key / Cloudflare API token /
+Cloud Run service account credentials / MCP OAuth token と、性質の異なる
+Secrets を複数扱う。これらを単一の保管場所 (例: 全部 GitHub Secrets) に
+集約すると、CI からの参照可否や本番 runtime からのアクセス経路、token
+ローテーション単位の粒度が揃わず、漏洩時の影響範囲が肥大化する。
+
+加えて、AI 駆動ハーネス (`pr-retrospective` / `code-reviewer` / `harness-meta`)
+が CI ログ・MCP 結果・PR diff を解析する経路は、Secrets が文字列として
+混入する余地がある。漏洩検出を CI に組み込まないと、incident 検知が
+人間レビューに依存して時間的に遅延する。
+
+R2 token (Litestream の write 用) は ColorMaster のユーザーデータ
+バックアップ経路の核心であり (ADR-0008、ADR-0022)、流出すると users.db の
+直接読み書きが可能になる。長期 token を発行し続けると侵害時の被害が
+拡大するため、定期ローテーションが必須となる。
+
+## 決定
+
+### 保管場所の使い分け
+
+| 種類 | 保管場所 | 取り扱い |
+|---|---|---|
+| ローカル開発用 | `.env` (`.gitignore` 対象) | 個人マシン外に絶対出さない、共有時は別チャネル + 人手で渡す |
+| CI/CD 用 | **GitHub Secrets** | repo 設定で管理、Pull Request からは参照不可、Actions の `secrets.*` 経由のみ |
+| 本番 Backend 用 | **Google Cloud Secret Manager** | Cloud Run service account 経由でアクセス、R2 access key / GIS client secret 等 |
+| Cloudflare 用 (R2 token / Pages deploy key) | Cloudflare dashboard + GitHub Secrets | dashboard が原本、CI 連携は GitHub Secrets 経由、TTL 90 日でローテーション |
+| Claude Code 内 (MCP OAuth) | ローカル Claude Code 安全領域 | リポジトリ commit 禁止、`.gitignore` で `.claude/oauth-tokens*` を除外 |
+
+各保管場所の選択理由:
+
+- **`.env` (ローカル)**: 個人マシン上の secret 管理ツールに統一すると依存が
+  増えるため、`.gitignore` 対象の plain file で十分。例として
+  `<GIS_CLIENT_SECRET>` 形式の placeholder を `.env.example` に列挙する。
+- **GitHub Secrets (CI/CD)**: Actions の標準機構で、PR からは参照不可という
+  保護モデルが組込み済み。fork からの secret 露出を構造的に防ぐ。
+- **Cloud Run Secret Manager (本番)**: service account 経由のアクセス制御が
+  IAM で完結し、Container イメージに焼込まずに runtime 注入できる。
+- **Cloudflare dashboard + GitHub Secrets**: Cloudflare の API token 発行は
+  dashboard でのみ可能で、CI 利用時は GitHub Secrets にコピーする 2 系統管理。
+- **Claude Code 内 (MCP OAuth)**: MCP サーバ (JetBrains / Context7 /
+  Cloudflare) は OAuth token をローカル安全領域に保管し、リポジトリには
+  含めない。
+
+### 絶対 commit してはいけないもの
+
+以下のパスは `.gitignore` で除外し、Konsist / trufflehog で機械検証する:
+
+- `.env*` (例: `.env`, `.env.local`, `.env.*.local`)
+- `*-credentials.json`
+- `users.db*` (例: `data/users.db`, `data/users.db-shm`, `data/users.db-wal`)
+- `service-account*.json`
+- `.claude/oauth-tokens*`
+- `*.pem` / `*.key` / `*.p12`
+- `.cloudflare/credentials` / `.gcloud/credentials`
+
+詳細は `.gitignore` 最終形を Single Source of Truth とする。
+
+### ローテーション
+
+- **R2 token は TTL 90 日** で定期ローテーション。期限切れ前に新 token を
+  発行し、GitHub Secrets / Cloud Run Secret Manager を更新後に旧 token を
+  失効させる (ゼロダウンタイム手順)。
+- **GIS client secret** は Google Cloud Console での発行・失効に従う。
+  漏洩疑い時は即時ローテーション。
+- **GitHub Actions OIDC token** は Actions 実行ごとに自動発行・失効。
+  手動ローテーション対象外。
+- **漏洩時 / 退職時 / 漏洩疑い時** は即時ローテーションし、history に
+  含まれる場合は `git filter-repo` で履歴除去する。
+- ローテーション手順と履歴は `docs/runbooks/secrets-rotation.md` に整備
+  する (Phase A〜C で本格化、A1 時点では雛形)。
+
+### 漏洩検出
+
+- **trufflehog** を A6 で CI 導入し、全 PR 差分をスキャンする。検出時は
+  PR を block + immediate rotate + history rewrite (`git filter-repo`)。
+- pre-commit hook でローカル段階のスキャンも追加検討 (A6 評価対象)。
+
+### Skill 出力の redaction 必須
+
+- `pr-retrospective` / `code-reviewer` / `harness-meta` が CI ログ / MCP
+  結果 / PR diff を learning / レビューコメントに含める場合、Secrets 値を
+  パターンマッチで検出し `[REDACTED-SECRET]` 等のプレースホルダに置換する。
+- `.env.example` には **キー名のみ + placeholder 値** (例:
+  `<GIS_CLIENT_SECRET>`) を記載し、実値は絶対に書かない。
+
+## 根拠
+
+- **場所別分離の必然性**: CI / 本番 runtime / ローカル開発 / Claude Code
+  内部はアクセス経路と権限境界が異なる。単一保管庫に集約すると、最弱の
+  経路 (例: PR fork からの参照) が全 Secrets の脆弱点になる。場所別に
+  分離すれば被害も場所別に限定される。
+- **R2 token TTL 90 日の根拠**: NIST SP 800-63B 等の業界推奨ローテーション
+  間隔と、Cloudflare R2 token の発行・失効コストのバランス。短すぎると
+  運用負荷が肥大化、長すぎると侵害時の被害期間が拡大する。
+- **trufflehog の採用**: OSS で広く採用され、汎用 secret パターン
+  (AWS / Google / GitHub / Slack 等) を網羅。CI 統合が軽量。
+- **Skill 出力 redaction の機械化**: 人間レビューに依存すると Skill の
+  自律性を損なう。Skill 内で redaction を必須化することで人手介入を最小化。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 全 Secrets を GitHub Secrets に集約 | 管理場所が 1 つで運用シンプル | 本番 runtime から GitHub Secrets を直接参照する経路がなく、結局別の場所が必要 | 本番 runtime は Cloud Run Secret Manager 必須、結果として場所別分離 |
+| HashiCorp Vault / Doppler 等の SaaS 集約 | 統一インターフェース、強力な audit log | 個人プロジェクトでは over-engineered、月額コストが顕著 | GitHub Secrets + Cloud Run Secret Manager の組合せで十分 |
+| Firebase の secret 管理を継続利用 | 既存導入済 | Firebase 廃止方針 (ADR-0011) と矛盾 | ADR-0011 で Firebase 完全廃止を決定済み |
+| 長期 token (TTL 無期限) で運用 | ローテーション運用負荷ゼロ | 漏洩時の被害期間が無制限、incident response の難易度が跳ね上がる | TTL 90 日でローテーション、運用負荷を許容 |
+| trufflehog 非導入、人間レビューに依存 | CI 導入コストゼロ | レビュー漏れで credentials がマージされるリスク | CI 検出を必須化、人間レビューはバックアップ |
+
+## 帰結
+
+### Positive
+
+- 保管場所が経路ごとに分離され、単一漏洩の被害範囲が構造的に限定される。
+- R2 token の TTL 90 日ローテーションで、侵害時の被害期間が上限される。
+- trufflehog による全 PR スキャンで credentials の mistaken commit が
+  CI 段階で検出され、history 汚染を未然に防ぐ。
+- Skill 出力の redaction 必須化で、learning / レビューコメントへの
+  Secrets 混入が構造的に塞がれる。
+
+### Negative / トレードオフ
+
+- 保管場所が複数になり、開発者は「どこに置くか」の判断が必要
+  → `.claude/rules/secrets.md` に lookup table を集約し判断を機械化。
+- R2 token のローテーション運用負荷が 90 日ごとに発生
+  → `docs/runbooks/secrets-rotation.md` で手順を定型化、A6 で
+  ローテーション通知の自動化も検討。
+- trufflehog の false positive で PR が block される可能性
+  → allowlist (例: `.env.example` の placeholder) を整備、レビュー対応。
+
+### Neutral / 将来の検討事項
+
+- `docs/runbooks/secrets-rotation.md` の本格化は Phase A〜C で段階対応。
+  A1 時点では雛形のみ。
+- pre-commit hook での trufflehog 実行は A6 で評価。CI 検出が主、ローカル
+  検出は補助。
+- 複数人体制移行時 (ADR-0020 の owner 単一を解除する別 ADR と連動)、
+  Secrets 共有ポリシー (誰が何にアクセスできるか) を別途検討する。
+- HashiCorp Vault 等の集約 SaaS への移行は、運用規模が個人プロジェクトを
+  超えた時点で再評価する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 6. セキュリティ・プライバシー・ライセンスに関する方針 (Secrets 管理が中核)
+- [x] 8. 複数の代替案を比較した結果としての判断 (集約 / SaaS / Firebase / TTL / trufflehog の比較)
+- [x] 9. 元に戻すコストが高い決定 (保管場所構成・ローテーション方式は一度動かすと撤回困難)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 Secrets 取扱と CI / runtime 構成に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR が単なる runbook (`docs/runbooks/secrets-rotation.md` で済む話) や
+      コーディング規約に留まらず、Secrets 管理のアーキテクチャ全体方針であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築)
+- ADR-0001 (ADR 運用基準)
+- ADR-0008 (ユーザーデータ Backend SQLite + Litestream + R2)
+- ADR-0020 (PII 保護、本 ADR と同時防御)
+- ADR-0022 (Cloudflare Pages + R2、R2 token 運用)
+- ADR-0024 (MCP サーバ採用、MCP OAuth token の取扱)
+- `.claude/rules/secrets.md` (Secrets 管理の Single Source of Truth)
+- `.claude/rules/pii.md` / `.claude/rules/db-protection.md` / `.claude/rules/mcp-usage.md`
+- `docs/harness/plan.md` §3.7 / §3.8
+- `docs/runbooks/secrets-rotation.md` (Phase A〜C で本格化)

--- a/docs/adr/ADR-0022-cloudflare-pages-and-r2.md
+++ b/docs/adr/ADR-0022-cloudflare-pages-and-r2.md
@@ -1,0 +1,148 @@
+---
+id: ADR-0022
+title: 静的配信を Cloudflare Pages、バックアップ先を R2 にする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0022: 静的配信を Cloudflare Pages、バックアップ先を R2 にする
+
+> **5 行以内 summary**: ColorMaster の静的配信 (wasmJs バンドル等) は **Cloudflare
+> Pages**、ユーザーデータ永続化 (Litestream バックアップ先) は **Cloudflare R2** を
+> 採用する。Backend (Cloud Run / ADR-0009) と組み合わせたハイブリッド構成で、
+> Pages の無制限 bandwidth + R2 の zero egress により、個人プロジェクト規模の
+> 完全無料運用と本番運用レベルの耐久性を両立する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は Backend を Cloud Run (ADR-0009) にホストする方針だが、以下の役割は
+Backend ではなく専用サービスに分離する必要がある:
+
+- **静的配信**: wasmJs バンドル / 画像 / フォント等のフロントエンドアセットを CDN
+  経由で世界中に配信したい。Cloud Run で配信すると vCPU-sec を消費して無料枠を
+  圧迫する。
+- **ユーザーデータ永続化**: Cloud Run はステートレスで filesystem が ephemeral の
+  ため、`users.db` の永続化には外部ストレージが必要。Litestream で WAL を S3 互換
+  ストレージへストリーミングレプリケートする戦略 (ADR-0008) を採るが、egress 課金が
+  発生するストレージはバックアップ運用に向かない。
+
+加えて Firebase は完全廃止方針 (ADR-0011) のため Firebase Hosting / Cloud Storage
+は選択肢から外れる。Web 配信は wasmJs ターゲット完成後に再開する (ADR-0012) ため、
+新しい配信先を本 ADR で確定する必要がある。
+
+## 決定
+
+ColorMaster の **静的配信を Cloudflare Pages**、**Litestream バックアップ先を
+Cloudflare R2** に統一する。Backend (Cloud Run / ADR-0009) と組み合わせた
+ハイブリッドホスティングを構成する。
+
+- **Cloudflare Pages**: wasmJs バンドル + 静的アセットの配信。Git 連携で自動デプロイ。
+- **Cloudflare R2**: `users.db` の WAL を Litestream v0.5.0 で連続レプリケート。
+  Backend 起動時に R2 から restore して局所ディスクの `users.db` を復元する。
+- R2 アクセストークンは TTL 90 日でローテーション (ADR-0021)。
+- バケットは private、Backend Service Account の credential のみアクセス可能。
+
+## 根拠
+
+- **Cloudflare Pages の無制限 bandwidth**: 静的配信の egress を月次上限なしで処理
+  できる唯一の主要 CDN。300+ edge locations による低レイテンシ配信。
+- **Git 連携の自動デプロイ**: PR ごとに preview deployment、main マージで本番
+  デプロイが自動化されており、CI スクリプトが最小で済む。
+- **R2 の zero egress**: S3 互換でありながら egress 課金が発生しないため、Cloud Run
+  起動時の restore (R2 → Backend) や Litestream の reverse-sync コストがゼロ。
+- **Litestream v0.5.0 との親和性**: endpoint URL を指定するだけで R2 を自動検出し、
+  追加設定をほぼ要しない。コミュニティの本番運用事例も多く、SQLite + Litestream +
+  R2 の組合せは確立済みパターン。
+- **ハイブリッド構成の合理性**: Backend は GCP (JVM 成熟)、配信 / ストレージは
+  Cloudflare (unlimited bandwidth + zero egress) と役割分担することで、両者の弱点を
+  相互補完しつつ完全無料運用が実現する。
+
+### 比較した代替案
+
+#### 静的配信先
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| **Cloudflare Pages (採用)** | 無制限 bandwidth、300+ edge、Git 連携、無料運用 | Cloudflare アカウントが必要 | 全項目で優位、本 ADR で採用 |
+| Firebase Hosting | Google エコシステム統一、設定容易 | **10GB / 月 bandwidth 上限**、Firebase 全廃方針 (ADR-0011) に整合しない | Firebase 廃止と bandwidth 上限のため、不採用 |
+| Vercel | DX 良好、preview deployment 自動化 | **Hobby plan は商用利用不可**、Pro plan は月額固定費 | ライセンス制約と固定費、不採用 |
+| Netlify | Build pipeline 機能が充実 | bandwidth は 100GB / 月で上限あり、Cloudflare Pages の unlimited に劣後 | bandwidth で Cloudflare Pages に劣る、不採用 |
+| AWS S3 + CloudFront | エンタープライズ実績豊富 | **egress 課金あり**、CloudFront 設定が複雑、IaC 前提 | 無料運用に整合せず設定コスト過大、不採用 |
+
+#### Litestream バックアップ先
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| **Cloudflare R2 (採用)** | S3 互換 + **zero egress**、Litestream v0.5.0 自動検出、本番運用実例多数 | Cloudflare アカウントが必要 | 全項目で優位、本 ADR で採用 |
+| AWS S3 | Litestream 公式リファレンス、長期耐久性 | **egress 課金あり**、restore のたびに従量課金が発生 | egress コストが Cloud Run 起動時に効いてくる、R2 に劣後で不採用 |
+| Google Cloud Storage | GCP 統一でアクセス制御が容易 | egress 課金あり、Litestream の S3 互換層を経由する必要 | egress 課金と互換層の二重コスト、不採用 |
+| Backblaze B2 | egress が一定量無料、S3 互換 | エコシステムが Cloudflare ほど成熟していない | R2 の方が無料枠と統合性で優位、不採用 |
+
+## 帰結 (Consequences)
+
+### Positive
+
+- 静的配信の bandwidth が事実上無制限となり、トラフィック増でも無料運用を維持できる。
+- R2 の zero egress により、Backend cold start 時の restore コストがゼロ。
+- Cloud Run (ADR-0009) と組み合わせて完全無料のハイブリッドホスティングが成立する。
+- Cloudflare Pages の Git 連携で wasmJs ビルドの本番デプロイが自動化される。
+- Firebase 完全廃止 (ADR-0011) と整合し、Firebase 依存をプラットフォーム層から
+  根絶できる。
+
+### Negative / トレードオフ
+
+- ホスティング先が GCP / Cloudflare の 2 ベンダーに分散する → 監視・運用手順が
+  2 系統になるが、役割が明確に分離されているため認知負荷は限定的。
+- Cloudflare 障害時には静的配信とバックアップが同時に影響を受ける → Backend
+  自体は Cloud Run で稼働継続、`users.db` は局所ディスクで読み書き継続できるため
+  即時影響は限定的。
+- R2 access token の管理が必要 → ADR-0021 の TTL 90 日ローテーションで運用化する。
+
+### Neutral / 将来の検討事項
+
+- Cloudflare Pages の Build minutes 制限に到達した場合は GitHub Actions で
+  事前ビルド → アーティファクトを Pages にアップロードする方式へ切替を検討する。
+- R2 の地域配置 (現状 auto) は、Cloud Run リージョン (`asia-northeast1`) との
+  レイテンシ実測値に応じて固定リージョンに切替する余地がある。
+- Litestream v0.5.x 以降のメジャーバージョンアップ時は restore 互換性を確認する。
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 3. 外部サービスの採用または変更 (静的配信 + バックアップ先の選定)
+- [x] 4. データ永続化 / 同期戦略 / バックアップ方式 (Litestream + R2 によるレプリケート)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Firebase Hosting / Vercel / Netlify / S3+CloudFront / S3 / GCS / B2 と比較)
+- [x] 9. 元に戻すコストが高い決定 (Pages / R2 を稼働させると移行コストが大きい)
+- [x] 10. 長期的な制約 (今後 1 年以上、配信・バックアップ運用に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+`.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+本 ADR がコーディング規約 / Plan で済む話 / runbook で済む話 ではなく、配信・
+バックアップという外部サービスの中核採用判断であることを確認した。R2 token の
+具体的なローテーション手順は runbook、Pages の preview deployment 設定変更は Plan
+で扱う。
+
+- [x] 確認済み
+
+## 関連
+
+- 関連 ADR: ADR-0006 (wasmJs i18n と Web ターゲット復帰)、ADR-0008 (Litestream + R2 で `users.db` レプリケート)、ADR-0009 (Cloud Run と組合せたハイブリッド)、ADR-0011 (Firebase 完全廃止)、ADR-0012 (Web 配信再開先)、ADR-0021 (R2 token TTL 90 日ローテーション)
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- `.claude/rules/cloudflare-pages.md`
+- `.claude/rules/r2-litestream.md`
+- `.claude/rules/secrets.md`
+- `docs/harness/plan.md` §3.4 (ホスティング採用根拠)、§3.2 (Litestream + R2 設計)

--- a/docs/adr/ADR-0023-ui-freeze-three-pillars.md
+++ b/docs/adr/ADR-0023-ui-freeze-three-pillars.md
@@ -1,0 +1,223 @@
+---
+id: ADR-0023
+title: UI/UX をリファクタ前に DESIGN.md と UI Inventory と Roborazzi baseline で凍結する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0023: UI/UX をリファクタ前に DESIGN.md と UI Inventory と Roborazzi baseline で凍結する
+
+> **5 行以内 summary**: Phase C の大規模リファクタ (Decompose 撤去 / CMP Navigation 3 /
+> Firebase 廃止 / wasmJs 化) が UI に与える影響を構造的にブロックするため、リファクタ前に
+> 既存 UI/UX を機械検証可能な形で凍結する。三本柱は `DESIGN.md` (repo root の 3 階層
+> design tokens) + UI Inventory (`docs/design/inventory/`) + Roborazzi baseline (mobile/desktop
+> x Light/Dark の 4 パターン)。code-reviewer は 8 aspect に拡張し、本格化は A10 で実施する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は Phase C で 4 つの大規模リファクタを並行実施する予定である:
+
+- Decompose を撤去し Compose Multiplatform Navigation 3 に統一 (ADR-0002 / ADR-0005)
+- Firebase を完全廃止して GIS に統一 (ADR-0011)
+- wasmJs ターゲット化と Cloudflare Pages 配信 (ADR-0022)
+- 共通 ViewModel 層への再編 (ADR-0002)
+
+これら 4 つのリファクタはいずれも振る舞い (UI / API レスポンス / 状態遷移) を変えないことが
+原則であるが、現状の ColorMaster には以下の構造的問題があり、Behavior Preservation を機械的に
+保証できない:
+
+- 色 / タイポ / スペーシング / radii が実コード内に hex / sp / dp としてハードコードされ、
+  Single Source of Truth が存在しない
+- 画面・コンポーネント・状態・フローの網羅的記録が無く、リファクタ前後の比較対象を人間の
+  記憶に依存している
+- visual regression test (screenshot test) が未導入で、リファクタによる微細な UI 退行を
+  検出する機械的手段が無い
+- code-reviewer の 6 aspect には UI に関わる評価軸が含まれない
+
+Phase C のリファクタを着手する前に、UI/UX 現状を構造化データ (design tokens) + 構造化文書
+(UI Inventory) + 構造化バイナリ (screenshot baseline) の三層で凍結し、リファクタ後に diff 0
+であることを `code-reviewer` のサブエージェントで自動判定できるようにする必要がある。
+
+## 決定
+
+リファクタ着手前の Phase A 末尾 (A10) で、以下の三本柱と code-reviewer 拡張、`ui-snapshot`
+Skill 新設を実施する。
+
+### 三本柱
+
+#### 1. `DESIGN.md` (リポジトリ root)
+
+Google Stitch / Anthropic が AI 駆動 UI 開発の de facto standard としてプッシュしている
+Markdown ベースの design tokens 仕様書を、ColorMaster でも採用する。
+
+- 上部: machine-readable な design tokens を Primitive / Semantic / Component の 3 階層で記述
+- 下部: human-readable な rationale (なぜその値か、どう適用するか、アクセシビリティ基準)
+- Markdown は LLM が最も読みやすい形式で、AI コーディングツールが自動参照する
+- Konsist で「DESIGN.md に存在しない hex code がコードに混入していない」を機械検証 (A6 で導入)
+
+#### 2. UI Inventory (`docs/design/inventory/`)
+
+Marcin Treder の "Interface Inventory" 手法に準拠し、全画面・全コンポーネント・全状態・
+全フローを網羅キャプチャする。
+
+- `screens/` / `components/` / `states/` / `flows/` の 4 軸でディレクトリを分割
+- 各 Markdown は frontmatter で関連 SPEC-ID / 実装パス / related screenshots / related design
+  tokens を記録
+- 5 行 summary + 構成要素 + 状態遷移 + データソース + アクセシビリティ + 参考 screenshot +
+  Open Questions の固定構造
+
+#### 3. Visual Regression Baseline (Roborazzi)
+
+採用ツールは Roborazzi。Compose Multiplatform 対応で、現時点で唯一 Compose Desktop に
+対応している screenshot test ライブラリである。
+
+- 主実行ランタイム: JVM (Compose Desktop)、補助: Android (Robolectric)
+- 対象: commonMain の Composable (全 target 共通)
+- 対象外: wasmJsMain / iosMain / androidMain の actual 実装 (Konsist + 単体テストで担保)
+- 解像度マトリックス必須: モバイル (412 x 915 dp、Pixel 7 portrait 相当) と PC 16:9
+  (1920 x 1080 dp、デスクトップブラウザ標準) の 2 種
+- テーママトリックス必須: Light / Dark の 2 種
+- 1 Composable あたり 4 パターン (mobile-light / mobile-dark / desktop-light / desktop-dark)
+  が baseline として `docs/design/inventory/screenshots/` に格納される
+
+### Roborazzi の wasmJs 未対応への対処
+
+2026/5 時点で Roborazzi は wasmJs を未サポート (JVM 実装から Multiplatform 実装への移行中)。
+本 ADR では以下の方針で対応する:
+
+- commonMain の Composable は Compose Desktop (JVM) で screenshot 化可能。Compose は全 target
+  で Skia ベースの同一レンダリングエンジンを用いるため、wasmJs 用に書いた commonMain コードも
+  そのまま検証できる
+- wasmJs ターゲット固有の actual 実装 (GIS 認証フロー等) は薄い層に閉じ込め、screenshot test
+  の対象外として Konsist + 単体テストで担保する
+- 将来 Roborazzi が wasmJs に公式対応したら本 ADR を改訂し、wasmJs ランタイムでの実機
+  screenshot 化に切替を検討する
+
+### code-reviewer aspect の拡張 (6 → 8)
+
+既存 6 aspect (spec-conformance / test-quality / architecture / security / performance /
+code-quality) に以下 2 aspect を追加する:
+
+- **visual-regression**: Roborazzi の diff が 0 ピクセル (または許容しきい値内) であること。
+  baseline 更新を伴う PR は意図的な UI 変更であることを PR description で明示し、human approve
+  を必須化
+- **design-tokens**: コード中の hex / sp / dp / radius がハードコードされておらず DESIGN.md の
+  token を参照していること。新規 token 追加時は DESIGN.md と Rationale を同時更新
+
+### 新規 Skill `ui-snapshot`
+
+A10 EPIC 内の Plan、または Phase C 各リファクタ後の visual regression 検証から起動する Skill。
+責務は以下:
+
+1. Konsist で全 Composable をスキャンし、`@Preview` 不在を検出
+2. Preview 追加 Plan を起票
+3. Roborazzi の `recordRoborazziDebug` 相当タスクを実行して screenshot baseline 生成
+4. DESIGN.md と UI Inventory のドラフト生成
+5. hex / sp / dp ハードコードを検出して tokens 化提案
+
+code-reviewer の visual-regression / design-tokens aspect と双方向参照する。
+
+## 根拠
+
+- **三層凍結による Behavior Preservation 構造化**: design tokens (構造化データ) + UI Inventory
+  (構造化文書) + screenshot baseline (構造化バイナリ) を組み合わせることで、リファクタ前後の
+  UI 同一性を 3 つの独立した検証軸から保証できる。単一軸では false-negative が残るが、
+  三層で冗長化することで実用的な信頼度が得られる
+- **Roborazzi 採用の必然性**: Compose Multiplatform プロジェクトで Compose Desktop に対応する
+  screenshot test ライブラリは現時点で Roborazzi のみ。Paparazzi / Shot はいずれも Android
+  専用で、本プロジェクトの主ターゲット (wasmJs / Desktop / Android) を網羅できない
+- **DESIGN.md を root に置く理由**: Google Stitch / Anthropic が AI 駆動 UI 開発の標準として
+  プッシュしており、AI Coding Agent が最初に参照する位置として最も発見性が高い。ADR-0027 の
+  docs 構造規約とも整合する
+- **解像度マトリックスを 2 種に絞る理由**: モバイル portrait + デスクトップ 16:9 で本プロジェクトの
+  実利用シナリオ (PWA + デスクトップブラウザ) をカバーできる。タブレットや ultrawide は
+  Phase C 完了後の拡張余地として保留
+- **A10 で本格化する理由**: Phase C のリファクタは A10 完了が前提条件 (R-22)。A10 までに
+  凍結を完了させ、Phase C 全 PR で visual-regression aspect を強制適用する
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| Paparazzi | Android 環境で安定 | Compose Multiplatform 非対応 (Android のみ) | wasmJs / Desktop を網羅できないため不採用 |
+| Shot | Android で実績 | Android のみ | 同上 |
+| 手動スクリーンショット管理 (`docs/design/screenshots/`) | 導入コスト最小 | スケールしない、リファクタ前後の自動 diff 不可、human レビュー依存 | リファクタ規模に対して人間負荷が爆発するため不採用 |
+| Visual regression を導入しない (DESIGN.md + Inventory のみ) | 学習コスト最小 | UI 退行を機械検出不能、リファクタ後の Behavior Preservation を主観判定に依存 | Phase C 4 リファクタの並行進行で Behavior Preservation が破綻するため不採用 |
+| DESIGN.md を `docs/design/` 配下に置く | docs 配下に統一できる | repo root の発見性 (AI / 人間) が落ちる、Google Stitch 標準から外れる | AI コーディングツールの参照頻度を最大化するため root を採用 |
+
+## 帰結
+
+### Positive
+
+- リファクタ前後の UI 同一性が 3 つの独立した軸 (tokens / Inventory / screenshot) で機械検証可能
+- code-reviewer の 8 aspect 化により、UI に関わる退行を Generator/Evaluator 二段構成
+  (ADR-0019) で自動ブロックできる
+- DESIGN.md が root にあることで AI Coding Agent / 人間の双方が最初に発見でき、新規参加者の
+  オンボーディングが平易化する
+- Phase C の 4 リファクタを並行進行しても、各 PR が visual-regression aspect で個別に
+  Behavior Preservation を保証されるため、結合時の UI 衝突リスクが極小化される
+
+### Negative / トレードオフ
+
+- screenshot baseline ファイル (PNG) が `docs/design/inventory/screenshots/` に大量 commit
+  されるため、リポジトリサイズが増加する。Git LFS は未採用 (`docs/harness/plan.md` で別途
+  判断、当面は通常 commit)
+- Roborazzi 実行が CI 時間を延長する (commonMain Composable 数 x 4 パターン)。`./gradlew check`
+  に追加されるため、CI ランタイムは段階的に最適化する (並列化 / 差分実行)
+- 4 リファクタが UI に意図的変更を含む場合、baseline 更新コミットを別 PR で切り出す運用負荷が
+  発生する。`.claude/rules/ui-snapshot.md` で運用フローを明文化して機械化する
+- DESIGN.md 初版生成 (`ui-snapshot` Skill が A10 で自動生成) 後、human approve なしの編集を
+  禁止するため、ブランドカラーの追加・修正にレビュー往復が必要になる
+
+### Neutral / 将来の検討事項
+
+- Roborazzi が wasmJs を公式サポートしたら本 ADR を改訂し、wasmJs ランタイムでの実機
+  screenshot 化に切替を検討する
+- タブレット / ultrawide 解像度の追加は Phase C 完了後の拡張案件として保留
+- `changeThreshold` の許容しきい値 (誤検出抑制) は A10 の `ui-snapshot` Skill 実装時に
+  Roborazzi デフォルトを基準に決定し、運用で調整する
+- Component 階層の design tokens 命名規則 (アイドル別ブランドカラーの粒度) は A10 で初版を
+  起こした後、Phase C の各リファクタ PR で実利用パターンを反映して洗練する
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 5. テスト戦略・品質指標の中核方針 (visual regression test の導入、code-reviewer 8 aspect 化)
+- [x] 7. ハーネス本体の中核設計 (`ui-snapshot` Skill 新設、code-reviewer aspect 拡張)
+- [x] 8. 複数の代替案を比較した結果としての判断 (Roborazzi / Paparazzi / Shot / 手動 / 不採用の比較)
+- [x] 10. 長期的な制約 (今後 1 年以上、Phase C 全リファクタおよび Phase C 以降の UI 開発に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」「ADR にすべきでない例」リストと照合し、
+      本 ADR が単なる Roborazzi 設定 (Plan で済む話) や DESIGN.md 表記規約
+      (`.claude/rules/design-tokens.md` で済む話) に留まらず、Behavior Preservation を
+      担保するハーネス構造そのものに影響する決定であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001 (本 ADR の起票 PR)
+- 関連 Epic: EPIC-000 (ハーネス基盤構築)
+- ADR-0001 (ADR 運用基準)
+- ADR-0002 (Compose Multiplatform + Navigation 3、リファクタ対象の前提)
+- ADR-0006 (i18n compose resources、UI Inventory との連携)
+- ADR-0019 (code-reviewer aspect 拡張、本 ADR で 6 → 8 に拡張)
+- ADR-0027 (docs 構造 + 日本語化方針、DESIGN.md の位置付けと `docs/design/inventory/` の構造)
+- `.claude/rules/design-tokens.md` (DESIGN.md の 3 階層構造、ハードコード禁止)
+- `.claude/rules/ui-snapshot.md` (Roborazzi baseline 維持規約、4 パターンマトリックス)
+- `.claude/rules/ui-inventory.md` (`docs/design/inventory/` の構造と更新規約)
+- `.claude/rules/behavior-preservation.md` (リファクタ時の振る舞い維持原則)
+- `.claude/rules/code-reviewer-aspects.md` (8 aspect の binary eval checklist)
+- `docs/harness/plan.md` §3.9 / §6.2 A10

--- a/docs/adr/ADR-0024-mcp-server-adoption.md
+++ b/docs/adr/ADR-0024-mcp-server-adoption.md
@@ -1,0 +1,165 @@
+---
+id: ADR-0024
+title: MCP サーバは JetBrains と Context7 と Cloudflare の 3 つを採用する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0024: MCP サーバは JetBrains と Context7 と Cloudflare の 3 つを採用する
+
+> **5 行以内 summary**: MCP サーバは **JetBrains MCP / Context7 MCP / Cloudflare MCP**
+> の 3 つを採用し、GitHub MCP / Sourcegraph MCP / Serena MCP は採用見送り
+> (代替手段が優位)。GitHub 操作は `gh` CLI、IDE 操作は JetBrains MCP、ライブラリ docs は
+> Context7 MCP、Cloudflare 操作は `wrangler` CLI 優先で複雑な API のみ Cloudflare MCP、
+> という使い分けに統一する。旧 `@jetbrains/mcp-proxy` npm パッケージは deprecated のため
+> 使用しない。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+MCP (Model Context Protocol) は 2025 年以降エコシステムが拡大し、Anthropic 公式 /
+JetBrains / Cloudflare / Sourcegraph / Serena など多数のサーバが利用可能になった。
+ColorMaster のハーネスは `implementation-workflow` / `code-reviewer` /
+`dependency-upgrade` / `harness-evolution` 等から各種 MCP を呼ぶ必要があり、採用範囲を
+絞らないとセットアップコスト / 認証情報管理 / 機能重複が膨らむ。
+
+検討対象:
+
+- **JetBrains MCP**: IntelliJ IDEA / Android Studio 2025.2+ にバンドル済、`JetBrains/
+  mcp-server-plugin` (Marketplace 26071)。rename / inspection / IDE index 検索 /
+  build / file analysis / refactoring。旧 `@jetbrains/mcp-proxy` npm パッケージは
+  deprecated
+- **Context7 MCP**: バージョン固有のライブラリ docs (Kotlin / Compose MP / Ktor /
+  SQLDelight / Roborazzi) を LLM に注入、ハルシネーション抑止
+- **Cloudflare MCP**: R2 / Pages / Workers / DNS / Secrets 管理
+- **GitHub MCP**: PR / Issue / Actions 操作。ただし `gh` CLI が training data 内蔵で
+  あり、実証ベンチマークで MCP は CLI より 10〜32 倍トークン消費
+- **Sourcegraph MCP**: コード横断検索。JetBrains MCP の IDE indexing と機能重複
+- **Serena MCP**: コードベース理解。Kotlin が "Indirect Support" にとどまり、JetBrains
+  backend は有料、30 分セットアップ + 初回インデックス overhead
+
+## 決定
+
+採用 MCP は以下の **3 つに限定** する:
+
+- **JetBrains MCP** (IDE 操作)
+- **Context7 MCP** (ライブラリ docs 注入)
+- **Cloudflare MCP** (R2 / Pages / Workers / DNS / Secrets)
+
+採用見送り:
+
+- **GitHub MCP** → `gh` CLI で代替 (token 効率 10〜32 倍優位、training data 内蔵)
+- **Sourcegraph MCP** → JetBrains MCP の IDE indexing で代替 (機能重複)
+- **Serena MCP** → JetBrains + Context7 で代替 (Kotlin Indirect Support / 有料 /
+  セットアップ重)
+
+使い分けルール:
+
+- **GitHub 操作は原則 `gh` CLI**: PR list / view / diff / search / create / merge /
+  comment / Actions logs / Issue 起票はすべて `gh`
+- **IDE 操作は JetBrains MCP**: rename / inspection / file analysis / index 経由 regex
+  search / build / run config 実行。手動 `git grep` の代わりに JetBrains MCP の検索を
+  優先 (IDE index が高速・正確)
+- **ライブラリ API 確認は Context7 MCP**: コード生成前に必ず Context7 を経由
+  (training data の古い情報や hallucination を回避)
+- **Cloudflare 操作**: `wrangler` CLI で済む場合 (`wrangler deploy` 等) は CLI 優先、
+  複雑な API 操作 (R2 token ローテーション、bucket policy 更新) のみ Cloudflare MCP
+- **MCP OAuth token はリポジトリ commit 禁止** (`.gitignore` で `.claude/oauth-tokens*`
+  除外、ADR-0021)
+
+旧 `@jetbrains/mcp-proxy` npm パッケージは deprecated のため使用しない。詳細セットアップ
+は `docs/runbooks/mcp-setup.md`、運用規約は `.claude/rules/mcp-usage.md` を参照。
+
+将来検討候補: Figma MCP (デザイン連携) / Code Pathfinder (静的解析) / Serena MCP
+(IDE 非起動環境で必要時) / Sentry MCP (本番運用後)。
+
+## 根拠
+
+- **`gh` CLI の token 効率優位**: 実証ベンチマークで GitHub MCP は CLI より 10〜32 倍
+  トークン消費。training data に gh 構文が大量に含まれており、Claude にとって
+  CLI の方が hallucination リスクも低い
+- **JetBrains MCP のバンドル性**: 2025.2+ で公式バンドル、セットアップ不要。IDE index
+  経由検索は ripgrep / git grep より高速かつシンボル aware
+- **Context7 の必須性**: Kotlin / Compose MP / Ktor 等のバージョン違いによる API drift
+  はハルシネーションの主要原因。Context7 で版固有 docs を注入することで構造的に抑止
+- **Cloudflare MCP の限定採用**: 単純デプロイは `wrangler` CLI で十分、MCP は複雑 API
+  だけに限定して認証情報露出経路を最小化
+- **Sourcegraph / Serena 不採用**: 機能重複 / Kotlin サポート不十分 / 有料 (Serena
+  backend) / セットアップ重 (Serena 30 分) のいずれかに該当
+- **`@jetbrains/mcp-proxy` 不使用**: deprecated の npm パッケージはセキュリティパッチ
+  対象外、IDE バンドル版に統一
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| GitHub MCP 採用 | MCP 経由で型付きレスポンス | `gh` CLI より 10〜32 倍 token 消費、機能重複 | 不採用、`gh` CLI で代替 |
+| Sourcegraph MCP 採用 | コード横断検索強力 | JetBrains IDE indexing と機能重複 | 不採用、JetBrains MCP で代替 |
+| Serena MCP 採用 | LSP ベースでコードベース理解強い | Kotlin Indirect Support / backend 有料 / セットアップ 30 分 | 不採用、IDE 起動環境では JetBrains + Context7 で十分 |
+| MCP 不採用 (全て CLI / ローカル script) | 認証情報露出ゼロ | IDE index / 版固有 docs を活かせない、hallucination 増 | 部分採用で 3 MCP 限定とトレードオフ |
+| 全部入り採用 | 全機能アクセス可 | 認証管理コスト爆発、機能重複 | 3 MCP に絞り込み |
+
+## 帰結
+
+### Positive
+
+- MCP 採用範囲が 3 つに固定され、認証情報管理 / セットアップ / 機能重複コストが最小化
+- `gh` CLI への寄せが整理され、GitHub 操作の training data 活用度が最大化
+- Context7 経由のライブラリ docs 注入で、版違いによるハルシネーションを構造的に抑止
+  (`dependency-upgrade` Skill 等で必須)
+
+### Negative / トレードオフ
+
+- **IDE 非起動環境で JetBrains MCP が使えない**: CI / 別マシン / バックグラウンドサーバ
+  上では fallback (`gh` CLI / `git grep`) に切り替える必要 (R-27)。長期化する場合は
+  Serena MCP 採用を別 Plan で再評価
+- **Context7 MCP の取得結果は外部依存**: AI が取得した内容を Konsist / detekt / 型
+  チェッカーで二重検証する (R-28)
+- **Cloudflare MCP の認証スコープ**: 対象 zone / bucket のみ allow する設計が必要
+  (`.claude/rules/secrets.md` / ADR-0021)
+
+### Neutral / 将来の検討事項
+
+- Figma MCP は DESIGN.md / UI Inventory との連携余地あり、A10 完了後に再評価
+- Sentry MCP は本番運用後に再評価 (Cloud Run + Litestream 稼働後)
+- `harness-evolution` の月次手動実行で `anthropics/skills` / MCP spec 更新を確認し、
+  新規 MCP 採用余地を `docs/harness/evolution-proposals/` に出力 (ADR-0026)
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 2. 主要なライブラリ / フレームワークの採用または撤去 (MCP サーバの採用 / 不採用)
+- [x] 3. 外部サービスの採用または変更 (Context7 / Cloudflare MCP の外部依存)
+- [x] 7. ハーネス本体の中核設計 (Skill が MCP を呼ぶ前提)
+- [x] 8. 複数の代替案を比較した結果としての判断
+- [x] 10. 長期的な制約 (今後 1 年以上、全 Skill の MCP 呼び出しに影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」(「MCP サーバは JetBrains + Context7 +
+      Cloudflare の 3 つ」) と一致。Plan / runbook / コーディング規約で済む話ではない
+      ことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0017 (ローカル Claude Code ポーリング、`gh` CLI 主軸)
+- ADR-0018 (`implementation-workflow` Phase 3 で JetBrains MCP / Context7 MCP を利用)
+- ADR-0019 (`code-reviewer` architecture aspect が JetBrains MCP IDE indexing を活用)
+- ADR-0021 (Secrets / MCP OAuth token 管理)
+- ADR-0025 (Skill 作成、`example-skills:skill-creator` 経由)
+- `.claude/rules/mcp-usage.md` (MCP 使い分けの Single Source of Truth)
+- `docs/runbooks/mcp-setup.md` (3 接続方式 / OAuth フロー / port 競合)
+- `docs/harness/plan.md` §5.6 / R-25 / R-27 / R-28

--- a/docs/adr/ADR-0025-skill-creator-via-example-skills.md
+++ b/docs/adr/ADR-0025-skill-creator-via-example-skills.md
@@ -1,0 +1,154 @@
+---
+id: ADR-0025
+title: Skill 作成は example-skills:skill-creator 経由とする
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0025: Skill 作成は example-skills:skill-creator 経由とする
+
+> **5 行以内 summary**: 新規 Skill 作成・既存 Skill 改修は **Claude Code ユーザースコープ
+> の `example-skills:skill-creator`** を呼び出して行う。本リポジトリには
+> `skill-creator` を mirror しない。SKILL.md は Anthropic "Complete Guide to Building
+> Skills for Claude" + AgentSkills 2026 spec + 100-point rubric 準拠とし、必須項目
+> (description = trigger / Gotchas / 関連 / status) と禁止表現 (MUST / ALWAYS / NEVER
+> の多用) を規約化する。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster のハーネスは複数の Skill (`feature-request` / `implementation-workflow` /
+`code-reviewer` / `harness-meta` / `harness-evolution` 等) を継続的に追加・改修する
+前提で設計されている。Skill ファイル (SKILL.md) のフォーマット drift が起きると、
+Skill 起動時の trigger 解釈が不安定になり、ハーネス全体の再現性が崩れる。
+
+Anthropic は 2025 末に "Complete Guide to Building Skills for Claude" を公開し、
+AgentSkills 2026 spec として SKILL.md の構造 / description (= trigger) / Gotchas 必須 /
+100-point rubric 評価を整備した。`example-skills:skill-creator` (Claude Code ユーザー
+スコープ) はこれらに準拠した scaffolding を提供している。
+
+選択肢:
+
+1. 本リポジトリに `skill-creator` を mirror して使う
+2. ユーザースコープの `example-skills:skill-creator` を呼び出して使う
+3. 手書きで SKILL.md を作成し、フォーマットは規約 (`.claude/rules/skill-authoring.md`)
+   のみで担保
+
+## 決定
+
+新規 Skill 作成・既存 Skill 改修は **`example-skills:skill-creator` 経由** とする。
+具体的には:
+
+- **本リポジトリに `skill-creator` を mirror しない**: ユーザースコープにインストール
+  済のものを利用する
+- **SKILL.md フォーマット必須項目**:
+  - frontmatter: `name` / `description` (= trigger を含む 1-3 文、200 文字以内推奨) /
+    `status` (skeleton | active | archived) / `phase` / `related_plan` /
+    `related_rules`
+  - 本文: `## 役割` / `## 入力` / `## 出力` / `## Gotchas` / `## 関連` の 5 セクションを
+    必ず含める
+- **description の書き方**: 「~を作成する」「~を生成する」より、「~の指示を受けたとき」
+  「~を必要とする状況で」のように **起動契機を明示** する
+- **禁止表現**: `MUST` / `ALWAYS` / `NEVER` の多用は避ける (Claude の挙動を硬直化させる)。
+  代わりに「~するべき」「~を推奨」「~してはいけない (理由付き)」で記述
+- **公式アップデートに追従**: `anthropics/skills` の更新を `harness-evolution` Skill
+  の手動実行時に確認 (月次推奨、ADR-0026)
+- **既存 Skill 改修も `skill-creator` 経由**を推奨 (直接編集禁止ではないが、フォーマット
+  drift を防ぐため)
+- **本リポジトリ `.claude/skills/skill-creator/` は配置しない** (ユーザースコープと
+  二重化させない)
+
+フォーマット構造を例示するために短い fenced block を SKILL.md / frontmatter フィールド
+規約箇所で許容する (本 ADR 本文では §4.6 のコード断片禁止対象外):
+
+```yaml
+name: <skill-name>
+description: <trigger を含む 1-3 文>
+status: skeleton | active | archived
+```
+
+## 根拠
+
+- **Anthropic 公式 scaffolding の活用**: `example-skills:skill-creator` は Complete
+  Guide + AgentSkills 2026 spec + 100-point rubric に準拠した SKILL.md を生成する。
+  公式準拠を機械的に担保できる
+- **mirror しない理由**: Claude Code ユーザースコープに既にインストール済のため、
+  リポジトリ内に mirror すると公式更新との同期コストが発生し drift する
+- **description = trigger の明示**: Skill 起動条件は description で判定される。
+  「いつ呼ばれるか」を明示することで誤起動 / 起動漏れを防ぐ
+- **禁止表現**: `MUST` / `ALWAYS` / `NEVER` の多用は LLM の挙動を硬直化させ、例外
+  ケースで適切に判断できなくなる。理由付き表現で柔軟性を確保
+- **公式アップデート追従**: `anthropics/skills` は継続更新されるため、`harness-evolution`
+  の月次手動実行で確認するルーチンを組み込む (R-30)
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 本リポジトリに `skill-creator` を mirror | バージョン固定可、オフライン動作 | 公式更新との drift、二重管理コスト | 不採用、ユーザースコープに統一 |
+| 手書き SKILL.md + 規約のみ | scaffolding コスト不要 | フォーマット drift が起きやすい、rubric 適合確認が手動 | 不採用、scaffolding 経由で構造担保 |
+| GitHub Copilot Workspace / 他社製 scaffolder | エコシステム広い | Anthropic Complete Guide / AgentSkills 2026 spec への準拠が保証されない | 不採用、Anthropic 公式に統一 |
+| `MUST` / `ALWAYS` / `NEVER` を許容 | 強制力が明確 | LLM 挙動硬直、例外対応不能 | 理由付き表現を採用 |
+
+## 帰結
+
+### Positive
+
+- SKILL.md フォーマットが Anthropic 公式準拠で統一され、Skill 起動の再現性が向上
+- 公式アップデート (AgentSkills spec の改訂) への追従パスが `harness-evolution` 経由で
+  明確化
+- `MUST` / `ALWAYS` / `NEVER` を避けることで、Skill 内記述が柔軟性を保つ
+
+### Negative / トレードオフ
+
+- **オフライン環境で `skill-creator` を呼べない**: ユーザースコープ未インストール時は
+  Skill 作成不能 → 開発前提として「Claude Code 利用環境では `example-skills:skill-creator`
+  がインストール済」を `docs/runbooks/local-development.md` (Phase A〜C で本格化) に
+  明記
+- **手書き SKILL.md の比較対象がないと品質判定が難しい**: 100-point rubric を
+  `.claude/rules/skill-authoring.md` に明示し、`harness-evolution` が evolution-proposals
+  で SKILL.md の品質チェックを補う
+
+### Neutral / 将来の検討事項
+
+- AgentSkills 2026 spec が大きく改訂された場合、本 ADR を superseded にして新 ADR で
+  対応 (ADR-0001 のステータス遷移ルールに従う)
+- 既存 Skill (`harness-bootstrap` 等) を `skill-creator` 経由でリファクタするのは
+  `harness-meta` の learning 集計次第 (任意)
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 7. ハーネス本体の中核設計 (Skill 作成プロセスの統一)
+- [x] 8. 複数の代替案を比較した結果としての判断 (mirror / 手書き / scaffolder の比較)
+- [x] 9. 元に戻すコストが高い決定 (全 Skill のフォーマットに影響)
+- [x] 10. 長期的な制約 (今後 1 年以上、全新規 Skill の作成方式に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」(「Skill 作成は
+      `example-skills:skill-creator` 経由」) と一致。Plan / runbook / コーディング規約で
+      済む話ではないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0017 (ローカル Claude Code ポーリング、ユーザースコープ Skill 呼び出し前提)
+- ADR-0026 (`harness-evolution` で公式アップデート追従、`skill-creator` 経由で改修起票)
+- ADR-0027 (テンプレ言語ポリシー、SKILL.md の日本語化)
+- `.claude/rules/skill-authoring.md` (Skill 作成規約の Single Source of Truth)
+- Anthropic "Complete Guide to Building Skills for Claude"
+  (https://docs.anthropic.com/skills/)
+- `docs/harness/plan.md` §5.3 / R-30

--- a/docs/adr/ADR-0026-harness-evolution-internal-external.md
+++ b/docs/adr/ADR-0026-harness-evolution-internal-external.md
@@ -1,0 +1,148 @@
+---
+id: ADR-0026
+title: ハーネス進化は harness-meta と harness-evolution の二系統で駆動する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0026: ハーネス進化は harness-meta と harness-evolution の二系統で駆動する
+
+> **5 行以内 summary**: ハーネスを継続的に改善する仕組みを **二系統補完** で構成する。
+> 内部 KPT 駆動の `harness-meta` (週次 cron + 閾値到達 + 手動起動) と、外部研究駆動の
+> `harness-evolution` (**手動起動のみ**、cron 不採用、Claude API コスト抑制のため) を
+> 並走させる。両者は重複しても許容し、両方から同じ改修案が出れば優先度を引き上げる。
+> 重要案は `example-skills:skill-creator` 経由で Skill scaffold / Plan / EPIC 起票し、
+> 人間 approve を必須とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ハーネスは構築して終わりではなく、PR 単位の学び (learning) と外部のベストプラクティス
+更新を取り込んで継続改善する必要がある。Anthropic 公式 / `anthropics/skills` / MCP spec
+/ awesome-harness-engineering 等の外部情報源は月次レベルで更新があり、内部 KPT だけでは
+取りこぼしが発生する。
+
+逆に、外部研究駆動だけでは「本リポジトリ固有の詰まり (例: fix loop 上限 3 回が短すぎた、
+特定 aspect の検出漏れ)」が拾えない。
+
+加えて、外部情報源を毎日 cron で取りに行く運用は WebSearch / WebFetch / Context7 MCP
+の呼び出しコストが線形に膨らみ、Claude API トークン消費が見合わない (ADR-0017)。
+
+## 決定
+
+ハーネス進化を **二系統補完** で構成する:
+
+- **`harness-meta`** (内部 KPT 駆動):
+  - 入力: `docs/harness/learnings/*.md` の Suggested harness changes / Try セクション
+  - 起動契機: 週次 cron + 閾値到達 (未処理 learning 10 件 or 前回実行から 7 日経過) +
+    手動起動
+  - 出力: 改修 PR 群 (1 改修テーマ = 1 PR)、見送り提案は元 learning ファイルに feedback
+    セクション追記、撤去候補は月次まとめて cleanup PR
+- **`harness-evolution`** (外部研究 / ベストプラクティス駆動):
+  - 入力: WebSearch / WebFetch + Context7 MCP で取得した外部情報 (ホワイトリスト:
+    Anthropic engineering blog / `anthropics/skills` GitHub / Claude Code docs / MCP
+    spec (modelcontextprotocol.io) / awesome-harness-engineering / Augment Code /
+    HumanLayer / Cognition (Devin) / arxiv AI agents / Martin Fowler / Red Hat
+    Developer / GitHub blog)
+  - 起動契機: **手動起動のみ** (Claude API コスト抑制のため cron 不採用)、月次相当の
+    頻度を推奨
+  - 出力: `docs/harness/evolution-proposals/YYYY-MM-DD.md` (出典 URL + 引用日付必須)、
+    重要案は `example-skills:skill-creator` 経由で Skill scaffold / Plan / EPIC 起票
+    (人間 approve 必須)
+
+両者は補完関係 (内部学び vs 外部研究) で、重複しても許容する。両方から同じ改修案が出れば
+優先度を引き上げる。提案重複防止のため、既に learning ファイルで指摘済の提案は
+`harness-evolution` 側を見送り、改修 PR は `harness-meta` / `harness-evolution` の
+**ラベル分離** で運用し、`harness-meta` 側を優先する (R-31)。
+
+`anthropics/skills` の更新確認をホワイトリスト先頭に組み込み、月次手動実行で公式追従
+パスを確保する (R-30、ADR-0025)。
+
+## 根拠
+
+- **二系統補完の理由**: 内部 KPT は本リポジトリ固有の詰まりに強く、外部研究は新規ベスト
+  プラクティスや新規 MCP / Skill 候補に強い。両者は責務が異なるため重複可
+- **`harness-evolution` 手動起動のみ**: WebSearch / WebFetch / Context7 は毎回 API
+  トークン消費が大きい。cron 化すると無人時にトークン枯渇するリスク。月次手動実行で
+  owner が判断するモデルに統一 (ADR-0017 のローカル駆動方針と整合)
+- **ホワイトリスト + 出典明記**: 不正確 / 古い情報源を構造的に排除。Context7 MCP で
+  API 引用を二重検証 (R-28)
+- **重要案は scaffold 起票 + 人間 approve**: 自動マージは絶対禁止 (GitHub Agentic
+  Workflows 原則、R-15)。`example-skills:skill-creator` 経由で SKILL.md フォーマットを
+  公式準拠に保つ (ADR-0025)
+- **ラベル分離 + harness-meta 優先**: 提案重複時は内部学び (実際の詰まりベース) を優先
+  することで、改修コストを実需に揃える
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 単一 Skill (内部 + 外部統合) | Skill 数最小 | 責務混在、入力源 / 出力先 / 起動契機が異なるため設計が複雑化 | 二系統補完で責務分離 |
+| `harness-evolution` を cron 駆動 | 自動的に外部追従 | API トークン消費が線形拡大、無人時に枯渇リスク | 手動起動のみで採用 |
+| 外部情報源ホワイトリスト無し (自由収集) | 情報網が広い | 不正確 / 偏った情報源混入、出典追跡不能 | ホワイトリスト + 出典明記で採用 |
+| 重要案も自動マージ可 | 高速 | 人間ゲート喪失、GitHub Agentic Workflows 原則違反 | 人間 approve 必須 |
+| 内部 KPT のみ採用 (`harness-meta` 単独) | 単純 | 外部ベストプラクティス取りこぼし、公式 update 追従不能 | 二系統補完で採用 |
+
+## 帰結
+
+### Positive
+
+- 内部学び + 外部研究の両輪でハーネス改善が継続駆動される
+- `harness-evolution` 手動起動により API コスト枠が予測可能
+- `anthropics/skills` 公式更新への追従パスが月次相当で確保される (ADR-0025 と整合)
+
+### Negative / トレードオフ
+
+- **`harness-evolution` 手動忘れリスク**: cron 不採用のため owner が起動を忘れると外部
+  追従が止まる → `harness-meta` の月次 cron 実行時に「今月 `harness-evolution` 走らせた
+  か」を確認する notice を入れる (`.claude/rules/harness-meta-criteria.md`)
+- **提案重複の調整コスト**: `harness-meta` / `harness-evolution` の両方から似た提案が
+  出た場合の見送り判定は owner の手動判断 → ラベル分離 + `harness-meta` 優先で機械化
+- **外部情報源の偏り**: ホワイトリスト依存のため、リスト外の良質情報を取り逃す → ホワイト
+  リスト追加は Plan 起票 + 人間 approve 必須で柔軟運用
+
+### Neutral / 将来の検討事項
+
+- `harness-evolution` の cron 化を再評価する場合、API トークン消費の見積もりを取って
+  別 ADR で対応
+- ホワイトリスト拡張 (例: Figma / Sentry / Linear ブログ) は `harness-evolution` の
+  evolution-proposal で提案 → Plan 起票
+
+## ADR 起票基準 (§4.5) の充足
+
+本 ADR が満たす起票基準 (2 項目以上で起票成立):
+
+- [x] 7. ハーネス本体の中核設計 (進化ループの構成)
+- [x] 8. 複数の代替案を比較した結果としての判断 (単一統合 / cron 化 / ホワイトリスト
+      有無 / 自動マージ可否)
+- [x] 9. 元に戻すコストが高い決定 (2 Skill 構成で全 learning / evolution-proposal の
+      入出力が固まる)
+- [x] 10. 長期的な制約 (今後 1 年以上、ハーネス改善駆動方式に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` の「ADR にすべき例」(「ハーネス進化は内部 (`harness-meta`)
+      + 外部 (`harness-evolution`) の二系統」) と一致。Plan / runbook / コーディング
+      規約で済む話ではないことを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0017 (ローカル Claude Code ポーリング、`harness-evolution` 手動起動と整合)
+- ADR-0024 (Context7 MCP 採用、外部情報源 API 検証に利用)
+- ADR-0025 (Skill 作成は `example-skills:skill-creator` 経由、重要案の起票で利用)
+- `.claude/rules/harness-evolution.md` (外部情報源ホワイトリスト + 出力フォーマット +
+  responsabilities 分離の Single Source of Truth)
+- `.claude/rules/harness-meta-criteria.md` (起動閾値 + 重複提案の調整ルール)
+- `docs/harness/plan.md` §5.3 / §5.4.6 / R-29 / R-30 / R-31

--- a/docs/adr/ADR-0027-docs-structure-and-japanese.md
+++ b/docs/adr/ADR-0027-docs-structure-and-japanese.md
@@ -1,0 +1,190 @@
+---
+id: ADR-0027
+title: docs 構造と命名規約と 5 行 summary と日本語化を統一する
+status: accepted
+date: 2026-05-17
+related_epics:
+  - EPIC-000
+related_plans:
+  - PLAN-001
+related_specs: []
+superseded_by: null
+supersedes: null
+---
+
+# ADR-0027: docs 構造と命名規約と 5 行 summary と日本語化を統一する
+
+> **5 行以内 summary**: AI 駆動実装の入力源として `docs/` を体系化する。
+> ディレクトリ構造 (`adr/` / `requirements/` / `specifications/{basic,detail}/` /
+> `architecture/` / `api/` / `security/` / `runbooks/` / `design/inventory/` /
+> `harness/`)、識別子採番 (REQ-NNN / SPEC-<entity>-<seq> / EPIC-NNN / PLAN-NNN / ADR-NNNN)、
+> 各 docs 冒頭 5 行 summary + lazy-load、ハーネス Markdown は全て日本語、を統一規約とする。
+
+## ステータス
+
+accepted
+
+## コンテキスト
+
+ColorMaster は AI 駆動のセルフ改善ループ (Spec Gen → Implementation → Evaluation →
+Merge → Retrospection → Meta) を稼働させる予定で、その入力となる docs 構造が
+未整備のままでは Skill が安定して動作しない。具体的には:
+
+- docs ディレクトリ構造が不揃いだと Skill が glob 絞り込みに失敗する。
+- 識別子採番 (REQ / SPEC / EPIC / PLAN / ADR) が揺れると `related_*` 参照が壊れ、
+  `docs/traceability.md` の自動生成が成立しない。
+- 各 docs が冒頭 summary を持たないと AI が全文 lazy-load し context window を圧迫する。
+- ハーネス Markdown の言語が混在すると、人間レビュー時と AI 起草時の認知負荷が乖離する。
+
+加えて、Google Stitch / Anthropic の AI 駆動 UI 開発でも Markdown ベースの仕様書が
+de facto standard になりつつあり、AI が最も読みやすい形に揃える価値は高い。
+
+## 決定
+
+以下を統一規約とする。
+
+### ディレクトリ構造
+
+詳細は `docs/harness/plan.md` §4.0.1 / `.claude/rules/docs-structure.md`。要点:
+
+- `DESIGN.md` (repo root): UI tokens + Rationale (ADR-0023)
+- `docs/README.md`: AI 用エントリポイント (推奨読み順)
+- `docs/{glossary, codebase-map, traceability}.md`: ドメイン用語 / 主要パス / 全体トレーサビリティ
+- `docs/architecture/{overview, layers, data-flow, domain-model, state-machines, sequences, infrastructure}.md`
+- `docs/api/`: OpenAPI 3.1 + auth/idols/me
+- `docs/requirements/REQ-NNN-<slug>.md`
+- `docs/specifications/{basic,detail}/SPEC-<entity-id>-<seq>-<slug>.md`
+- `docs/adr/ADR-NNNN-<slug>.md`
+- `docs/epics/EPIC-NNN-<slug>/{README, roadmap, open-questions, decisions, progress}.md`
+- `docs/plans/PLAN-NNN-<slug>.md`
+- `docs/harness/{plan, roadmap, learnings/, evolution-proposals/}.md`
+- `docs/runbooks/<name>.md`
+- `docs/design/{README.md, inventory/{screens,components,states,flows}/}`
+
+基本設計と詳細設計は **物理的にサブディレクトリで分離** し、`related_basic` /
+`related_detail` の双方向 frontmatter リンクで参照する。
+
+### 命名規約
+
+| 種別 | 形式 | 例 |
+|---|---|---|
+| ADR | `ADR-NNNN` (4 桁ゼロパディング) | `ADR-0001` |
+| Epic | `EPIC-NNN` (3 桁ゼロパディング) | `EPIC-001` |
+| Plan | `PLAN-NNN` (3 桁ゼロパディング、Epic と独立採番) | `PLAN-001` |
+| 要件 | `REQ-NNN-<slug>` | `REQ-001-search-by-brand` |
+| 仕様 | `SPEC-<entity-id>-<seq>` (basic/detail 共通) | `SPEC-IDOL-001-3` |
+
+### 各 docs の構造
+
+```markdown
+---
+id: <id>
+title: <タイトル>
+status: <ステータス>
+last_updated: YYYY-MM-DD
+related_adrs:
+  - ADR-NNNN
+related_specs:
+  - SPEC-NNN-N
+---
+
+# <タイトル>
+
+> **5 行以内 summary**: この docs が答える問い / 主読者 / 関連 docs
+
+## 詳細
+
+...
+```
+
+5 行 summary は **lazy-load の入口**: AI が summary だけ読んで本文が必要か判断できる
+ようにし、context window を圧迫しない。
+
+### frontmatter
+
+- YAML、配列は **ブロック形式必須** (`- ADR-0001` 形式)、flow `[A, B]` は禁止
+- 必須キー: `id` / `title` / `status` / `last_updated` (種別ごとに追加キーあり、
+  `.claude/rules/docs-structure.md` 参照)
+
+### 日本語化
+
+ハーネスが生成・参照する全 Markdown は **日本語で記述** する。例外:
+
+- YAML frontmatter のキー名 (`id` / `title` / `status` 等)
+- ステータス値 (`proposed` / `accepted` / `in-progress` / `completed` 等)
+- コマンド・ファイルパス・コード断片
+- 識別子 (`SPEC-IDOL-001-3` / `EPIC-NNN` / `ADR 0001` 等)
+
+ADR / Plan / Epic のタイトルは **日本語で簡潔・現在形・断定的** に記述する。
+
+## 根拠
+
+- **AI 駆動の入力源としての docs**: AI Coding Agent が最も信頼性高く動作するのは
+  「構造化された Markdown + 識別子による相互参照」であり、Google Stitch / Anthropic /
+  GitHub Copilot Workspace 等の事例で実証されている。
+- **5 行 summary の効果**: context window が有限な LLM では「全文 vs 要約」の選択が
+  パフォーマンスに直結する。5 行 summary を入口にすると、関連性判断 → 詳細 lazy-load の
+  2 段階で context を節約できる。
+- **物理ディレクトリ分離 (basic / detail)**: 段階的起票 (Plan で basic だけ書く、
+  詳細は別 PR) のスコープが明確になり、AI の glob 絞り込みも単純化する。
+- **識別子 4 桁 / 3 桁ゼロパディング**: lexical sort と自然順 sort が一致し、
+  `ls` / glob / 機械検証スクリプトが扱いやすい。
+- **日本語化**: 認知負荷が第一言語で最も低く、AI も日本語コンテキストで一貫させた方が
+  ハルシネーション減少 (英訳・和訳の往復で意味ずれが起きるリスクを構造的に排除)。
+
+### 比較した代替案
+
+| 代替案 | 利点 | 欠点 | 採用しなかった理由 |
+|---|---|---|---|
+| 全英語化 | 国際的な共同開発に親和 | 主要開発者 (owner) の認知負荷増 + AI の往復翻訳でずれ | 個人プロジェクト規模、owner 単一なら和文で十分 |
+| basic / detail を 1 ファイル統合 | 関連情報がまとまる | PR スコープが肥大化 + glob 絞り込み不能 | 物理分離 + frontmatter 双方向リンクを採用 |
+| frontmatter なし (Markdown 単体) | シンプル | 機械検証不可、識別子参照を grep 頼みになる | frontmatter 強制で `docs/traceability.md` 自動生成を可能に |
+| 5 行 summary なし | 起草コスト最小 | AI 全文ロードで context 圧迫 | 5 行 summary を機械検証 (A6) で強制 |
+
+## 帰結
+
+### Positive
+
+- AI Skill が docs を体系的に参照可能、`docs/traceability.md` (A6 自動生成) の入力源として完成。
+- 5 行 summary により context 効率化、複雑な要件・仕様 docs でも AI が判断容易。
+- 日本語化により owner / AI 双方の認知負荷最小化、和訳往復によるハルシネーション排除。
+
+### Negative / トレードオフ
+
+- 英語話者の貢献者が将来加わる場合、翻訳コストが発生 → owner 単一ロールの間は許容、
+  複数人体制になったら別 ADR で再評価。
+- 5 行 summary を厳守する起草コスト → テンプレで強制、A6 で機械検証。
+
+### Neutral / 将来の検討事項
+
+- frontmatter 必須キー / 5 行 summary / 識別子参照実在 / 設計書コード断片不在の
+  機械検証 (Gradle カスタムタスク、Kotlin、`org.commonmark` + snakeyaml 2.x) は
+  A6 で導入。
+- `docs/traceability.md` の自動生成 (Konsist + frontmatter parser join) も A6。
+- 国際化が必要になったら ADR を改訂し、英訳と原文の同期方式 (例: `*.en.md` 並置) を決める。
+
+## ADR 起票基準 (§4.5) の充足
+
+- [x] 1. アーキテクチャパターン / 層分割 / モジュール構造に影響する (docs ディレクトリ構造)
+- [x] 7. ハーネス本体の中核設計 (Skill の入力源としての docs 体系)
+- [x] 8. 複数の代替案を比較した結果としての判断 (英語化 / 統合 / frontmatter 有無 / summary 有無)
+- [x] 9. 元に戻すコストが高い決定 (一度採用すると全 docs が依存)
+- [x] 10. 長期的な制約 (今後 1 年以上、全 Markdown 起草に影響)
+
+## ADR 化すべき例 / すべきでない例 (テンプレ末尾の自己チェック)
+
+- [x] `.claude/rules/adr.md` のリストと照合し、本 ADR が単なる Markdown 表記規約 (
+      `.claude/rules/markdown.md` で済む話) に留まらず、docs アーキテクチャ全体に
+      影響する決定であることを確認した。
+
+## 関連
+
+- 関連 Plan: PLAN-001
+- 関連 Epic: EPIC-000
+- ADR-0001 (ADR 運用基準)
+- ADR-0023 (UI 凍結三本柱、DESIGN.md の位置付け)
+- `.claude/rules/docs-structure.md` (docs 構造規約の Single Source of Truth)
+- `.claude/rules/template-language.md` (日本語化規約の Single Source of Truth)
+- `.claude/rules/markdown.md` (Markdown 表記規約、A6 で本格化)
+- `docs/harness/plan.md` §4 / §5.5
+- `docs/README.md` (AI 用エントリポイント)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 ---
 id: adr-readme
 title: ADR (Architecture Decision Records) README
-status: skeleton
+status: living
 last_updated: 2026-05-17
 related_plan: docs/harness/plan.md §4.5
 ---
@@ -11,7 +11,7 @@ related_plan: docs/harness/plan.md §4.5
 > **5 行以内 summary**: 重要なアーキテクチャ決定の記録。Michael Nygard 原則
 > ("Architecturally Significant Decisions" のみ記録) 準拠。起票基準は §4.5 と
 > `.claude/rules/adr.md` を参照。連番 4 桁ゼロパディング、日本語、`accepted` 以降は
-> immutable で変更時は新 ADR + `Superseded by` リンク。0001-0027 は A1 で一括起草予定。
+> immutable で変更時は新 ADR + `Superseded by` リンク。0001-0027 は A1 (PLAN-001) で起草済。
 
 ## ステータス遷移 (MADR 4 状態)
 
@@ -33,39 +33,40 @@ related_plan: docs/harness/plan.md §4.5
 - 運用手順 → runbook
 - PR ごとの学び・改善案 → `docs/harness/learnings/`
 
-## ADR 0001-0027 一覧 (A1 で一括起草)
+## ADR 0001-0027 一覧 (A1 = PLAN-001 で起草済)
 
-詳細は `docs/harness/plan.md` §4.0.3 参照。要約:
+詳細は `docs/harness/plan.md` §4.0.3 参照。状態は全件 `accepted` (PLAN-001 PR で `proposed → accepted`
+の中間遷移を経ずに `accepted` で起票、根拠は PLAN-001 のメモを参照)。
 
-| ADR | 状態 | 内容 |
-|---|---|---|
-| 0001 | 既存 | ADR 運用基準・書式・起票判断フロー |
-| 0002 | 既存 | Compose Multiplatform + 共通 ViewModel + Navigation 3 |
-| 0003 | 既存 | モジュール構造 feature-first |
-| 0004 | 既存 | テスト戦略総論 |
-| 0005 | 既存 | Decompose 撤去 |
-| 0006 | 既存 | i18n compose-multiplatform-resources |
-| 0007 | 既存 | im@sparql upstream-driven 同期 |
-| 0008 | 既存 | ユーザーデータ Backend SQLite + Litestream + R2 |
-| 0009 | 既存 | Backend ホスティングは Cloud Run |
-| 0010 | 既存 | アイドル情報マスタ SQLite を repo 内 commit |
-| 0011 | 統合 | 認証スタック転換 (Firebase 廃止 + GIS 統一) |
-| 0012 | 既存 | js/app 撤去 |
-| 0013 | 既存 | Line/Branch coverage 段階達成 |
-| 0014 | 既存 | im@sparql ローカル Docker (Fuseki) |
-| 0015 | 既存 | Mutation testing (PITest) |
-| 0016 | 既存 | Spec coverage / `@Spec` annotation |
-| 0017 | 既存 | ハーネスローカル Claude Code ポーリング駆動 |
-| 0018 | 既存 | `implementation-workflow` 10 フェーズ設計 |
-| 0019 | 既存 | `code-reviewer` 8 aspect + Coordinator |
-| 0020 | 既存 | PII 保護と権限ロール |
-| 0021 | 既存 | Secrets 管理ポリシー |
-| 0022 | 既存 | Cloudflare Pages + R2 |
-| 0023 | 統合 | UI 凍結三本柱 (DESIGN.md + Inventory + Roborazzi) |
-| 0024 | 既存 | MCP サーバ採用 |
-| 0025 | 既存 | Skill 作成は `example-skills:skill-creator` 経由 |
-| 0026 | 既存 | `harness-evolution` Skill 採用 |
-| 0027 | 統合 | docs 構造 + 命名規約 + 5 行 summary + lazy-load + 日本語化 |
+| ADR | 状態 | 内容 | ファイル |
+|---|---|---|---|
+| 0001 | accepted | ADR 運用基準・書式・起票判断フロー | [ADR-0001](ADR-0001-adr-charter.md) |
+| 0002 | accepted | Compose Multiplatform + 共通 ViewModel + Navigation 3 | [ADR-0002](ADR-0002-compose-multiplatform-with-nav3.md) |
+| 0003 | accepted | モジュール構造 feature-first | [ADR-0003](ADR-0003-feature-first-module-structure.md) |
+| 0004 | accepted | テスト戦略総論 (三層指標 index) | [ADR-0004](ADR-0004-test-strategy-overview.md) |
+| 0005 | accepted | Decompose 撤去 | [ADR-0005](ADR-0005-decompose-removal.md) |
+| 0006 | accepted | i18n compose-multiplatform-resources | [ADR-0006](ADR-0006-i18n-compose-resources.md) |
+| 0007 | accepted | im@sparql upstream-driven 同期 | [ADR-0007](ADR-0007-imasparql-upstream-driven-sync.md) |
+| 0008 | accepted | ユーザーデータ Backend SQLite + Litestream + R2 | [ADR-0008](ADR-0008-user-data-backend-sqlite-litestream-r2.md) |
+| 0009 | accepted | Backend ホスティングは Cloud Run | [ADR-0009](ADR-0009-backend-hosting-cloud-run.md) |
+| 0010 | accepted | アイドル情報マスタ SQLite を repo 内 commit | [ADR-0010](ADR-0010-idol-master-sqlite-in-repo.md) |
+| 0011 | accepted (★統合) | 認証スタック転換 (Firebase 廃止 + GIS 統一) | [ADR-0011](ADR-0011-auth-stack-firebase-to-gis.md) |
+| 0012 | accepted | js/app と関連 Web 配信構成を撤去 | [ADR-0012](ADR-0012-js-app-removal.md) |
+| 0013 | accepted | Line/Branch coverage 段階達成 | [ADR-0013](ADR-0013-coverage-stepwise-100.md) |
+| 0014 | accepted | im@sparql ローカル Docker (Fuseki) | [ADR-0014](ADR-0014-imasparql-local-fuseki.md) |
+| 0015 | accepted | Mutation testing (PITest) | [ADR-0015](ADR-0015-mutation-testing-pitest.md) |
+| 0016 | accepted | Spec coverage / `@Spec` annotation | [ADR-0016](ADR-0016-spec-coverage-annotation.md) |
+| 0017 | accepted | ハーネスローカル Claude Code ポーリング駆動 | [ADR-0017](ADR-0017-local-claude-code-polling.md) |
+| 0018 | accepted | `implementation-workflow` 10 フェーズ設計 | [ADR-0018](ADR-0018-implementation-workflow-10-phases.md) |
+| 0019 | accepted | `code-reviewer` 8 aspect + Coordinator | [ADR-0019](ADR-0019-code-reviewer-8-aspects.md) |
+| 0020 | accepted | PII 保護と権限ロール | [ADR-0020](ADR-0020-pii-protection-and-roles.md) |
+| 0021 | accepted | Secrets 管理ポリシー | [ADR-0021](ADR-0021-secrets-management-policy.md) |
+| 0022 | accepted | Cloudflare Pages + R2 | [ADR-0022](ADR-0022-cloudflare-pages-and-r2.md) |
+| 0023 | accepted (★統合) | UI 凍結三本柱 (DESIGN.md + Inventory + Roborazzi) | [ADR-0023](ADR-0023-ui-freeze-three-pillars.md) |
+| 0024 | accepted | MCP サーバ採用 (JetBrains + Context7 + Cloudflare) | [ADR-0024](ADR-0024-mcp-server-adoption.md) |
+| 0025 | accepted | Skill 作成は `example-skills:skill-creator` 経由 | [ADR-0025](ADR-0025-skill-creator-via-example-skills.md) |
+| 0026 | accepted | `harness-evolution` Skill 採用 (内部 + 外部 二系統) | [ADR-0026](ADR-0026-harness-evolution-internal-external.md) |
+| 0027 | accepted (★統合) | docs 構造 + 命名規約 + 5 行 summary + lazy-load + 日本語化 | [ADR-0027](ADR-0027-docs-structure-and-japanese.md) |
 
 ## 関連
 

--- a/docs/harness/roadmap.md
+++ b/docs/harness/roadmap.md
@@ -18,7 +18,7 @@ source_plan: docs/harness/plan.md
 | ID | タイトル | status | expected_modules | 完了根拠 |
 |---|---|---|---|---|
 | **B0** | ブートストラップ PR | completed | `.claude/**`, `docs/**`, `.github/**`, `scripts/**` | PR #117 (2026-05-17 マージ、commit `0256be9`) |
-| **A1** | ADR 0001-0027 一括起草 | proposed | `docs/adr/**` | — |
+| **A1** | ADR 0001-0027 一括起草 | in-progress | `docs/adr/**` | (PLAN-001 で作業中、PR merge 時に PR# 追記) |
 | **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 | proposed | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | — |
 | **A3** | 専用 Skill 群実装 PR | proposed | `.claude/skills/**` | — |
 | **A4** | ローカルポーリング機構の本格化 | proposed | `.claude/skills/pr-poller/**`, `.claude/rules/harness-meta-criteria.md` | — |
@@ -94,6 +94,7 @@ gantt
 | 日付 | 変更内容 | 理由 |
 |---|---|---|
 | 2026-05-17 | 初期ロードマップ起草 (plan.md merge 時) | B0 ブートストラップ PR で `docs/harness/plan.md` §6 から取り込み |
+| 2026-05-17 | A1 status を proposed → in-progress | PLAN-001 (ADR 0001-0027 一括起票) 作業着手、worktree feature/A1-adr-bootstrap で起草中 |
 
 ## 次の推奨着手 (並行実装観点)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -15,6 +15,7 @@ last_updated: 2026-05-17
 
 | PLAN ID | タイトル | type | status | related_epic | 起票日 |
 |---|---|---|---|---|---|
+| PLAN-001 | ADR 0001-0027 一括起票 | chore | in-progress | EPIC-000 | 2026-05-17 |
 
 ## ステータス語彙
 

--- a/docs/plans/PLAN-001-adr-bootstrap.md
+++ b/docs/plans/PLAN-001-adr-bootstrap.md
@@ -1,0 +1,132 @@
+---
+id: PLAN-001
+title: ADR 0001-0027 一括起票
+type: chore
+status: in-progress
+related_pr: null
+related_epic: EPIC-000
+related_specs: []
+related_adrs:
+  - ADR-0001
+  - ADR-0002
+  - ADR-0003
+  - ADR-0004
+  - ADR-0005
+  - ADR-0006
+  - ADR-0007
+  - ADR-0008
+  - ADR-0009
+  - ADR-0010
+  - ADR-0011
+  - ADR-0012
+  - ADR-0013
+  - ADR-0014
+  - ADR-0015
+  - ADR-0016
+  - ADR-0017
+  - ADR-0018
+  - ADR-0019
+  - ADR-0020
+  - ADR-0021
+  - ADR-0022
+  - ADR-0023
+  - ADR-0024
+  - ADR-0025
+  - ADR-0026
+  - ADR-0027
+expected_modules:
+  - docs/adr/**
+  - docs/plans/**
+  - docs/harness/roadmap.md
+created_at: 2026-05-17
+completed_at: null
+promoted_to: null
+---
+
+# ADR 0001-0027 一括起票
+
+> **5 行以内 summary**: B0 で merge 済み `docs/harness/plan.md` (commit 0256be9) に
+> 記載済みの 27 件のアーキテクチャ決定を `docs/adr/ADR-NNNN-<kebab>.md` として
+> 物理化する。全 ADR を `accepted` で起票し、`docs/adr/README.md` の状態列と
+> `docs/harness/roadmap.md` の A1 行ステータスも更新する。Phase A の起点。
+> 影響範囲: `docs/adr/**`、`docs/plans/**`、`docs/harness/roadmap.md`。
+
+## 目的
+
+- `docs/harness/plan.md` §6.2 A1 を満たす。
+- 既存 plan.md に記載済みのアーキテクチャ決定 (Compose Multiplatform / Backend SQLite / GIS 認証 /
+  ハーネスループ / MCP / UI 凍結 / docs 構造 等) を ADR 形式で参照可能にし、
+  以降の Plan / Epic / Skill から `related_adrs` を介して機械的に追跡できるようにする。
+
+## 背景
+
+- `.claude/rules/adr.md` および `docs/adr/README.md` に「A1 で一括起草」と明記済み。
+- B0 PR (#117、commit 0256be9) で `docs/adr/{README,template}.md` を配置済みだが、
+  ADR 本体ファイルは未作成。
+- 27 件の決定は plan.md §3 (設計指針) / §4 (docs 構造) / §5 (ハーネス構造) に集約されており、
+  ADR 本体は要約 + Single Source of Truth (plan.md 章) への参照で構成する。
+
+## アプローチ
+
+1. ADR 0001 (運用基準) と ADR 0027 (docs 構造) を先行起草し、他 ADR が参照する
+   メタ ADR を確定。
+2. グループ別に並列起草:
+   - G2 アプリ設計 (0002 / 0003 / 0004 / 0005 / 0006 / 0012)
+   - G3 データ・認証・同期 (0007 / 0008 / 0010 / 0011 / 0014)
+   - G4 ホスティング (0009 / 0022)
+   - G5 テスト品質 (0013 / 0015 / 0016)
+   - G6 セキュリティ (0020 / 0021)
+   - G7 ハーネス中核 (0017 / 0018 / 0019 / 0024 / 0025 / 0026)
+   - G8 UI/UX (0023)
+3. 各 ADR は `docs/adr/template.md` 準拠、ステータスは `accepted`、起票日 2026-05-17、
+   5 行 summary + コンテキスト + 決定 + 根拠 + 帰結 + 起票基準充足チェックを含む。
+4. クロスリファレンス整合: `related_adrs` / `related_specs` / `related_epics` /
+   `related_plans` の参照先実在を手動で確認。
+5. 副次更新:
+   - `docs/adr/README.md` の状態列を「既存 / ★統合」→「★起草済 (accepted)」に更新。
+   - `docs/harness/roadmap.md` の A1 行 status を `proposed` → `in-progress`。
+   - `docs/plans/INDEX.md` に PLAN-001 行を追加。
+6. Self-Verification: frontmatter 必須キー / 日本語見出し / 5 行 summary 存在 /
+   コード断片不在 / 識別子参照実在を全 ADR で確認。
+7. `feature/A1-adr-bootstrap` ブランチで commit、`gh pr create --draft
+   --template docs.md` で Draft PR 起票、`code-reviewer` 起動 (Phase 6)、
+   人間 approve 後に squash merge (Phase 7)。
+
+## 受け入れ基準
+
+- [ ] `docs/adr/ADR-0001-*.md` から `docs/adr/ADR-0027-*.md` まで 27 ファイルが存在する。
+- [ ] 全 ADR の frontmatter が `.claude/rules/docs-structure.md` の必須キーを満たす
+      (`id` / `title` / `status` / `date` / `related_epics` / `related_plans` /
+      `related_specs` / `superseded_by` / `supersedes`)。
+- [ ] 全 ADR が冒頭 5 行以内の summary を持つ (ADR 0027 / docs-structure.md)。
+- [ ] 全 ADR が日本語見出し (ADR 0027 / template-language.md)。
+- [ ] 全 ADR の `related_*` 参照先が実在する (相互参照のあるものは双方向で確認)。
+- [ ] `docs/adr/README.md` の状態一覧表が更新済み (27 行全てに「★起草済 (accepted)」を反映)。
+- [ ] `docs/harness/roadmap.md` の A1 行 status が `in-progress` (本 PR 着手) に更新済み。
+- [ ] `docs/plans/INDEX.md` に PLAN-001 行が追加済み。
+- [ ] ADR 本文に Kotlin / Gradle DSL / SQL 等のコード断片を含まない (§4.6 のコード禁止原則)。
+- [ ] PII / Secrets が diff に含まれない (`.claude/rules/{pii,secrets}.md`)。
+
+## スコープ外
+
+- A2 (`.claude/rules/*` 全ファイル本格化 + docs 拡充): rules の skeleton → 本格版への昇格は
+  別 PR で実施。本 PR は rule への参照を ADR 内から張るのみ。
+- A3 (専用 Skill 群実装): `feature-request` / `bug-fix` / `refactor` / `adr-author` /
+  `harness-meta` の実装は別 PR。
+- 各 ADR が記述する決定の **実装** は Phase C の各 Epic / Plan で実施。
+- ADR 内容の機械検証 (frontmatter JSON Schema / 5 行 summary 検証 / 識別子実在検証):
+  A6 で Gradle カスタムタスクとして導入。本 PR では手動 Self-Verification のみ。
+
+## メモ
+
+- ADR ステータスを `proposed` ではなく `accepted` で起票する判断:
+  本 PR は B0 で merge 済み plan.md に既に記載された決定を ADR ファイルに物理化する
+  フェーズであり、決定自体は plan.md レビュー時点で accept 済。`proposed → accepted` の
+  遷移を同 PR 内で行うのは冗長。後で revoke が必要になれば `.claude/rules/adr.md`
+  §採番・命名・ステータスの規約通り **新 ADR + `Superseded by`** で対応する。
+- Plan の `type` 値が template.md 上 `feature | bug-fix | refactor | dep-upgrade | chore`
+  となっており `docs` が無いため、本 Plan は `type: chore` で起票。PR テンプレート側は
+  `.github/PULL_REQUEST_TEMPLATE/docs.md` を使用する (Plan type と PR type は別系統)。
+  Plan template の type 一覧に `docs` を追加するかは A2 で `.claude/rules/plan.md` 拡充時に判断。
+- `related_adrs` に 0001-0027 を全て列挙: 本 PR の影響範囲を明示し、A6 の
+  `docs/traceability.md` 自動生成で全 ADR が PLAN-001 から逆引きできるようにする。


### PR DESCRIPTION
---
type: docs
related_plan: PLAN-001
related_epic: EPIC-000
related_adrs:
  - ADR-0001
  - ADR-0002
  - ADR-0003
  - ADR-0004
  - ADR-0005
  - ADR-0006
  - ADR-0007
  - ADR-0008
  - ADR-0009
  - ADR-0010
  - ADR-0011
  - ADR-0012
  - ADR-0013
  - ADR-0014
  - ADR-0015
  - ADR-0016
  - ADR-0017
  - ADR-0018
  - ADR-0019
  - ADR-0020
  - ADR-0021
  - ADR-0022
  - ADR-0023
  - ADR-0024
  - ADR-0025
  - ADR-0026
  - ADR-0027
related_specs: []
expected_modules:
  - docs/adr/**
  - docs/plans/**
  - docs/harness/roadmap.md
---

## 概要

A1 (`docs/harness/plan.md` §6.2) — B0 で merge 済 plan.md (#117 / commit 0256be9) に
記載された 27 件のアーキテクチャ決定を `docs/adr/ADR-NNNN-<slug>.md` として物理化し、
Plan / Epic / Skill / rule から `related_adrs` で機械的に逆引きできるようにする。

## 関連

- Plan: PLAN-001 (本 PR の起票元 Plan、`docs/plans/PLAN-001-adr-bootstrap.md`)
- Epic: EPIC-000 (ハーネス基盤構築、`docs/epics/EPIC-000-harness-foundation/`)
- ADR: ADR-0001 から ADR-0027 (本 PR で起票する 27 件全て)

## 更新 docs パス一覧

| パス | 変更内容 |
|---|---|
| `docs/adr/ADR-0001-adr-charter.md` 〜 `ADR-0027-*.md` | 27 ADR 新規追加 (全て `status: accepted`) |
| `docs/adr/README.md` | 状態一覧表を「既存 / ★統合」→「accepted」に置換、各 ADR への相対リンク列を追加、frontmatter `status` を skeleton → living |
| `docs/plans/PLAN-001-adr-bootstrap.md` | 新規起票 (type=chore、status=in-progress、related_adrs に 0001-0027 全列挙) |
| `docs/plans/INDEX.md` | PLAN-001 行を追加 |
| `docs/harness/roadmap.md` | A1 行 status を proposed → in-progress、着手順変更履歴に 2026-05-17 エントリを append |

## 影響を受ける Skill / rule

| Skill / rule | 影響 |
|---|---|
| `.claude/rules/adr.md` | ADR-0001 が本 rule の Single Source of Truth であることを `related_adrs` で確立 |
| `.claude/rules/docs-structure.md` | ADR-0027 が本 rule の Single Source of Truth |
| `.claude/rules/template-language.md` | ADR-0027 が本 rule の Single Source of Truth |
| `.claude/rules/pii.md` / `.claude/rules/secrets.md` / `.claude/rules/db-protection.md` | ADR-0020 / ADR-0021 が Single Source of Truth |
| `.claude/rules/mcp-usage.md` | ADR-0024 が Single Source of Truth |
| `.claude/rules/skill-authoring.md` | ADR-0025 が Single Source of Truth |
| `.claude/rules/harness-evolution.md` | ADR-0026 が Single Source of Truth |
| `.claude/rules/implementation-workflow.md` | ADR-0018 が Single Source of Truth |
| `.claude/rules/code-reviewer-aspects.md` | ADR-0019 が Single Source of Truth |
| `.claude/rules/design-tokens.md` / `ui-snapshot.md` / `ui-inventory.md` / `behavior-preservation.md` | ADR-0023 が Single Source of Truth |
| `.claude/rules/roadmap.md` | A1 行 status 更新の根拠 (R-34 片方向ミラー / R-36) |
| `harness-bootstrap` Skill | ADR 起草モードの本格動作 (本 PR で初回稼働) |
| `roadmap-tracker` Skill | 本 PR merge 後に Phase 8 で起動して A1 行 status を `in-progress` → `completed` に遷移 |

## 受け入れ基準 (AC)

- [x] frontmatter 必須キーを設定済 (`id` / `title` / `status` / `date` / `related_epics` / `related_plans` / `related_specs` / `superseded_by` / `supersedes`)
- [x] 冒頭 5 行 summary を全 27 ADR で維持 (ADR-0027 / `.claude/rules/docs-structure.md`)
- [x] 設計書 (`docs/{requirements,specifications}/**`) ではないため §4.6 のコード断片禁止は本 PR 対象外。ただし ADR 本文にも fenced code block は ADR-0025 の yaml 3 行 (SKILL.md フォーマット例示) を除き不在
- [x] 日本語見出し (ADR-0027 / `.claude/rules/template-language.md`)
- [x] 関連 ID 参照の実在 (ADR-NNNN 識別子参照を grep で抽出し、全て対応するファイルが存在することを Self-Verification で確認済)
- [x] frontmatter 配列の block 形式 (空配列 `[]` 以外で flow 形式なしを grep 確認済)
- [x] PII / Secrets が diff に含まれない (`@example.com` 以外のメール、`googleusercontent.com` URL、21 桁数字を grep 確認、検出なし)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降、本 PR 時点では Lint 基盤未導入)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、frontmatter JSON Schema / 5 行 summary / 識別子参照実在の機械検証は A6 で導入)
- [x] 手動 Self-Verification: 必須キー / 5 行 summary / accepted status / block 形式 / コード断片 / ADR 参照実在 / 27 件完全性 / PII / Secrets を全て確認済

## レビュー観点

- **ADR 0001 (運用基準) と ADR 0027 (docs 構造)** がメタ ADR としての記述内容に過不足ないか、`.claude/rules/adr.md` と `docs-structure.md` の規約と二重定義になっていないか
- **ADR 0011 / 0023 / 0027** は plan.md §4.0.3 で「★統合」マークされている (旧 ADR の統合)。コンテキスト節で統合経緯を簡潔に明記、`supersedes` には記載しない (前身 ADR が物理化されていないため) という処理が妥当か
- **各 ADR の「ADR 起票基準 (§4.5) の充足」チェックボックス** が、本当に満たすものだけにチェックされているか (起票成立条件: 2 項目以上)
- **代替案比較表** が plan.md §3 / §5 の根拠と整合しているか (特に ADR 0009 Cloud Run 比較、ADR 0022 静的配信比較、ADR 0024 MCP 比較)
- **`docs/adr/README.md` の各 ADR への相対リンク** が機能するか (将来 markdownlint で検証予定)

## チェックリスト

- [x] `.claude/rules/{docs-structure,template-language,markdown,adr,roadmap}.md` の該当規約を確認した
- [x] (ADR 更新時) ステータスが `accepted` 以降の ADR は immutable なため新 ADR + `Superseded by` で更新済 — 本 PR は **新規起票** のため該当なし
- [x] (roadmap.md / Epic roadmap 更新時) 手動更新の理由を記載: A1 着手の旨を着手順変更履歴に append、`roadmap-tracker` Skill 本格稼働は A3 完了後のため本 PR 内では手動更新
- [x] PII が含まれていない (`.claude/rules/pii.md`)

## 補足: ステータスを accepted で起票する判断

本 PR は B0 で merge 済み plan.md (commit 0256be9) に記載済みの決定を ADR ファイルに
物理化するフェーズであり、決定自体は plan.md レビュー時点で accept 済。
`proposed → accepted` の中間遷移を同 PR 内で行うのは冗長なため、最初から
`accepted` で起票する。後で revoke が必要になれば `.claude/rules/adr.md`
§採番・命名・ステータスの規約通り **新 ADR + `Superseded by`** で対応する。
