### PR TITLE
docs(harness): mirror A1 completion in roadmap (PR #119)

### DIFF
--- a/docs/harness/roadmap.md
+++ b/docs/harness/roadmap.md
@@ -18,7 +18,7 @@ source_plan: docs/harness/plan.md
 | ID | タイトル | status | expected_modules | 完了根拠 |
 |---|---|---|---|---|
 | **B0** | ブートストラップ PR | completed | `.claude/**`, `docs/**`, `.github/**`, `scripts/**` | PR #117 (2026-05-17 マージ、commit `0256be9`) |
-| **A1** | ADR 0001-0027 一括起草 | in-progress | `docs/adr/**` | (PLAN-001 で作業中、PR merge 時に PR# 追記) |
+| **A1** | ADR 0001-0027 一括起草 | completed | `docs/adr/**` | PR #119 (2026-05-17 マージ、commit `7f155b5`) |
 | **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 | proposed | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | — |
 | **A3** | 専用 Skill 群実装 PR | proposed | `.claude/skills/**` | — |
 | **A4** | ローカルポーリング機構の本格化 | proposed | `.claude/skills/pr-poller/**`, `.claude/rules/harness-meta-criteria.md` | — |
@@ -44,8 +44,11 @@ source_plan: docs/harness/plan.md
 | ID | PR 番号 | マージ日 | 主要ファイル |
 |---|---|---|---|
 | B0 | [#117](https://github.com/subroh0508/colormaster/pull/117) | 2026-05-17 | `.claude/{rules,skills,mcp.json,settings.json}/**`, `docs/{adr,api,architecture,design,epics,harness,requirements,runbooks,security,specifications,README.md,glossary.md,codebase-map.md,traceability.md}`, `DESIGN.md`, `.github/{pull_request_template.md,PULL_REQUEST_TEMPLATE/**}`, `scripts/install-git-hooks.sh`, `CLAUDE.md`, `AGENTS.md` |
+| A1 | [#119](https://github.com/subroh0508/colormaster/pull/119) | 2026-05-17 | `docs/adr/ADR-0001-*.md` 〜 `ADR-0027-*.md` (27 件)、`docs/adr/README.md`、`docs/plans/{PLAN-001-adr-bootstrap.md,INDEX.md}`、`docs/harness/roadmap.md` |
 
 (B0 は `implementation-workflow` を経由せず手動マージしたため `roadmap-tracker` の Phase 8 自動起動は発火せず、`pr-retrospective` の learning PR (`harness/learnings-batch-2026-W20`) で手動更新)
+
+(A1 は `implementation-workflow` Phase 0-9 の枠組みで進めたが、`code-reviewer` / `pr-poller` / `roadmap-tracker` が skeleton 段階のため手動補助で実施。`code-reviewer` は 3 aspect (spec-conformance / architecture / security) を手動サブエージェント並列で実行し PR #119 にコメント post。owner 単一で self-approve 不可のため `gh pr merge --merge` で通常マージ。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替)
 
 ## 着手順とブロック関係
 
@@ -95,6 +98,7 @@ gantt
 |---|---|---|
 | 2026-05-17 | 初期ロードマップ起草 (plan.md merge 時) | B0 ブートストラップ PR で `docs/harness/plan.md` §6 から取り込み |
 | 2026-05-17 | A1 status を proposed → in-progress | PLAN-001 (ADR 0001-0027 一括起票) 作業着手、worktree feature/A1-adr-bootstrap で起草中 |
+| 2026-05-17 | A1 status を in-progress → completed | PR #119 (commit `7f155b5`) で ADR 0001-0027 一括起票が merge 完了、本 PR で `roadmap-tracker` Phase 8 自動同期の手動代替を実施 |
 
 ## 次の推奨着手 (並行実装観点)
 


### PR DESCRIPTION
---
type: docs
related_plan: null
related_epic: EPIC-000
related_adrs: []
related_specs: []
expected_modules:
  - docs/harness/roadmap.md
---

## 概要

PR #119 (A1: ADR 0001-0027 一括起票、merge commit `7f155b5`、merged at 2026-05-17T08:50:28Z) の
merge 完了を `docs/harness/roadmap.md` に反映する片方向ミラー (R-34 / R-36)。
本 PR は `roadmap-tracker` Skill が本格化 (A3 完了後) されるまでの **手動代替**。

## 関連

- 関連 PR: #119 (A1 本体)
- Epic: EPIC-000 (ハーネス基盤構築、A1 はその構成 PR)
- 規約: `.claude/rules/roadmap.md` (片方向ミラー / append-only / R-34 / R-36)
- 参考 PR: #118 (B0 完了反映の同種 PR、retro と一体化されていた)

## 更新 docs パス一覧

| パス | 変更内容 |
|---|---|
| `docs/harness/roadmap.md` | (1) A1 行 status を in-progress → completed、完了根拠列に PR #119 / 2026-05-17 / commit `7f155b5` を記録。(2) 完了根拠表に A1 行を追加。(3) 注釈テキストに A1 の手動補助運用と `--merge` 通常マージの経緯を追記。(4) 着手順変更履歴に 2026-05-17 のエントリを append |

## 影響を受ける Skill / rule

| Skill / rule | 影響 |
|---|---|
| `roadmap-tracker` Skill (skeleton) | 本格動作 (A3 完了後) で本 PR の処理を自動化する想定。本 PR はその手動代替 |
| `.claude/rules/roadmap.md` | 片方向ミラー / append-only 原則 / R-34 / R-36 に準拠した更新 |
| `pr-poller` Skill (skeleton) | 本格動作で merge 直後に pr-retrospective を起動する想定。A1 の retrospective は別途 `harness/learnings-batch-2026-W20` への append で実施予定 |

## 受け入れ基準 (AC)

- [x] A1 行 status が `completed` に更新済み
- [x] 完了根拠列に PR 番号 + マージ日 + commit hash が記録済み
- [x] 完了根拠表に A1 行が追加済み (PR リンク + マージ日 + 主要ファイル)
- [x] 着手順変更履歴に 2026-05-17 のエントリが append (append-only 原則遵守、既存行は削除なし)
- [x] 注釈テキストで A1 の手動補助運用 (code-reviewer / pr-poller / roadmap-tracker が skeleton 段階) と `--merge` 通常マージ (owner 単一で self-approve 不可) の経緯を明記
- [x] frontmatter `last_updated: 2026-05-17` (同日のため変更不要)
- [x] `plan.md` / EPIC-000 本体への逆同期なし (片方向ミラー、R-34)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、項目 ID 実在検証含む)
- [x] 手動検証: B0 / A1 の完了根拠が PR 番号 / マージ日 / commit hash 形式で一貫、着手順変更履歴の append-only 原則遵守

## レビュー観点

- 注釈テキストの記述粒度が将来の参照者にとって過不足ないか (`implementation-workflow` skeleton 段階の運用注記として有用か)
- A1 主要ファイルの列挙が冗長すぎないか (27 ADR は `ADR-0001-*.md` 〜 `ADR-0027-*.md` の範囲指定で集約)
- A2 着手前に本 PR を merge することで、A2 worktree の roadmap.md base が最新化されることを確認

## チェックリスト

- [x] `.claude/rules/{roadmap,docs-structure,template-language}.md` の該当規約を確認した
- [x] (roadmap.md 更新時) 手動更新の理由を記載: `roadmap-tracker` Skill が skeleton 段階のため手動代替、これは A3 完了後に自動化される
- [x] PII が含まれていない (`.claude/rules/pii.md`)
