### PR TITLE
docs(harness): mirror A2-1 completion in roadmap

### DIFF
--- a/docs/epics/EPIC-000-harness-foundation/roadmap.md
+++ b/docs/epics/EPIC-000-harness-foundation/roadmap.md
@@ -19,7 +19,7 @@ source_epic: EPIC-000
 |---|---|---|---|---|
 | **B0** | ブートストラップ PR | completed | `.claude/**`, `docs/**`, `.github/**`, `scripts/**`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md` | PR [#117](https://github.com/subroh0508/colormaster/pull/117) (2026-05-17 マージ、commit `0256be9`) |
 | **A1** | ADR 0001-0027 一括起草 | completed | `docs/adr/**` | PR [#119](https://github.com/subroh0508/colormaster/pull/119) (2026-05-17 マージ、commit `7f155b5`) |
-| **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 (EPIC-A2 で 5 PR に分割) | in-progress | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | (EPIC-A2 配下 PR で更新、`docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` 参照) |
+| **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 (EPIC-A2 で 5 PR に分割) | in-progress (A2-1 完了、A2-2/A2-4 着手準備中) | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | A2-1: PR [#121](https://github.com/subroh0508/colormaster/pull/121) (2026-05-17 マージ、commit `feb41b5`)。残 A2-2/A2-3/A2-4/A2-5 は `docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` 参照 |
 | **A3** | 専用 Skill 群実装 PR | proposed | `.claude/skills/**` | — |
 | **A4** | ローカルポーリング機構の本格化 | proposed | `.claude/skills/pr-poller/**`, `.claude/rules/harness-meta-criteria.md` | — |
 | **A5** | 不要モジュール撤去 (Firebase 系) | proposed | `js/**`, `kotlin-js-store/**`, `public/**`, `core/network/{auth,firestore}/**`, `firebase.json`, `.firebaserc`, `web-build-and-deploy.yml` | — |
@@ -71,6 +71,7 @@ gantt
 |---|---|---|
 | 2026-05-17 | 初期ロードマップ起草 (B0 PR 内で) | EPIC-000 起票と同時 |
 | 2026-05-17 | B0 → completed、A1 → completed、A2 → in-progress (A2-1 PR で更新) | B0 PR #117 / A1 PR #119 がマージ済、A2 は EPIC-A2 で 5 PR に分割して A2-1 着手 |
+| 2026-05-17 | A2-1 (EPIC-A2 配下、初の EPIC PR) マージ完了 | PR #121 commit `feb41b5`。本 PR (`harness/roadmap-mirror-a2-1`) は `roadmap-tracker` Phase 8 自動同期の手動代替 |
 
 ## 次の推奨着手 (並行実装観点)
 

--- a/docs/epics/EPIC-A2-rules-docs-extension/progress.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/progress.md
@@ -16,15 +16,21 @@ source_epic: EPIC-A2
 
 | 日付 | 出来事 | 関連 PR / SPEC / 担当 |
 |---|---|---|
-| 2026-05-17 | EPIC-A2 起票 (A2-1 PR 内で) + 5 PR 分割方針確定 | A2-1 PR (本 PR) |
-| 2026-05-17 | A2-1 着手 (現 worktree `feature/A2-rules-docs-extension` を reuse、`implementation-workflow` Phase 1 から) | A2-1 PR |
+| 2026-05-17 | EPIC-A2 起票 + 5 PR 分割方針確定 | A2-1 PR #121 |
+| 2026-05-17 | A2-1 着手 (worktree `feature/A2-rules-docs-extension`、`implementation-workflow` Phase 1 から) | A2-1 PR #121 |
+| 2026-05-17 | A2-1 Draft PR #121 起票 (24 ファイル / +784 / -93) | A2-1 PR #121 |
+| 2026-05-17 | A2-1 code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) 並列 review 完了 → Critical 1 (plan.md L1125 SSoT 矛盾) + Improvement 13 件検出 | A2-1 PR #121 |
+| 2026-05-17 | A2-1 fix loop 実施 (commit `2e820bc`、Critical 1 解消 + Easy improvements 5 件消化) → Coordinator が Ready 判定 → Draft → Ready 昇格 | A2-1 PR #121 |
+| 2026-05-17 | A2-1 PR #121 merge 完了 (commit `feb41b5`、`gh pr merge --merge`) | A2-1 PR #121 |
+| 2026-05-17 | A2-1 Phase 8 (roadmap-tracker 手動代替) 実施 → 本 PR (`harness/roadmap-mirror-a2-1`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md 更新 | (本 PR) |
+| 2026-05-17 | A2-1 Phase 9 (worktree cleanup) 実施 → `feature/A2-rules-docs-extension` worktree remove + branch -d | — |
 
 ## マイルストーン
 
 | 日付 | マイルストーン | 達成 / 未達 |
 |---|---|---|
-| 2026-05-17 | A2-1 PR ドラフト起票 | (本 PR で達成見込み) |
-| (未定) | A2-1 マージ → A2-2 / A2-4 並走着手 | 未達 |
+| 2026-05-17 | A2-1 PR ドラフト起票 | ✅ 達成 (PR #121) |
+| 2026-05-17 | A2-1 マージ → A2-2 / A2-4 並走着手の前提整備 | ✅ 達成 (PR #121 merge commit `feb41b5`、本 PR で roadmap mirror) |
 | (未定) | A2-2 / A2-3 マージ (rules 全本格化完了) | 未達 |
 | (未定) | A2-4 / A2-5 マージ (docs 全面拡充完了) | 未達 |
 | (未定) | EPIC-A2 status → completed | 未達 |

--- a/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
@@ -17,7 +17,7 @@ source_epic: EPIC-A2
 
 | ID | タイトル | status | expected_modules | 完了根拠 |
 |---|---|---|---|---|
-| **A2-1** | A1 レトロ即時消化 + ハーネス即時改善 | in-progress | EPIC-A2 起票 + `CLAUDE.md` / `.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message,roadmap}.md` / `.claude/skills/code-reviewer/SKILL.md` / `.github/PULL_REQUEST_TEMPLATE/{harness,feature,bugfix}.md` / `docs/adr/README.md` / `docs/harness/learnings/flaky-tests.md` | (本 PR で更新) |
+| **A2-1** | A1 レトロ即時消化 + ハーネス即時改善 | completed | EPIC-A2 起票 + `CLAUDE.md` / `.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message,roadmap}.md` / `.claude/skills/code-reviewer/SKILL.md` / `.github/PULL_REQUEST_TEMPLATE/{harness,feature,bugfix}.md` / `docs/adr/README.md` / `docs/harness/{plan,learnings/flaky-tests,learnings/INDEX,learnings/2026-05-17-pr-117,roadmap}.md` / `scripts/install-git-hooks.sh` | PR [#121](https://github.com/subroh0508/colormaster/pull/121) (2026-05-17 マージ、commit `feb41b5`) |
 | **A2-2** | rules 実装・コード系本格化 | proposed | `.claude/rules/{plan,epic,adr,roadmap,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,pii,secrets,db-protection,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream,rules-index}.md` | — |
 | **A2-3** | rules プロセス・ハーネス・UI系本格化 | proposed | `.claude/rules/{pr-template,branch-naming,merge-readiness,pr-draft-policy,spec-living-sync,harness-meta-criteria,retrospective-format,pr-poller,skill-authoring,harness-evolution,implementation-workflow,code-reviewer-aspects,design-tokens,ui-snapshot,ui-inventory,behavior-preservation,docs-structure,template-language,rules-index}.md` | — |
 | **A2-4** | docs/ コア + runbooks 拡充 | proposed | `docs/{README,glossary,codebase-map}.md`, `docs/security/README.md`, `docs/requirements/{README,template}.md`, `docs/specifications/{README,basic/template,detail/template}.md`, `docs/runbooks/{local-development,testing,i18n,mcp-setup}.md` | — |
@@ -27,8 +27,7 @@ source_epic: EPIC-A2
 
 | ID | PR 番号 | マージ日 | 主要ファイル |
 |---|---|---|---|
-
-(A2-1 マージ時に追記)
+| A2-1 | [#121](https://github.com/subroh0508/colormaster/pull/121) | 2026-05-17 | EPIC-A2 5 ファイル起票 (`docs/epics/EPIC-A2-rules-docs-extension/{README,roadmap,open-questions,decisions,progress}.md`)、`docs/epics/INDEX.md` 更新、`.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message (新規),roadmap}.md`、`.claude/skills/code-reviewer/SKILL.md` Gotchas、`.github/PULL_REQUEST_TEMPLATE/{harness (新規),feature,bugfix}.md`、`CLAUDE.md` lookup table 注記、`docs/adr/README.md` 索引拡充、`docs/harness/learnings/{flaky-tests.md (新規),2026-05-17-pr-117.md,INDEX.md}`、`docs/harness/{plan,roadmap}.md` (commit `feb41b5`、squash merge、code-reviewer 4 aspect 並列 review 通過 + fix loop で Critical 1 解消) |
 
 ## 着手順とブロック関係
 
@@ -64,13 +63,14 @@ A2-1 完了後、A2-2/A2-3 (rules 系) と A2-4/A2-5 (docs 系) は **並走可*
 |---|---|---|
 | 2026-05-17 | EPIC-A2 起票 + A2 を 5 PR に分割 | B0 (96 files / +5408 行) のレビュー負荷が上限近く、A2 全体は B0 を超える規模が想定されるため。A1 レトロ Try「巨大 PR の aspect 並列 review における入力分割」と整合 |
 | 2026-05-17 | A2-1 着手 (現 worktree `feature/A2-rules-docs-extension` を reuse) | A1 レトロ 15 提案のうち消化可能項目を最優先で消化、後続 PR の規約・索引基盤を整える |
+| 2026-05-17 | A2-1 status を in-progress → completed (PR #121 マージ、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、後続 A2-2 / A2-4 並走着手の前提が整う。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
 
 ## 次の推奨着手 (並行実装観点)
 
-A2-1 マージ後の手動更新例:
+A2-1 マージ済 (PR #121、commit `feb41b5`)。次のステップ:
 
-1. **A2-4 (docs/ コア + runbooks 拡充)** — `docs/` のみ touch、`.claude/rules/` に依存しない
-2. **A2-2 (rules 実装・コード系本格化)** — A2-4 と並走可 (touch ファイル重複ゼロ)
+1. **A2-4 (docs/ コア + runbooks 拡充)** — `docs/` のみ touch、`.claude/rules/` に依存しない。別 worktree で並走着手可
+2. **A2-2 (rules 実装・コード系本格化)** — A2-4 と並走可 (touch ファイル重複ゼロ)。別 worktree で並走着手可
 3. A2-3 (rules プロセス系) 着手は A2-2 完了後 (`.claude/rules/rules-index.md` の連続編集回避のため)
 4. A2-5 (docs/architecture + api) 着手は A2-4 完了後または並走 (`docs/` 内のサブツリーが異なれば衝突なし)
 

--- a/docs/harness/roadmap.md
+++ b/docs/harness/roadmap.md
@@ -45,10 +45,13 @@ source_plan: docs/harness/plan.md
 |---|---|---|---|
 | B0 | [#117](https://github.com/subroh0508/colormaster/pull/117) | 2026-05-17 | `.claude/{rules,skills,mcp.json,settings.json}/**`, `docs/{adr,api,architecture,design,epics,harness,requirements,runbooks,security,specifications,README.md,glossary.md,codebase-map.md,traceability.md}`, `DESIGN.md`, `.github/{pull_request_template.md,PULL_REQUEST_TEMPLATE/**}`, `scripts/install-git-hooks.sh`, `CLAUDE.md`, `AGENTS.md` |
 | A1 | [#119](https://github.com/subroh0508/colormaster/pull/119) | 2026-05-17 | `docs/adr/ADR-0001-*.md` 〜 `ADR-0027-*.md` (27 件)、`docs/adr/README.md`、`docs/plans/{PLAN-001-adr-bootstrap.md,INDEX.md}`、`docs/harness/roadmap.md` |
+| A2-1 (EPIC-A2 配下) | [#121](https://github.com/subroh0508/colormaster/pull/121) | 2026-05-17 | EPIC-A2 5 ファイル起票 (`docs/epics/EPIC-A2-rules-docs-extension/{README,roadmap,open-questions,decisions,progress}.md`)、`.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message,roadmap}.md`、`.claude/skills/code-reviewer/SKILL.md` Gotchas、`.github/PULL_REQUEST_TEMPLATE/{harness,feature,bugfix}.md`、`CLAUDE.md`、`docs/adr/README.md`、`docs/harness/learnings/{flaky-tests,2026-05-17-pr-117,INDEX}.md`、`docs/harness/{plan,roadmap}.md` (commit `feb41b5`) |
 
 (B0 は `implementation-workflow` を経由せず手動マージしたため `roadmap-tracker` の Phase 8 自動起動は発火せず、`pr-retrospective` の learning PR (`harness/learnings-batch-2026-W20`) で手動更新)
 
-(A1 は `implementation-workflow` Phase 0-9 の枠組みで進めたが、`code-reviewer` / `pr-poller` / `roadmap-tracker` が skeleton 段階のため手動補助で実施。`code-reviewer` は 3 aspect (spec-conformance / architecture / security) を手動サブエージェント並列で実行し PR #119 にコメント post。owner 単一で self-approve 不可のため `gh pr merge --merge` で通常マージ。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替)
+(A1 は `implementation-workflow` Phase 0-9 の枠組みで進めたが、`code-reviewer` / `pr-poller` / `roadmap-tracker` が skeleton 段階のため手動補助で実施。`code-reviewer` は 3 aspect (spec-conformance / architecture / security) を手動サブエージェント並列で実行し PR #119 にコメント post。owner 単一で self-approve 不可のため `gh pr merge --merge` で通常マージ。PR #120 は `roadmap-tracker` Phase 8 自動同期の手動代替)
+
+(A2-1 は `implementation-workflow` Phase 0-9 の枠組みで進めた最初の EPIC 配下 PR。`code-reviewer` 4 aspect (spec-conformance / architecture / security / code-quality) を手動サブエージェント並列で実行し PR #121 にコメント post。Critical 1 (plan.md SSoT 矛盾) を fix loop で commit `2e820bc` で解消。owner 単一で self-approve 不可のため `gh pr merge --merge` で通常マージ (squash merge、commit `feb41b5`)。本 PR (`harness/roadmap-mirror-a2-1`) は `roadmap-tracker` Phase 8 自動同期の手動代替)
 
 ## 着手順とブロック関係
 
@@ -100,15 +103,17 @@ gantt
 | 2026-05-17 | A1 status を proposed → in-progress | PLAN-001 (ADR 0001-0027 一括起票) 作業着手、worktree feature/A1-adr-bootstrap で起草中 |
 | 2026-05-17 | A1 status を in-progress → completed | PR #119 (commit `7f155b5`) で ADR 0001-0027 一括起票が merge 完了、PR #120 で `roadmap-tracker` Phase 8 自動同期の手動代替を実施 |
 | 2026-05-17 | A2 status を proposed → in-progress + EPIC-A2 を 5 PR に分割 (A2-1〜A2-5) | B0 (96 files / +5408 行) のレビュー負荷上限に近く、A2 全体は B0 を超える規模が想定されるため。A1 レトロ Try「巨大 PR の aspect 並列 review における入力分割」と整合 |
+| 2026-05-17 | A2-1 (EPIC-A2 配下、初の EPIC PR) マージ完了 (PR #121、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、EPIC-A2 起票、rules / docs / template 索引基盤を整備。後続 A2-2 / A2-4 並走着手の前提が整う。本 PR (`harness/roadmap-mirror-a2-1`) は `roadmap-tracker` Phase 8 自動同期の手動代替 |
 
 ## 次の推奨着手 (並行実装観点)
 
-`roadmap-tracker` Skill が更新する想定。A1 マージ後・A2-1 着手時点の手動更新例:
+`roadmap-tracker` Skill が更新する想定。A2-1 マージ後 (PR #121、commit `feb41b5`) の手動更新例:
 
-1. **A2-1 (A1 レトロ即時消化 + ハーネス即時改善)** — 現 worktree `feature/A2-rules-docs-extension` で着手中、`.claude/rules/` の一部と `docs/{adr/README,harness/learnings}` を touch
-2. **A2-4 (docs/ コア + runbooks 拡充)** — A2-1 マージ後に並走可 (`docs/` のみ touch、`.claude/rules/` と衝突しない)
-3. **A2-2 (rules 実装・コード系本格化)** — A2-1 マージ後に並走可 (`.claude/rules/` のみ touch、`docs/` と衝突しない)
-4. **A3 着手は EPIC-A2 完了後** — ADR + 本格化された rules を参照する Skill 群実装のため
+1. **A2-4 (docs/ コア + runbooks 拡充)** — `docs/` のみ touch、`.claude/rules/` と衝突しない。別 worktree で並走着手可
+2. **A2-2 (rules 実装・コード系本格化)** — A2-4 と並走可 (touch ファイル重複ゼロ)。別 worktree で並走着手可
+3. **A2-3 (rules プロセス系) 着手は A2-2 完了後** (`.claude/rules/rules-index.md` の連続編集回避のため)
+4. **A2-5 (docs/architecture + api) 着手は A2-4 完了後または並走** (`docs/` 内のサブツリーが異なれば衝突なし)
+5. **A3 着手は EPIC-A2 完了後** — ADR + 本格化された rules を参照する Skill 群実装のため
 
 ## 関連
 


### PR DESCRIPTION
---
type: harness
related_plan: —
related_epic: EPIC-A2 / EPIC-000
related_adrs: []
related_specs: []
expected_modules:
  - docs/harness/roadmap.md
  - docs/epics/EPIC-A2-rules-docs-extension/{roadmap,progress}.md
  - docs/epics/EPIC-000-harness-foundation/roadmap.md
---

## 概要

A2-1 PR #121 (merge commit `feb41b5`、merged at 2026-05-17T09:50:45Z) の merge 完了を 4 ロードマップに片方向ミラー反映する (R-34)。`roadmap-tracker` Skill が A3 で本格化するまでの間、手動代替として PR #118 (B0)・PR #120 (A1) と同じパターン。

## 関連

- 元 PR: [#121](https://github.com/subroh0508/colormaster/pull/121) feat(harness): A2-1 A1 レトロ即時消化 + EPIC-A2 起票
- Epic: EPIC-A2-rules-docs-extension (A2-1〜A2-5、本 PR で A2-1 行を `completed` 化) / EPIC-000-harness-foundation (A2 行の進捗を A2-1 完了で更新)

## PR の種別

- [x] **その他** (`roadmap-tracker` Phase 8 自動同期の手動代替、PR #118 / PR #120 と同パターン)

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 |
|---|---|---|
| [#121](https://github.com/subroh0508/colormaster/pull/121) | — (roadmap mirror、KPT は別途 pr-retrospective で生成予定) | — |

## 変更内容

| 区分 | パス | 変更内容 |
|---|---|---|
| docs | `docs/harness/roadmap.md` | 完了根拠表に A2-1 (EPIC-A2 配下) 行追加、注釈テキストに A2-1 が `implementation-workflow` Phase 0-9 の枠組みで進めた最初の EPIC PR で `code-reviewer` 4 aspect 並列 review + fix loop で Critical 1 解消したこと、本 PR が `roadmap-tracker` Phase 8 自動同期の手動代替であることを追記、着手順変更履歴に A2-1 マージ完了エントリ append、次の推奨着手を A2-1 マージ後の手動更新例に更新 (A2-4 / A2-2 並走着手、A2-3 / A2-5 直列) |
| docs | `docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` | A2-1 行 status を in-progress → completed、完了根拠列に PR #121 + commit `feb41b5` を記録、完了根拠表に A2-1 行追加、着手順変更履歴に A2-1 マージ完了エントリ append、次の推奨着手をマージ後の手動更新例に更新 |
| docs | `docs/epics/EPIC-A2-rules-docs-extension/progress.md` | A2-1 実装の時系列を Phase 1-9 で記録 (Draft PR 起票 → code-reviewer 4 aspect 並列 review → fix loop commit `2e820bc` → Ready 昇格 → merge `feb41b5` → Phase 8 手動代替 (本 PR) → Phase 9 worktree cleanup)、マイルストーン「A2-1 マージ」を達成済に更新 |
| docs | `docs/epics/EPIC-000-harness-foundation/roadmap.md` | A2 行の status / 完了根拠列に A2-1 完了の参照を追加、着手順変更履歴にエントリ append |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 0 | 0 | 0 | 0 |
| `[skill]` | 0 | 0 | 0 | 0 |
| `[template]` | 0 | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

本 PR は roadmap mirror のため KPT 起点ではなく、ハーネス改善提案は対象外。

## 受け入れ基準 (AC)

- [x] AC-1: `docs/harness/roadmap.md` の完了根拠表に A2-1 行が追加され、PR #121 リンク + commit `feb41b5` + 主要ファイルが記録されている
- [x] AC-2: `docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` の A2-1 行が `in-progress` → `completed`、完了根拠表に A2-1 行が追加されている
- [x] AC-3: `docs/epics/EPIC-A2-rules-docs-extension/progress.md` に A2-1 Phase 1-9 の時系列が記録されている
- [x] AC-4: `docs/epics/EPIC-000-harness-foundation/roadmap.md` の A2 行に A2-1 完了の参照が追加されている
- [x] AC-5: plan.md / EPIC-A2 README.md 本体への逆同期がない (片方向ミラー R-34 遵守)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降、本 PR 時点では未導入のため未検証)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、同上)
- [x] (commit-msg hook) Conventional Commits 形式で commit subject 通過、subject 52 文字 (72 字推奨範囲内)

## レビュー観点

- 完了根拠表の主要ファイル列の網羅性 (実 PR #121 が touch した 24 ファイル + fix commit `2e820bc` の追加 6 ファイルを EPIC-A2 roadmap.md 完了根拠で網羅)
- 着手順変更履歴の文言が「`roadmap-tracker` Phase 8 自動同期の手動代替」と明示しているか (R-36 経過措置記録)
- 「次の推奨着手」が A2-1 マージ後の状況 (A2-4 / A2-2 並走着手、A2-3 / A2-5 直列) を反映しているか
- ハーネス中核 Skill (`implementation-workflow` / `code-reviewer` / `roadmap-tracker` / `pr-poller`) への影響: なし (roadmap mirror のみ、Skill 本格化は A3)

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown,roadmap}.md` の規約を確認した (本 PR で更新した `.claude/rules/roadmap.md` の手動マージ時同 PR 更新ルールに準拠)
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須)
- [x] PII / Secrets が diff に含まれていない (目視確認済、本 PR は roadmap 更新のみで PII 流入経路なし)
- [x] Epic 配下 PR: `roadmap-tracker` が skeleton 段階のため `docs/harness/roadmap.md` を手動更新、`.claude/rules/roadmap.md` (PR #121 で追加) の「手動マージ時同 PR 更新ルール」に準拠
- [x] status ラベル変更時: `rules-index.md` の status 語彙 (`skeleton (B0)` / `planned (X)` / `living`) を遵守 (本 PR は ロードマップ項目の status を `in-progress` → `completed` で `living` 文書を更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)