### PR TITLE
feat(harness): A2-2 rules 実装・コード系本格化

### DIFF
--- a/.claude/rules/adr.md
+++ b/.claude/rules/adr.md
@@ -1,14 +1,14 @@
 ---
 id: rules-adr
 title: ADR 起票基準と書式
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "docs/adr/**/*.md"
   - ".claude/skills/adr-author/**"
-related_plan: docs/harness/plan.md §4.5
 related_adrs:
   - ADR-0001
+  - ADR-0027
 ---
 
 # adr.md — ADR 起票基準と書式
@@ -16,6 +16,7 @@ related_adrs:
 > Michael Nygard の原則 ("Architecturally Significant Decisions" のみ記録、
 > "Any Decision Records" ではない) + AWS / Microsoft / Google / Martin Fowler の
 > ADR ガイドラインに準拠。詳細は ADR 0001 を Single Source of Truth とする。
+> Plan / Epic / 補助 rule との責務分離は本ルール §他の記録方法を参照。
 
 ## 起票基準: 以下の 2 つ以上を満たすときに ADR を起こす
 
@@ -67,15 +68,66 @@ related_adrs:
 ## 採番・命名・ステータス
 
 - 連番、4 桁ゼロパディング (`0001`, `0002`, ...)
-- ファイル名: `{NNNN}-{kebab-case-title}.md`
+- ファイル名: `ADR-{NNNN}-{kebab-case-title}.md`
 - タイトル: 簡潔・現在形・断定的
 - ステータス: `proposed` → `accepted` → `deprecated` | `superseded by ADR-NNNN` (MADR 4 状態)
 - `accepted` 以降は immutable。変更時は新 ADR を起こし旧 ADR を `Superseded by` でリンク
 - 採番欠番は実装前なら整理可、運用後は番号維持で `withdrawn` を許容
 - **言語は日本語** (ADR 0027)
 
+## 本文構造 (`docs/adr/template.md` と整合)
+
+```markdown
+---
+id: ADR-NNNN
+title: <日本語タイトル>
+status: proposed | accepted | deprecated | superseded
+date: YYYY-MM-DD
+related_epics:
+  - EPIC-NNN
+related_plans:
+  - PLAN-NNN
+related_specs:
+  - SPEC-NNN-N
+superseded_by: ADR-NNNN | null
+supersedes:
+  - ADR-NNNN
+---
+
+# ADR-NNNN: <タイトル>
+
+## ステータス
+
+## コンテキスト
+
+## 決定
+
+## 影響
+
+## 代替案
+```
+
+## 機械検証 (A6 で導入)
+
+- Gradle カスタムタスクで以下を検証 (§5.2):
+  - `id` の正規表現 (`^ADR-\d{4}$`) とファイル名整合
+  - `superseded_by` / `supersedes` の相互参照が実在
+  - `accepted` 以降のステータスで本文末尾の immutable 性 (git blame で改変検出は人間レビュー任せ)
+  - `docs/adr/README.md` の索引行と本体 status / title の整合
+
+## Gotchas
+
+- **`accepted` 以降は本文を改変しない**。誤記訂正でも新 ADR を起こすか、`docs/adr/README.md` 側に正誤表を追記
+- 補助 Skill / 撤回コスト低の方針は ADR 化見送り → `.claude/rules/*` で運用 (例: `roadmap.md` / `commit-message.md` 等)
+- ADR 起票判断は `docs/harness/plan.md` §4.5 の判断フロー Mermaid に従う
+- 関連 SPEC / Epic / Plan / ADR の双方向リンクは **frontmatter で管理**、本文に手書きしない (機械検証対象)
+
 ## 関連
 
 - ADR 0001 (本ルールの Single Source of Truth)
-- `docs/adr/template.md`
+- ADR 0027 (テンプレート言語 / docs 構造)
+- `docs/adr/README.md` (ADR 0001-0027 索引)
+- `docs/adr/template.md` (ADR 本体テンプレ)
 - `docs/harness/plan.md` §4.5 (判断フロー Mermaid)
+- `.claude/skills/adr-author/SKILL.md`
+- `.claude/rules/{plan,epic,docs-structure}.md`

--- a/.claude/rules/backend-auth.md
+++ b/.claude/rules/backend-auth.md
@@ -1,0 +1,117 @@
+---
+id: rules-backend-auth
+title: Backend 認証 (GIS ID Token + JWKS)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "backend/**/*.kt"
+  - "core/network/auth/**/*.kt"
+  - "docs/api/auth.md"
+related_adrs:
+  - ADR-0011
+  - ADR-0020
+---
+
+# backend-auth.md — Backend 認証 (GIS ID Token + JWKS)
+
+> Firebase Authentication 撤去 (ADR 0011) に伴い、**Google Identity Services (GIS)** で
+> ID Token を取得し、Backend (Ktor Server) で **JWKS 検証 + uid 抽出** を行う規約。
+> PII 最小化 (ADR 0020) のため Backend に保存するのは **`uid` (sub claim) のみ**。
+
+## 認証フロー
+
+```text
+[ClientApp]
+    1. GIS Sign-In ボタン押下 → Google OAuth flow
+    2. ID Token (JWT) を取得
+    3. 以降のリクエストに Authorization: Bearer <id_token> header
+
+[Backend (Cloud Run)]
+    4. ID Token を JWKS で検証 (signature / iss / aud / exp)
+    5. sub claim を uid として抽出
+    6. users.db の users テーブルで uid を確認/挿入
+    7. リクエスト処理
+```
+
+## ClientApp 側 (`core/network/auth/*`)
+
+```kotlin
+// commonMain
+interface AuthClient {
+    suspend fun signIn(): Result<IdToken>
+    suspend fun signOut()
+    val idToken: StateFlow<IdToken?>
+}
+
+// platform 別 actual で GIS SDK 呼び出し
+```
+
+- platform 別 actual: Android (`Identity.getSignInClient` / Credential Manager API)、Wasm (Google Identity Services JS lib)、Desktop (OAuth browser flow)
+- ID Token は **memory のみで保持** (永続化禁止、PII 最小化)
+- 期限切れ (`exp` 経過) 時は自動 re-fetch
+
+## Backend 側 (Ktor) の検証
+
+```kotlin
+fun Application.installAuth() {
+    install(Authentication) {
+        jwt("gis") {
+            verifier(JwkProvider(URL(jwksUrl)), audience) {
+                acceptIssuer("https://accounts.google.com")
+            }
+            validate { credential ->
+                val sub = credential.payload.subject ?: return@validate null
+                Principal(uid = sub)
+            }
+        }
+    }
+}
+
+fun Route.protectedRoutes() {
+    authenticate("gis") {
+        get("/me") { ... }
+    }
+}
+```
+
+- **JWKS endpoint**: `https://www.googleapis.com/oauth2/v3/certs`
+- **issuer**: `https://accounts.google.com` または `accounts.google.com`
+- **audience**: GIS Client ID (Cloud Run env var `GIS_CLIENT_ID`)
+- 検証失敗 → 401 Unauthorized
+
+## uid の取り扱い
+
+- **`users.db` の `users` テーブルには `uid TEXT PRIMARY KEY` のみ保存** (ADR 0020、`pii.md` 厳守)
+- メールアドレス / 表示名 / プロフィール画像 URL は **memory cache (TTL 15 分)** で都度取得 (`pii.md` 参照)
+- 初回ログイン時に `INSERT INTO users(uid) VALUES (?)` で row 作成
+
+## userinfo の取得 (display name / email / picture)
+
+- Backend が GIS userinfo endpoint (`https://www.googleapis.com/oauth2/v3/userinfo`) を Bearer token で叩く
+- レスポンスは memory cache (TTL 15 分) に保持、DB に persist しない
+- ClientApp が `/me` endpoint を叩くと Backend が cache → fallback で userinfo を返却
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `backend/**/*.kt` の `users` テーブル schema (SqlDelight) に `email` / `display_name` / `picture` columns が含まれない (`pii.md` 統合)
+  - `core/network/auth/*` に Firebase Authentication SDK の import がない (`firebase-boundary.md`)
+- **OpenAPI spec** (`docs/api/colormaster-api.yaml`、A2-5 で本格化) と Ktor route の整合検証 (将来)
+
+## Gotchas
+
+- **GIS ID Token の `aud` は GIS Client ID** (Backend が発行した token ではない、Google が発行)
+- **`acceptIssuer` で `accounts.google.com` (https 無し) と `https://accounts.google.com` の両方を許可** する (Google が両方 issue する場合あり)
+- **JWKS cache**: `JwkProvider` 内蔵 cache (TTL 10 分) を使う、毎回 fetch するとレイテンシ悪化
+- **ID Token のリフレッシュ**: GIS は ID Token のみ提供 (Access Token / Refresh Token は別 API)。期限切れ時は再 sign-in flow
+- **Backend が ClientApp の認証情報を log に出さない** (`pii.md` / `secrets.md` redaction、Authorization header sanitize)
+- ローカル開発時の GIS Client ID は **dev 用 OAuth Client** を別途作成 (本番 Client ID を流用しない)
+
+## 関連
+
+- ADR 0011 (Firebase → GIS 移行)
+- ADR 0020 (PII 保護)
+- GIS docs: https://developers.google.com/identity
+- JWKS RFC 7517: https://datatracker.ietf.org/doc/html/rfc7517
+- `.claude/rules/{firebase-boundary,no-firebase,pii,secrets,sqlite-data-file,network-client}.md`
+- `docs/api/auth.md` (A2-5 で本格化)

--- a/.claude/rules/cloud-run-deploy.md
+++ b/.claude/rules/cloud-run-deploy.md
@@ -1,0 +1,157 @@
+---
+id: rules-cloud-run-deploy
+title: Cloud Run デプロイ規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "Dockerfile"
+  - ".dockerignore"
+  - "backend/**"
+  - ".github/workflows/deploy-backend.yml"
+related_adrs:
+  - ADR-0009
+  - ADR-0020
+  - ADR-0021
+  - ADR-0022
+---
+
+# cloud-run-deploy.md — Cloud Run デプロイ規約
+
+> Backend は **Google Cloud Run** にデプロイ (ADR 0009)。コンテナ起動時に Litestream で
+> R2 から `users.db` を restore し、Ktor Server で API を提供する。**`min-instances=0`**
+> でコスト最小化、cold start ~5s を許容 (詳細は本 rule §パフォーマンス参照)。
+
+## デプロイ構成
+
+| 項目 | 値 | 根拠 |
+|---|---|---|
+| Region | `asia-northeast1` (東京) | 国内ユーザー向けレイテンシ |
+| Min instances | 0 | コスト最小化 (cold start 許容) |
+| Max instances | 5 | スパイクトラフィック上限 (Phase B-C で再評価) |
+| Memory | 512 MiB | Ktor + SQLite + Litestream の最小構成 |
+| CPU | 1 | 同上 |
+| Concurrency | 80 | Cloud Run デフォルト |
+| Service Account | `cloud-run-backend@<project>.iam.gserviceaccount.com` | R2 / Secret Manager アクセス用 |
+
+## Dockerfile 規約
+
+```dockerfile
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
+# Litestream バイナリ取得
+RUN apk add --no-cache curl bash && \
+    curl -L https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz \
+        | tar xz -C /usr/local/bin/
+
+WORKDIR /app
+
+# アイドル情報 DB (read-only) は焼込み
+COPY data/idols.db /app/data/idols.db
+
+# Backend JAR
+COPY backend/build/libs/backend-all.jar /app/backend.jar
+
+# users.db は image に含めない (Litestream restore で hydrate)
+# COPY data/users.db ❌ 禁止
+
+# 起動スクリプト
+COPY scripts/cloud-run-start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+EXPOSE 8080
+CMD ["/app/start.sh"]
+```
+
+- **`data/users.db` を COPY しない** (`.dockerignore` で除外、`db-protection.md` 必須項目)
+- **Litestream バイナリ取得**: pin した version (`v0.3.13`) でハッシュ検証推奨 (将来追加)
+- Base image は **`alpine` 系** で軽量化、JRE 21 を使用 (Kotlin 2.0+ 対応)
+
+## 起動スクリプト (`scripts/cloud-run-start.sh`)
+
+```bash
+#!/bin/bash
+set -e
+
+# Litestream restore (R2 から users.db を hydrate)
+litestream restore -if-replica-exists -config /etc/litestream.yml /data/users.db
+
+# Backend 起動 (Litestream replicate を background で起動)
+litestream replicate -config /etc/litestream.yml &
+
+# Ktor Server 起動
+exec java -jar /app/backend.jar
+```
+
+- restore 失敗時は Backend 起動を継続 (新規 DB として動作)
+- Litestream config (`litestream.yml`) は **R2 endpoint + bucket** を環境変数経由で参照、詳細は `r2-litestream.md`
+
+## 環境変数 / Secret Manager
+
+| 変数 | 用途 | 取得元 |
+|---|---|---|
+| `R2_ACCESS_KEY_ID` | R2 認証 | Google Cloud Secret Manager |
+| `R2_SECRET_ACCESS_KEY` | R2 認証 | 同上 |
+| `R2_ENDPOINT` | R2 endpoint URL | 同上 |
+| `IMASPARQL_BASE_URL` | im@sparql endpoint | Cloud Run env (公開可) |
+| `GIS_CLIENT_ID` | Google Identity Services client ID | Cloud Run env (公開可) |
+| `JWKS_URL` | GIS JWKS endpoint | Cloud Run env |
+
+- Secret Manager 参照は Cloud Run の `--update-secrets` フラグ経由 (Service Account が `secretAccessor` ロール保持)
+- 公開可能な設定 (URL 等) は env var、秘密情報は Secret Manager に分離
+
+## CI / CD
+
+```yaml
+# .github/workflows/deploy-backend.yml (概略)
+on:
+  push:
+    branches: [master]
+    paths: ['backend/**', 'Dockerfile', '.github/workflows/deploy-backend.yml']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions: { id-token: write, contents: read }  # Workload Identity Federation
+    steps:
+      - checkout
+      - setup-gcloud (with WIF)
+      - run: ./gradlew :backend:shadowJar
+      - run: gcloud builds submit --tag asia-northeast1-docker.pkg.dev/...
+      - run: gcloud run deploy backend --image=...
+```
+
+- **Workload Identity Federation** で GitHub Actions → GCP 認証 (Service Account key は使わない)
+- 本番デプロイは **master ブランチ** のみ、PR では deploy しない
+- **GitHub Actions で Claude API を呼ばない** (ADR 0017)
+
+## パフォーマンス
+
+- **Cold start**: ~5s (Litestream restore + Kotlin JVM 起動)
+- **温まると ~200ms / request** を目標
+- min-instances=0 でコスト最小化、トラフィック増時は max-instances=5 までスケール
+- Phase B-C で **Cloud Run gen2** + **CPU always allocated** の有償オプション再評価
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `Dockerfile` 内に `COPY data/users.db` パターンが存在しない (`db-protection.md` 必須)
+  - `.dockerignore` が必須項目 (`data/users.db*` / `.env*` / `*-credentials.json` / `service-account*.json` / `.claude/oauth-tokens*`) を含む
+  - `Dockerfile` の base image が allowed list (`eclipse-temurin:21-jre-alpine` 等) 内
+- **CI** で Docker image の secret scan (`trivy` / `dockle` 候補、A6 で導入)
+
+## Gotchas
+
+- **min-instances=0 の cold start は ~5s**、即時応答が必要な endpoint はキャッシュ層で吸収
+- **Litestream restore 中に Backend 起動を待たない**ことに注意 (起動スクリプトで sequential 実行)
+- **Cloud Run の `--allow-unauthenticated` を使う場合**は Ktor 側で GIS ID Token 検証必須 (`backend-auth.md`)
+- **GitHub Actions の OIDC token を Service Account key で代用しない** (key 漏洩リスク、WIF が標準)
+- ローカル開発は `docker compose up` で Backend + Fuseki を起動 (`docs/runbooks/local-development.md`、A2-4 で本格化)
+
+## 関連
+
+- ADR 0009 (Backend Cloud Run)
+- ADR 0020 (PII 保護)
+- ADR 0021 (Secrets 管理)
+- ADR 0022 (Cloudflare Pages + R2)
+- `.claude/rules/{db-protection,r2-litestream,backend-auth,secrets,sqlite-data-file}.md`
+- `docs/runbooks/release.md` (B0 配置済、Phase B-C で本格化)

--- a/.claude/rules/cloudflare-pages.md
+++ b/.claude/rules/cloudflare-pages.md
@@ -1,0 +1,124 @@
+---
+id: rules-cloudflare-pages
+title: Cloudflare Pages デプロイ規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".github/workflows/deploy-pages.yml"
+  - "wrangler.toml"
+  - "**/wasmJsMain/resources/**"
+related_adrs:
+  - ADR-0022
+  - ADR-0012
+---
+
+# cloudflare-pages.md — Cloudflare Pages デプロイ規約
+
+> Wasm/JS フロントエンド (Compose Multiplatform 配下 `wasmJsMain`) を **Cloudflare Pages**
+> にデプロイ (ADR 0022)。Firebase Hosting からの移行 (ADR 0011)、本格化は Phase C7 だが
+> 本 rule で起草。Cloudflare MCP (ADR 0024) でデプロイ操作 / ドメイン管理を行う。
+
+## デプロイ構成
+
+| 項目 | 値 | 根拠 |
+|---|---|---|
+| Project name | `colormaster` (Cloudflare Pages) | — |
+| Production branch | `master` | — |
+| Preview branches | PR ごとに自動生成 | レビュー時の動作確認 |
+| Build command | `./gradlew :app:wasmJsBrowserDistribution` | Compose Multiplatform Wasm build |
+| Build output | `app/build/dist/wasmJs/productionExecutable` | Compose Multiplatform 標準出力 |
+| Functions | 不使用 (静的配信のみ) | Backend は Cloud Run 別運用 |
+| Custom domain | `colormaster.subroh0508.net` (将来) | Phase C7 で確定 |
+
+## CI / CD
+
+```yaml
+# .github/workflows/deploy-pages.yml (概略)
+on:
+  push:
+    branches: [master]
+    paths: ['app/**', 'core/**', '.github/workflows/deploy-pages.yml']
+  pull_request:
+    paths: ['app/**', 'core/**']
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - checkout
+      - setup-jdk21
+      - run: ./gradlew :app:wasmJsBrowserDistribution
+      - uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: colormaster
+          directory: app/build/dist/wasmJs/productionExecutable
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- **`CLOUDFLARE_API_TOKEN`**: GitHub Secrets で管理 (90 日 ローテーション、`secrets.md`)
+- **`CLOUDFLARE_ACCOUNT_ID`**: 同上 (公開可能だが Secrets 経由で統一)
+- PR では preview deployment、master では production deployment
+- **GitHub Actions で Claude API は呼ばない** (ADR 0017)
+
+## Headers と Security
+
+`public/_headers` (Cloudflare Pages の routing config) で以下を設定:
+
+```text
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https://<backend-cloudrun-url> https://accounts.google.com https://sparql.crssnky.xyz; img-src 'self' data: https://lh3.googleusercontent.com; style-src 'self' 'unsafe-inline'
+```
+
+- **CSP**: `wasm-unsafe-eval` 必須 (Compose Multiplatform Wasm の制約)
+- `connect-src` に Backend (Cloud Run) と im@sparql endpoint を allowlist
+- `img-src` に GIS userinfo の avatar URL を allowlist (PII 含むため `pii.md` で別途 redact)
+
+## SPA routing
+
+```text
+# public/_redirects
+/*  /index.html  200
+```
+
+- Compose Multiplatform Web は SPA、全 path を `index.html` に return (Navigation 3 で内部 routing)
+
+## ローカル開発との切替
+
+- ローカル: `./gradlew :app:wasmJsBrowserDevelopmentRun` で開発サーバ起動
+- 本番: Cloudflare Pages の URL
+- Backend URL は `BuildKonfig.BACKEND_BASE_URL` で切り替え (local: `http://localhost:8080` / prod: Cloud Run URL)
+
+## Cloudflare MCP の活用 (ADR 0024)
+
+- デプロイ前検証 / Pages project 設定変更 / DNS 操作は **Cloudflare MCP** (`mcp-usage.md`) 経由
+- API Token は MCP OAuth フローで管理、`.claude/oauth-tokens*` に保存 (`secrets.md`)
+
+## 機械検証 (A6 / C7 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `app/build/dist/wasmJs/productionExecutable` の SHA256 hash が再現可能
+  - `_headers` に CSP / HSTS が含まれる
+- **CI で Lighthouse 等の web vitals check** (将来、Phase C7)
+
+## Gotchas
+
+- **Cloudflare Pages の build minutes 上限** (free plan で月 500 build) に注意。`paths` filter で不要な build を抑制
+- **Wasm artifact のサイズ膨張**: Compose Multiplatform Wasm bundle は MB 級になりやすい、`./gradlew :app:wasmJsBrowserDistribution --info` で size 確認
+- **CSP `wasm-unsafe-eval`** は Compose Multiplatform の Wasm runtime に必須、外すと動かない
+- **Preview deployment のドメイン**: `*.colormaster.pages.dev` 等、GIS Client ID の Authorized JavaScript origins に登録忘れに注意 (本番 / dev を別 Client ID にする運用と整合)
+- 旧 Firebase Hosting 設定 (`firebase.json` / `.firebaserc`) は撤去 (`removed-modules.md`)
+
+## 関連
+
+- ADR 0022 (Cloudflare Pages + R2)
+- ADR 0012 (旧 JS 実装撤去 → Wasm 統一)
+- ADR 0024 (MCP 採用、Cloudflare MCP)
+- `.claude/rules/{wasm-compat,r2-litestream,mcp-usage,secrets,removed-modules}.md`
+- Cloudflare Pages: https://developers.cloudflare.com/pages/

--- a/.claude/rules/composable.md
+++ b/.claude/rules/composable.md
@@ -1,0 +1,123 @@
+---
+id: rules-composable
+title: Composable Screen の実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/features/**/*Screen.kt"
+  - "feature/**/*Screen.kt"
+  - "core/features/**/composable/**/*.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0006
+  - ADR-0023
+---
+
+# composable.md — Composable Screen の実装規約
+
+> Compose Multiplatform (ADR 0002) における `@Composable` 関数の構造・命名・Preview 必須化・
+> design tokens 強制を規定する。`@Composable` の引数 contract は UiState 入力 / event callback 出力で固定し、
+> Screen から ViewModel への直接参照を禁じる。
+
+## 配置と命名
+
+- 配置: `core/features/<feature>/src/commonMain/kotlin/net/subroh0508/colormaster/features/<feature>/composable/`
+- Screen 命名: `<機能>Screen.kt` (例: `SearchIdolsScreen.kt` / `PenlightScreen.kt`)
+- 共通 component 命名: `<役割>.kt` (例: `IdolListItem.kt` / `LoadingOverlay.kt`)
+
+## Screen の関数シグネチャ
+
+```kotlin
+@Composable
+fun SearchIdolsScreen(
+    uiState: SearchIdolsUiState,
+    onAction: (SearchIdolsUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // ...
+}
+```
+
+- **第 1 引数 `uiState: *UiState`** (画面に表示する全状態)
+- **第 2 引数 `onAction: (*UiAction) -> Unit`** (ViewModel への入力 callback)
+- **第 3 引数以降 `modifier: Modifier = Modifier`** + 必要に応じ ナビゲーション callback (`onNavigateToDetail: (IdolId) -> Unit`)
+- **ViewModel を直接引数に取らない** (Preview / テスト容易性のため、wrapper 関数 (`SearchIdolsRoute`) で ViewModel を解決)
+
+## Route wrapper
+
+```kotlin
+@Composable
+fun SearchIdolsRoute(
+    viewModel: SearchIdolsViewModel = koinViewModel(),
+    onNavigateToDetail: (IdolId) -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    SearchIdolsScreen(
+        uiState = uiState,
+        onAction = viewModel::dispatch,
+        // ...
+    )
+}
+```
+
+- `*Route` 関数で ViewModel を解決し、`*Screen` に UiState / dispatch を渡す
+- ナビゲーション graph の destination として登録するのは `*Route`
+- `*Screen` は state-less に近づき、Preview / screenshot test が容易
+
+## Preview 必須化
+
+```kotlin
+@Preview
+@Composable
+private fun SearchIdolsScreenPreview() {
+    AppTheme {
+        SearchIdolsScreen(
+            uiState = SearchIdolsUiState(
+                query = "幻奏",
+                results = listOf(/* sample */),
+            ),
+            onAction = {},
+        )
+    }
+}
+```
+
+- **全 `*Screen` Composable に `@Preview` を 1 つ以上設置必須** (`ui-snapshot.md` 参照、A10 で Konsist 自動検出)
+- Preview 関数は `private` 可視性、命名 `<Screen>Preview` / `<Screen>EmptyPreview` / `<Screen>LoadingPreview` 等
+- `AppTheme` でラップ (design tokens を適用)、`Preview` 引数で device / locale / theme を切り替え
+
+## design tokens (DESIGN.md 3 階層) の強制
+
+- **hex 直書き禁止** (`Color(0xFFFF0000)` 等)、`MaterialTheme.colorScheme.primary` 等の Semantic token のみ使用
+- **dp / sp の magic number 禁止** (`Padding(16.dp)` 等)、`AppDimensions.spacing.medium` (将来定義) または Compose `MaterialTheme.dimensions.*` 経由
+- 詳細は `.claude/rules/design-tokens.md` (A2-3 で本格化)
+
+## i18n 強制
+
+- 文字列 literal を `@Composable` 内に直書きしない (`Text("Search")` 禁止)
+- `stringResource(Res.string.search_button)` 経由で `compose-resources` の `strings.xml` から取得
+- 詳細は `.claude/rules/i18n.md` 参照 (ADR 0006)
+
+## 機械検証 (A6 / A7 / A10 で導入)
+
+- **Konsist** で以下を強制 (R-22 / R-23):
+  - `*Screen` 関数の第 1 引数が `uiState: *UiState`
+  - `*Screen` 関数の第 2 引数が `onAction: (*UiAction) -> Unit`
+  - `*Screen` 関数に対応する `@Preview` が同ファイル内に 1 つ以上存在
+  - Composable 内で hex 直書き (`Color(0x...)`) / dp/sp magic number / 文字列 literal が出現しない
+- **Roborazzi** で 4 パターン baseline (mobile/desktop × Light/Dark)、`ui-snapshot.md` 参照
+
+## Gotchas
+
+- **`@Composable` 内で `viewModel()` / `koinViewModel()` を呼ぶのは `*Route` のみ**。`*Screen` は ViewModel 非依存
+- **`remember { mutableStateOf(...) }` で local state を持つ場合は注意**。再構成で消えるべき transient state (テキスト入力等) のみ許容、永続化が必要なものは UiState に乗せる
+- **`LaunchedEffect` のキー設計**。`uiState.event` で発火する場合、`key1 = uiState.event` で重複起動を防ぐ
+- **Wasm 互換性に注意**。`java.awt.*` / `android.content.*` 等のプラットフォーム特有 API を `commonMain` で参照しない (`wasm-compat.md` 参照)
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0006 (i18n + compose-resources)
+- ADR 0023 (UI/UX 凍結 三本柱: DESIGN.md + UI Inventory + Roborazzi)
+- `.claude/rules/{viewmodel,ui-state,navigation,i18n,design-tokens,ui-snapshot,wasm-compat}.md`
+- `docs/architecture/layers.md` (A2-5 で本格化)

--- a/.claude/rules/db-protection.md
+++ b/.claude/rules/db-protection.md
@@ -1,7 +1,7 @@
 ---
 id: rules-db-protection
 title: ユーザーデータ DB の保護
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "data/**"
@@ -9,7 +9,11 @@ paths:
   - "core/network/**"
   - "Dockerfile"
   - ".dockerignore"
-related_plan: docs/harness/plan.md §3.8 / ADR 0008 / ADR 0020 / ADR 0021
+related_adrs:
+  - ADR-0008
+  - ADR-0020
+  - ADR-0021
+  - ADR-0022
 ---
 
 # db-protection.md — ユーザーデータ DB の保護

--- a/.claude/rules/epic.md
+++ b/.claude/rules/epic.md
@@ -1,0 +1,123 @@
+---
+id: rules-epic
+title: Epic ディレクトリ構成 / 状態遷移
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "docs/epics/**"
+  - ".claude/skills/epic-author/**"
+related_adrs:
+  - ADR-0027
+---
+
+# epic.md — Epic ディレクトリ構成 / 状態遷移
+
+> Epic は **複数 PR にまたがる構造化された取り組み** を 1 ディレクトリで管理する記録。
+> Plan (1 PR 完結) との分担は `plan.md` 参照。起票は `epic-author` Skill 経由、
+> ロードマップ追跡対象 (`roadmap-tracker` が `docs/epics/<id>/roadmap.md` を更新)。
+
+## いつ Epic を起こすか
+
+- 複数 PR (目安: 3 PR 以上) に分割した方がレビュー / 並走 / リスク分散の観点で有利な取り組み
+- フェーズ全体 (A1-A10 / C1-C10) のうち、複数アーティファクトを跨ぐもの (例: EPIC-A2 = rules + docs)
+- 単一 PR で完結する見込みが立たない単一 Plan の昇格 (`plan.md` §Epic 昇格条件 参照)
+
+## ディレクトリ構成 (必須 5 ファイル)
+
+```text
+docs/epics/EPIC-NNN-<kebab-case-slug>/
+  README.md          # Epic 本体: 目的 / 背景 / スコープ / 構成 PR / AC
+  roadmap.md         # PR 進捗トラッカー (roadmap-tracker が更新)
+  open-questions.md  # 未解決事項 (append-only)
+  decisions.md       # 細粒度決定の記録 (ADR 昇格未満)
+  progress.md        # 時系列の進捗ログ
+```
+
+`docs/epics/template/` に各ファイルのテンプレ配置済。新規 Epic 起票時はテンプレを copy し frontmatter を埋める。
+
+## 命名規約
+
+- ディレクトリ名: `EPIC-NNN-<kebab-case-slug>` (3 桁ゼロパディング、Plan と独立採番)
+- 例: `EPIC-000-harness-foundation/` / `EPIC-A2-rules-docs-extension/` (フェーズ ID も許容)
+- `EPIC-NNN` 形式は連番、フェーズ ID (A2 / B0 / C1 等) 形式は plan.md §6 のフェーズと対応
+- スラグはタイトルから kebab-case で導出 (動詞は省略可、要件のキーワードを含める)
+
+## ステータス語彙 (`README.md` frontmatter `status`)
+
+| 値 | 意味 |
+|---|---|
+| `proposed` | 起票済み、未着手 |
+| `in-progress` | 構成 PR の少なくとも 1 つが進行中 |
+| `completed` | 構成 PR が全てマージ済み、AC 達成 |
+| `blocked` | 障壁により停止中 (`roadmap.md` の Blockers セクション参照) |
+| `abandoned` | 取り下げ (理由を `decisions.md` に記載) |
+
+## 必須 frontmatter (`README.md`)
+
+```yaml
+---
+id: EPIC-NNN
+title: <日本語タイトル>
+status: proposed | in-progress | completed | blocked | abandoned
+created_at: YYYY-MM-DD
+completed_at: YYYY-MM-DD | null
+expected_modules:
+  - <touch 予定の glob>
+related_adrs:
+  - ADR-NNNN
+related_specs:
+  - SPEC-IDOL-001-3
+---
+```
+
+各補助ファイル (`roadmap.md` / `open-questions.md` / `decisions.md` / `progress.md`) の frontmatter は `source_epic: EPIC-NNN` を必須、`status: living` で固定。
+
+## INDEX.md 更新規約
+
+- 起票時 / status 変更時に `docs/epics/INDEX.md` を更新
+- `epic-author` Skill が自動更新
+- 行構造: `| EPIC ID | タイトル | status | 構成 PR 数 | 起票日 | 完了日 |`
+
+## 自動起動フック (roadmap-tracker)
+
+- Epic 起票直後 (`epic-author` 経由) → `docs/epics/<id>/roadmap.md` 雛形生成 + `docs/harness/roadmap.md` の Epic 行追加
+- 構成 PR マージ直後 (`implementation-workflow` Phase 8) → 当該 Epic の `roadmap.md` 完了根拠表に PR 番号 + マージ日を追記、status を `in-progress` → `completed` (全 PR マージ済時)
+- 詳細は `.claude/rules/roadmap.md` §自動起動フック 参照
+
+## 補助ファイルの役割
+
+| ファイル | 役割 | 更新規約 |
+|---|---|---|
+| `README.md` | 目的 / 背景 / スコープ / 構成 PR / AC | 構成 PR 増減時に更新、AC 達成チェック |
+| `roadmap.md` | PR 進捗 / 完了根拠 / 着手順 / Open Questions / Blockers | `roadmap-tracker` が自動更新、手動マージ時は同 PR で手動更新 |
+| `open-questions.md` | 未解決事項 (起票日 / 内容 / 暫定方針 / 解決状態) | **append-only**、解決時は別行に解決日と方法を追記 |
+| `decisions.md` | ADR 昇格未満の細粒度決定 (rule の分割粒度 / docs 責務境界 / テンプレ文言) | append-only、ADR 起票基準を満たすものは `docs/adr/` に昇格してリンク |
+| `progress.md` | 時系列の進捗ログ (日付 / 出来事 / 関連 PR) | 日次 / 週次レベルの記録、マイルストーン表も含む |
+
+## Epic ⇄ Plan ⇄ ADR の責務分離
+
+`.claude/rules/plan.md` §責務分離表 参照。Epic は「複数 PR の構造化」、Plan は「単一 PR」、ADR は「アーキテクチャ的に不変な決定」。
+
+## 機械検証 (A6 で導入)
+
+- Gradle カスタムタスクで以下を検証 (§5.2):
+  - `docs/epics/EPIC-NNN-*/` ディレクトリ内に必須 5 ファイルが存在
+  - 各補助ファイルの `source_epic` が親ディレクトリ ID と一致
+  - `INDEX.md` 行と README の status 整合
+  - `expected_modules` 未記入の Epic は warning (`roadmap-tracker` の並行可否判定が機能しない)
+
+## Gotchas
+
+- **`open-questions.md` / `decisions.md` は append-only**。既存項目の削除は禁止 (解決時は別行に追記)
+- **Epic 配下 PR は Plan を起こさない**。Epic ロードマップの構成 PR 行で AC 管理
+- **status: abandoned 時もディレクトリを削除しない**。古い PR / ADR の参照が壊れるため、`decisions.md` に取り下げ理由を残す
+- フェーズ ID 形式 (`EPIC-A2`) と連番形式 (`EPIC-001`) は混在可能だが、混乱を避けるため **フェーズ ID 形式は plan.md §6 のフェーズと厳密に対応** させること
+
+## 関連
+
+- `docs/harness/plan.md` §4.1 (Epic と Plan の区別)
+- `docs/epics/INDEX.md`
+- `docs/epics/template/` (5 ファイルテンプレ)
+- `.claude/skills/epic-author/SKILL.md`
+- `.claude/skills/roadmap-tracker/SKILL.md`
+- `.claude/rules/{plan,adr,roadmap,docs-structure}.md`

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,0 +1,109 @@
+---
+id: rules-error-handling
+title: エラーハンドリング規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/**/*.kt"
+  - "feature/**/*.kt"
+  - "backend/**/*.kt"
+related_adrs:
+  - ADR-0002
+---
+
+# error-handling.md — エラーハンドリング規約
+
+> Kotlin の `Result<T>` / `runCatching` の使い分け、例外伝播ポリシー、UI への表出方法を規定。
+> Repository は例外を投げ、ViewModel が `runCatching` で wrap して UiState に反映する設計を強制。
+
+## 層ごとの方針
+
+| 層 | 方針 | 戻り値 |
+|---|---|---|
+| `core/network/*Client*` | `IOException` / `ResponseException` / `SerializationException` を投げる | DTO または `null` |
+| `core/data/Default*Repository` | network 層の例外をそのまま伝播 (wrap しない) | ドメインモデル |
+| `core/usecase` (将来) | 例外伝播のまま、業務例外 (`DomainException`) のみカスタム化 | ドメインモデル |
+| ViewModel | `runCatching { repository.xxx() }` で wrap、UiState の `error: Throwable?` に保持 | UiState |
+| `@Composable` Screen | UiState の `error` を Snackbar / Dialog で表示、`onAction(Retry)` で再試行 | Unit |
+
+## `Result<T>` の使い分け
+
+- **Repository は `Result<T>` を返さない** (例外を投げる)
+- ViewModel 内で `runCatching { ... }.onSuccess { ... }.onFailure { ... }` を使う
+- 業務例外 (`InvalidQueryException` 等) は `DomainException` 階層に定義し、ユーザー向けメッセージを `error.localizedMessage` で `stringResource` 経由のキーに mapping
+
+## ViewModel のパターン
+
+```kotlin
+private fun handleSearchClicked() {
+    viewModelScope.launch {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+
+        runCatching { repository.searchByName(_uiState.value.query) }
+            .onSuccess { results ->
+                _uiState.update { it.copy(isLoading = false, results = results) }
+            }
+            .onFailure { error ->
+                _uiState.update { it.copy(isLoading = false, error = error) }
+            }
+    }
+}
+```
+
+- `isLoading` / `error` を毎回 reset
+- `onFailure` で `error` を UiState に保持、UI 側でフィルタ / 表示
+
+## Compose Screen のパターン
+
+```kotlin
+LaunchedEffect(uiState.error) {
+    uiState.error?.let {
+        snackbarHostState.showSnackbar(
+            message = it.localizedMessageOrFallback(),
+            actionLabel = stringResource(Res.string.retry),
+        )
+    }
+}
+```
+
+- `LaunchedEffect(uiState.error)` で副作用化
+- 表示後は `onAction(ErrorDismissed)` で `error: null` に戻す (UiAction 経由)
+
+## Logging
+
+- **例外は必ず Napier / 同等 logger で出力** (`logging.md` 参照)
+- 業務例外 (`DomainException`) は `level: warn`、network / IO 例外は `level: error`
+- stack trace は `Napier.e(throwable = e)` で post、PII / Secrets が含まれていないことを確認 (`pii.md` / `secrets.md` redaction)
+
+## 禁止事項
+
+- **`try { ... } catch (e: Exception) { /* ignore */ }`** (silent swallow 禁止)
+- **`try { ... } catch (e: Throwable) { ... }`** (`Error` 系を catch しない、OOM / StackOverflow を握り潰さない)
+- **`throw RuntimeException("...")`** 直書き (業務例外は `DomainException` 階層を定義、network は Ktor の `ResponseException` 等を使う)
+- **`null` 戻りでエラー表現**: `findById(id: IdolId): Idol?` のように「見つからなかった = null」は OK、「ネットワーク失敗 = null」は禁止 (例外を投げる)
+
+## Backend (Kotlin) のエラーハンドリング
+
+- Ktor Server Application で `StatusPages` plugin により例外 → HTTP status 変換
+- ドメイン例外 → 400 / 認証例外 → 401 / not found → 404 / それ以外 → 500
+- レスポンス body は `{ error: { code: "...", message: "..." } }` 形式 (OpenAPI spec と整合)
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `core/model/**/*Repository.kt` の interface 戻り値型に `Result<*>` が含まれない
+  - `core/data/**/Default*Repository.kt` 内に `try { ... } catch (e: Exception) {}` (空 catch) パターンが存在しない
+  - top-level `throw RuntimeException(...)` の直書きが存在しない
+- **Detekt** で `SwallowedException` / `TooGenericExceptionCaught` を有効化
+
+## Gotchas
+
+- **CoroutineExceptionHandler を `viewModelScope` に attach しない**。`viewModelScope` の親 `SupervisorJob` がキャンセル隔離するため、`runCatching` で各 launch 内に閉じ込めるのが正しい
+- **`runCatching` は `CancellationException` も catch する**。`coroutineScope` でキャンセル伝播が必要な箇所では `coroutineScope { try { ... } catch (e: Exception) { ... } }` パターンで `CancellationException` を rethrow
+- **wasm-js では `Throwable.printStackTrace()` 不可**。stacktrace は Napier 経由で扱う (`logging.md` 参照)
+- ユーザー向けメッセージは i18n 必須 (`i18n.md` 参照)、技術的 detail は debug build のみ表示
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- `.claude/rules/{viewmodel,ui-state,repository,network-client,logging,i18n,pii,secrets}.md`

--- a/.claude/rules/firebase-boundary.md
+++ b/.claude/rules/firebase-boundary.md
@@ -1,0 +1,98 @@
+---
+id: rules-firebase-boundary
+title: 既存 Firebase import の境界検出
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*.kt"
+  - "**/*.kts"
+  - "firebase.json"
+  - ".firebaserc"
+  - "**/google-services.json"
+related_adrs:
+  - ADR-0011
+---
+
+# firebase-boundary.md — 既存 Firebase import の境界検出
+
+> ADR 0011 (Firebase → GIS 移行) に伴う **既存 Firebase 依存の検出と段階的撤去** を担う規約。
+> 新規追加禁止は `.claude/rules/no-firebase.md` の責務 (Skill 事前ガード)、本 rule は
+> **既存 import の検出と移行進捗の管理** (Konsist による事後検証) を担当する。
+> 二段運用と改名再評価方針は EPIC-A2 `decisions.md` 参照。
+
+## 既存 Firebase 関連の所在 (移行対象)
+
+| 種別 | 場所 | 対応 |
+|---|---|---|
+| Firebase Authentication (旧 SDK) | `core/network/auth/*` (一部) | GIS に置き換え (ADR 0011)、`core/network/auth/` 内の Firebase 依存を撤去 |
+| Firebase Firestore | `core/network/firestore/*` | Backend SQLite + Litestream + R2 に置き換え (`removed-modules.md`) |
+| `firebase.json` / `.firebaserc` | リポジトリ root | Cloud Run + Cloudflare Pages 移行完了時に削除 (ADR 0022, 0009) |
+| `google-services.json` | `android/app/` (もし存在) | Firebase SDK 撤去時に削除 |
+| `com.google.gms.google-services` plugin | `android/app/build.gradle.kts` | 同上 |
+
+## 検出パターン (Konsist)
+
+`core/**/*.kt` / `feature/**/*.kt` で以下の import が存在する箇所を **エラーとして検出**:
+
+| パターン | 例 |
+|---|---|
+| `com.google.firebase.*` | `import com.google.firebase.auth.FirebaseAuth` |
+| `dev.gitlive.firebase.*` | `import dev.gitlive.firebase.auth.FirebaseAuth` (KMP Firebase wrapper) |
+| `com.google.android.gms.tasks.*` | (Firebase の Task API) |
+
+## エスケープ (移行進行中の例外)
+
+完全撤去までの間、以下を **ホワイトリストとして許容**:
+
+```yaml
+# .claude/rules/firebase-boundary.allowlist.yaml (将来配置候補)
+allowlist:
+  - module: core/network/firestore
+    reason: ADR 0011 移行中、Phase C5 (Litestream 完成) で撤去予定
+    until: 2026-12-31
+```
+
+- ホワイトリストは **撤去予定日 (`until`) と理由必須**
+- Konsist 検証で allowlist 外の import を error、allowlist 内は warning (期限切れ時 error 化)
+- ホワイトリスト追加は人間レビューで承認必須 (auto-approve 禁止)
+
+## 撤去フロー
+
+1. 撤去対象 module を確定 (例: `core/network/firestore`)
+2. 代替実装を `core/data/*` または別 module に作成
+3. 既存 ViewModel / Repository の依存を切り替え
+4. 旧 module の `build.gradle.kts` から Firebase dependency 削除
+5. import 残骸を Konsist で検証
+6. ADR 0011 / `removed-modules.md` を更新
+7. PR で削除確定
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証 (R-22):
+  - `core/**/*.kt` / `feature/**/*.kt` の import 文に `com.google.firebase.*` / `dev.gitlive.firebase.*` が含まれない (allowlist 例外あり)
+- **Gradle カスタムタスク** で:
+  - `firebase.json` / `.firebaserc` / `google-services.json` の存在検出 (撤去 PR まで warning、撤去後は error)
+  - `gradle/libs.versions.toml` に Firebase coordinate が含まれない (`no-firebase.md` と統合)
+
+## `no-firebase.md` との責務分担
+
+| ファイル | 責務 | 検出タイミング |
+|---|---|---|
+| `no-firebase.md` | **新規追加禁止** (build 系 / Skill 起草時の事前ガード) | Skill 起草段階 / build script 検証 |
+| `firebase-boundary.md` (本 rule) | **既存 import 検出** (Kotlin source / 設定ファイル) | Konsist による事後検証 |
+
+二段運用と改名再評価方針は EPIC-A2 `decisions.md` 参照。
+
+## Gotchas
+
+- **Konsist は Kotlin file 専用** (`docs/harness/plan.md` §5.2)、`.json` / `.kts` の検出は Gradle カスタムタスクに分離
+- **import alias で偽装した Firebase 参照も検出**: `import com.google.firebase.auth.FirebaseAuth as FA` 形式も Konsist で検出可能
+- **transitively pulled Firebase**: 他 lib (Crashlytics 等) が Firebase を transitive dependency として持ち込むケースは `./gradlew :module:dependencies` で確認
+- 撤去完了後は本 rule の `paths` から該当 file pattern を削除可能 (`firebase.json` 等が存在しない状態を期待)
+
+## 関連
+
+- ADR 0011 (Firebase → GIS 移行)
+- `.claude/rules/{no-firebase,removed-modules,backend-auth}.md`
+- EPIC-A2 `decisions.md` (二段運用の判断記録)
+- `docs/architecture/infrastructure.md` (A2-5 で本格化、Firebase 撤去後の構成図)

--- a/.claude/rules/gradle.md
+++ b/.claude/rules/gradle.md
@@ -1,0 +1,150 @@
+---
+id: rules-gradle
+title: Gradle ビルド設定規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/build.gradle.kts"
+  - "settings.gradle.kts"
+  - "gradle/libs.versions.toml"
+  - "gradle.properties"
+  - "buildSrc/**"
+  - "plugins/**"
+related_adrs:
+  - ADR-0002
+  - ADR-0003
+  - ADR-0017
+---
+
+# gradle.md — Gradle ビルド設定規約
+
+> Kotlin DSL (`*.gradle.kts`) + Version Catalog (`libs.versions.toml`) + Convention plugin
+> (`plugins/` または `buildSrc/`) でビルド設定を集約。
+> Compose Multiplatform + KMP 構造 (ADR 0002 / 0003) に対応。
+
+## ビルドファイル構造
+
+```text
+gradle/libs.versions.toml       # 単一 source of truth: version + alias
+settings.gradle.kts             # subproject 列挙、include
+build.gradle.kts (root)         # 共通 buildscript / plugin
+core/<module>/build.gradle.kts  # KMP target 設定 + dependency
+plugins/src/main/kotlin/        # Convention plugin (再利用ロジック)
+```
+
+## Version Catalog 規約
+
+```toml
+[versions]
+kotlin = "2.0.0"
+compose-multiplatform = "1.6.10"
+ktor = "2.3.10"
+sqldelight = "2.0.1"
+napier = "2.7.1"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+
+[plugins]
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+```
+
+- **`libs.versions.toml` を Single Source of Truth** とし、build.gradle.kts に version 直書き禁止
+- alias は kebab-case (TOML 仕様)
+- version は `versions` セクションで集約、`version.ref` で参照
+
+## KMP target 設定 (Compose Multiplatform module)
+
+```kotlin
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    androidTarget()
+    jvm("desktop")
+    wasmJsTarget { browser() }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.ktor.client.core)
+            implementation(libs.kotlinx.coroutines.core)
+        }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
+        }
+    }
+}
+```
+
+- target: `androidTarget()` + `jvm("desktop")` + `wasmJsTarget { browser() }` を基本構成
+- Wasm 非互換 lib は対応 source set のみに配置 (`wasm-compat.md` 参照)
+- Backend module (`backend/`) は Cloud Run 用に JVM only
+
+## Convention plugin
+
+```kotlin
+// plugins/src/main/kotlin/net/subroh0508/colormaster/primitive/compose/ComposeDsl.kt
+fun KotlinMultiplatformExtension.composeTargets(...) { ... }
+```
+
+- 複数 module で共通の設定 (Android SDK version / Compose target / Kotest 設定 等) は Convention plugin に集約
+- 配置: `plugins/src/main/kotlin/net/subroh0508/colormaster/primitive/`
+- Custom plugin の `id` は `net.subroh0508.colormaster.primitive.<purpose>`
+
+## gradle.properties
+
+```properties
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+kotlin.code.style=official
+android.useAndroidX=true
+```
+
+- **`configuration-cache=true`** を必須 (build 高速化、ADR 推奨)
+- `parallel=true` + `caching=true` で multi-module build を高速化
+- 秘匿情報 (API key 等) は `gradle.properties` に書かない (`.env` / GitHub Secrets で管理、`secrets.md` 参照)
+
+## CI 起動
+
+```bash
+./gradlew check                  # lint + test 全 module
+./gradlew :module:compileKotlin  # 個別 module の compile 確認
+./gradlew assembleDebug          # Android Debug build
+```
+
+- CI (`.github/workflows/ci.yml`) で `./gradlew check` を起動 (Konsist + Detekt + Kotest 含む)
+- **GitHub Actions で Claude API は呼ばない** (ADR 0017、コスト回避)
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証 (§5.2):
+  - `build.gradle.kts` 内に version 直書き (`"2.0.0"`) が存在しない (Version Catalog 経由に強制)
+  - Firebase 関連 coordinate が含まれない (`no-firebase.md` と統合)
+  - 不要な repository (`mavenLocal()` 等) が含まれない
+- **Renovate** で依存更新自動化、PR ラベル `renovate` を `pr-poller` が検出して `dependency-upgrade` Skill 起動
+
+## Gotchas
+
+- **`implementation` / `api` の使い分け**: 公開 API として transitively 露出させたい場合のみ `api`、通常は `implementation`
+- **`ksp` plugin の version 整合**: KSP plugin version は Kotlin version と厳密に対応 (`2.0.0-1.0.21` 形式)、`libs.versions.toml` で managed
+- **Wasm target 設定変更後は `wasm-d8` の cache が古いと build 失敗**することがある。`./gradlew clean` を実行
+- **configuration-cache 有効時の build script 制約**: closure 内で `Project` を参照しない、`providers.gradleProperty(...)` を使う
+- buildSrc は configuration-cache と相性に注意、`plugins/` (Convention plugin) を優先
+
+## 関連
+
+- ADR 0002 / 0003 / 0017
+- Kotlin Gradle DSL: https://kotlinlang.org/docs/gradle.html
+- Version Catalog: https://docs.gradle.org/current/userguide/platforms.html
+- `.claude/rules/{wasm-compat,no-firebase,kotlin-test,secrets,cloud-run-deploy}.md`

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,102 @@
+---
+id: rules-i18n
+title: i18n / 多言語化規約 (compose-resources)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/composeResources/**/strings.xml"
+  - "core/features/**/composable/**/*.kt"
+  - "feature/**/*Screen.kt"
+related_adrs:
+  - ADR-0006
+  - ADR-0027
+---
+
+# i18n.md — i18n / 多言語化規約 (compose-resources)
+
+> Compose Multiplatform 標準の **`compose-resources`** で多言語化を実装 (ADR 0006)。
+> 文字列 literal を `@Composable` 内に直書き禁止、`Res.string.*` 経由で `strings.xml` から取得。
+> **日本語が一次言語**、英語は将来追加候補 (`docs/runbooks/i18n.md` で本格化、A2-4)。
+
+## ファイル配置
+
+```text
+<module>/src/commonMain/composeResources/
+  values/strings.xml          # 日本語 (default、フォールバック先)
+  values-en/strings.xml       # 英語 (将来追加時)
+```
+
+- module 単位 (`core/features/<feature>/`) で `composeResources/values/` を持つ
+- `default locale = ja`、英語 / 他言語は `values-<locale>/` で override
+
+## strings.xml 規約
+
+```xml
+<resources>
+    <string name="search_button">検索</string>
+    <string name="search_placeholder">アイドル名を入力</string>
+    <string name="error_network">ネットワークエラーが発生しました</string>
+    <plurals name="search_results_count">
+        <item quantity="zero">該当なし</item>
+        <item quantity="other">%1$d 件見つかりました</item>
+    </plurals>
+</resources>
+```
+
+- key 命名: **snake_case、機能スコープ**（`search_button` / `error_network`）
+- key の prefix で機能を表す: `search_*` / `myidols_*` / `error_*` / `common_*`
+- **複数形は `<plurals>`** を使用 (CLDR の `zero` / `one` / `other` を意識)
+- placeholder は `%1$s` (string) / `%1$d` (int) 等の番号付き (順序入替に対応)
+
+## Composable での参照
+
+```kotlin
+@Composable
+fun SearchIdolsScreen(...) {
+    Button(onClick = { onAction(SearchClicked) }) {
+        Text(stringResource(Res.string.search_button))
+    }
+}
+```
+
+- **`stringResource(Res.string.*)` 必須**、`Text("検索")` 直書き禁止
+- `pluralStringResource(Res.plurals.search_results_count, count, count)` で複数形
+- `stringResource(Res.string.x, arg1, arg2)` で placeholder 埋め込み
+
+## ViewModel / Repository での文字列
+
+- **ViewModel / Repository から文字列リソースを直接参照しない** (`@Composable` 外で `Res.string` 使用不可、`compose-resources` の制約)
+- 業務例外 → key mapping は `error-handling.md` のとおり: `DomainException.kind` (enum) → `Res.string.*` mapping を Screen 側で行う
+- 例: `when (error) { is InvalidQuery -> Res.string.error_invalid_query; else -> Res.string.error_unknown }`
+
+## 一次言語 (日本語) 規約
+
+- **ADR 0027** に基づき、デフォルト locale を `ja` とし `values/strings.xml` が日本語
+- 英語追加時は `values-en/strings.xml` を新規追加 (Phase B 以降で別 ADR / Plan)
+- 文言の声 (敬体 / 常体): UI 表示は **敬体** (「検索しています」)、エラーは **断定** (「ネットワークエラーが発生しました」)
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証 (R-23):
+  - `*Screen.kt` / `*Composable.kt` 内の `Text("...")` で文字列 literal を引数渡しした箇所を warning (許容例: 数値 / `%`、識別子)
+  - `core/model` / `core/data` で `Res.string.*` を参照していない
+- **Gradle カスタムタスク** で:
+  - 全 module の `composeResources/values/strings.xml` に key が存在する (`values-<locale>/` の key と差分検出)
+  - placeholder 数の整合 (`%1$s` 出現数が翻訳間で一致)
+  - 未使用 key 検出 (`grep` で Kotlin source から参照されていない key を warning)
+
+## Gotchas
+
+- **placeholder 番号付きを推奨** (`%s` / `%d` の順序依存より `%1$s` / `%2$d` が翻訳時に robust)
+- **HTML タグ / Markdown 構文を strings.xml に含めない** (`<b>` / `**` は AnnotatedString で表現)
+- **長文の改行は `\n` で明示**、自動折り返しに依存しない (font / locale で崩れる)
+- **wasm-js は compose-resources の限定機能のみサポート**、画像 / フォントのバンドル方式に注意 (`wasm-compat.md` 参照)
+- locale 切り替え時の再構成: `LocalConfiguration` (Android) の変更で再描画される、Wasm / Desktop は手動切り替え API を別途検討
+
+## 関連
+
+- ADR 0006 (i18n + compose-resources)
+- ADR 0027 (docs 構造 + 日本語化方針)
+- compose-resources: https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html
+- `.claude/rules/{composable,wasm-compat,error-handling,template-language}.md`
+- `docs/runbooks/i18n.md` (A2-4 で本格化)

--- a/.claude/rules/kotlin-test.md
+++ b/.claude/rules/kotlin-test.md
@@ -1,0 +1,113 @@
+---
+id: rules-kotlin-test
+title: Kotlin テスト規約 (Kotest)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*Spec.kt"
+  - "**/*Test.kt"
+  - "**/commonTest/**/*.kt"
+  - "**/androidUnitTest/**/*.kt"
+  - "**/wasmJsTest/**/*.kt"
+  - "**/desktopTest/**/*.kt"
+related_adrs:
+  - ADR-0004
+  - ADR-0013
+  - ADR-0016
+---
+
+# kotlin-test.md — Kotlin テスト規約 (Kotest)
+
+> 共通テストフレームワークに **Kotest 5.x** を採用 (ADR 0004)。`DescribeSpec` を基本スタイルとし、
+> KMP の commonTest で共通テストを書き、必要に応じて platform-specific test (`androidUnitTest` /
+> `wasmJsTest` / `desktopTest`) で actual 実装を検証する。
+
+## 命名と配置
+
+| 種別 | 配置 | 命名 |
+|---|---|---|
+| 共通テスト | `<module>/src/commonTest/kotlin/.../*Spec.kt` | `<実装>Spec.kt` (例: `SearchIdolsViewModelSpec.kt`) |
+| Android 専用 | `<module>/src/androidUnitTest/kotlin/.../*AndroidSpec.kt` | suffix `AndroidSpec` |
+| Wasm 専用 | `<module>/src/wasmJsTest/kotlin/.../*WasmSpec.kt` | suffix `WasmSpec` |
+| Desktop 専用 | `<module>/src/desktopTest/kotlin/.../*DesktopSpec.kt` | suffix `DesktopSpec` |
+| Screenshot (Roborazzi) | `<module>/src/jvmTest/kotlin/.../*ScreenshotTest.kt` | `screenshot-test.md` 参照 |
+
+- ペアリング (`SearchIdolsViewModel.kt` ⇄ `SearchIdolsViewModelSpec.kt`) は `test-paired-class.md` で Konsist 検証
+
+## スタイル: `DescribeSpec`
+
+```kotlin
+class SearchIdolsViewModelSpec : DescribeSpec({
+    describe("dispatch(QueryChanged)") {
+        it("updates uiState.query") {
+            val viewModel = SearchIdolsViewModel(FakeIdolColorsRepository())
+            viewModel.dispatch(SearchIdolsUiAction.QueryChanged("Hoshii"))
+            viewModel.uiState.value.query shouldBe "Hoshii"
+        }
+
+        context("when query is empty") {
+            it("clears results") { ... }
+        }
+    }
+})
+```
+
+- 階層: `describe("対象 / 状況")` → `context("条件")` → `it("期待")`
+- 動詞は **現在形** (`updates`, `clears`)、Compose Multiplatform の英語 / 日本語混在は許容 (テスト内のみ)
+- 1 it 内のアサーションは **1-3 個まで**、複数の振る舞いをチェックしたい場合は it を分割
+
+## アサーション
+
+- **Kotest matchers** (`shouldBe` / `shouldContain` / `shouldThrow<...>`) を使用
+- 浮動小数点比較は `shouldBe(expected plusOrMinus 0.01)`
+- `runTest { ... }` でコルーチン処理を検証 (`kotlinx-coroutines-test`)
+
+## fixture 規約
+
+- 共通 fixture は `<module>/src/commonTest/.../fixture/*.kt` に配置
+- `IdolFixture.kt`、`UserFixture.kt` 等で `fun givenIdol(id: String = "test-1"): Idol = ...` パターン
+- **テスト fixture のメールアドレスは `@example.com` ドメイン限定** (`pii.md` 参照、R-21)
+- **uid は連番文字列** (`test-uid-001`)、`sub` claim 風の 21 桁数字は避ける
+
+## Repository / Network のテスト
+
+- Repository テストは `Fake<実装>Repository` を `core/data/commonTest/.../fake/` に置く
+- Network Client は **MockEngine** (Ktor) で HTTP モック化、実エンドポイントは叩かない
+- DB テストは SqlDelight の **InMemory driver** で実行 (`sql-delight.md` 参照)
+
+## カバレッジ目標 (ADR 0013)
+
+- **段階達成**: Line/Branch coverage を 段階的に 100% に近づける
+- 詳細な閾値 / 段階表は `.claude/rules/coverage-100.md` (A7 で本格化)
+- カバレッジ計測は **kover** plugin、CI で `./gradlew koverHtmlReport` 出力
+
+## Spec coverage (ADR 0016)
+
+- **`@Spec("SPEC-IDOL-001-3")`** annotation でテストと仕様 ID を紐付け
+- `spec-traceability.md` (A7 で本格化) 参照
+- Konsist でカバー漏れ仕様 (annotation 未参照 SPEC ID) を検出
+
+## 機械検証 (A6 / A7 で導入)
+
+- **Konsist** で以下を検証 (R-21 / R-22):
+  - `*Spec.kt` が `DescribeSpec` を継承 (FunSpec / BehaviorSpec は warning)
+  - 実装クラス ⇄ Spec のペアリング (`test-paired-class.md`)
+  - fixture 内のメールアドレス文字列が `@example.com` で終わる
+- **Kover** で line / branch coverage を CI で取得
+- **PITest** (`mutation-testing.md`、A7) で mutation score を計測
+
+## Gotchas
+
+- **`runBlocking` を test に使わない**。`runTest { ... }` を使用 (Kotest + kotlinx-coroutines-test 統合)
+- **`Dispatchers.Main` を直接置換しない**。constructor 注入で `TestDispatcher` を受け取る (`viewmodel.md` 参照)
+- **wasm-js test は実行速度が遅い**ことがある。共通ロジックは commonTest、wasm 固有検証のみ wasmJsTest
+- **Screenshot test は Android 物理デバイス不要**、Roborazzi (Compose JVM) で `screenshot-test.md` に従う
+- `assertThat(...)` (truth-style) は使わず Kotest matchers に統一
+
+## 関連
+
+- ADR 0004 (テスト戦略概観)
+- ADR 0013 (Line/Branch 段階達成)
+- ADR 0016 (Spec coverage)
+- Kotest: https://kotest.io/
+- `.claude/rules/{viewmodel,repository,network-client,screenshot-test,test-paired-class,coverage-100,spec-traceability,mutation-testing,pii}.md`

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,91 @@
+---
+id: rules-logging
+title: ログ出力規約 (Napier)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/**/*.kt"
+  - "feature/**/*.kt"
+  - "backend/**/*.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0020
+---
+
+# logging.md — ログ出力規約 (Napier)
+
+> Compose Multiplatform 配下で **Napier** を共通ロガーに採用 (`io.github.aakira:napier`)。
+> Android / iOS / Wasm / Desktop / Backend で同じ API でログを出力でき、
+> PII / Secrets を含めない redaction を強制する。
+
+## ログレベル
+
+| level | 用途 | 例 |
+|---|---|---|
+| `Napier.v` (verbose) | 詳細トレース、debug build のみ有効化想定 | viewmodel dispatch 開始 |
+| `Napier.d` (debug) | 開発時の確認用、debug build のみ | HTTP request body |
+| `Napier.i` (info) | 通常運用で残したい情報 | ユーザーログイン成功 (uid のみ) |
+| `Napier.w` (warn) | 業務例外 / リトライ可能なエラー | network timeout、retry |
+| `Napier.e` (error) | リトライ不可能なエラー / バグ | SerializationException、unexpected null |
+
+## 出力先設定
+
+| build | 設定 | 詳細 |
+|---|---|---|
+| debug | `Napier.base(DebugAntilog())` | logcat (Android) / console (Wasm/Desktop) に全 level 出力 |
+| release | `Napier.base(CrashReportingAntilog())` (将来) | `warn` 以上のみ収集、PII 除外 |
+| Backend | `Napier.base(BackendAntilog())` (stdout JSON) | Cloud Run の Cloud Logging に流す |
+
+- 初期化は App エントリポイント (`MainActivity` / `wasmJsMain` / `main()`) で `Napier.base(...)` を 1 回呼ぶ
+- 切り替えは `BuildKonfig.IS_DEBUG` 等で判定
+
+## ログメッセージ規約
+
+```kotlin
+Napier.d("Search query=$query results=${results.size}")
+Napier.w("Network retry attempt=$attempt", throwable = e)
+Napier.e("Unexpected null in repository response", throwable = e)
+```
+
+- **PII / Secrets を埋め込まない** (`pii.md` / `secrets.md` 参照)
+  - メールアドレス / 表示名 / IP / Authorization header / API キー → 禁止
+  - uid (PII 同等扱い) も避ける、必要時は `uid.take(6) + "..."` で truncate
+- 業務上の数値 / フラグは OK (`results.size` / `attempt` / `isOnline`)
+- ロケール固定 (`Locale.ROOT`) で文字列フォーマット、`String.format("%.2f", ...)` 等
+
+## tag 規約 (Napier)
+
+- Napier はデフォルトで呼び出し元クラス名を tag に使う
+- 明示時は `Napier.d("...", tag = "SearchVm")` のように短い大文字始まり identifier
+- module 横断的な subsystem (`Sync`、`Auth`) は専用 tag で grep しやすくする
+
+## Backend のログ規約
+
+- Cloud Run の structured logging (JSON) に流す
+- 各 log entry は以下を含む:
+  - `severity` (Napier level → Cloud Logging severity)
+  - `message` (本文)
+  - `trace_id` (request scope の trace ID、Ktor middleware で attach)
+- レスポンス body / request body のフルダンプは `level: debug` のみ、PII 含む field は redact
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `println(...)` / `System.out.println(...)` / `print(...)` の直接呼び出しが production source に存在しない (テスト除外)
+  - `kotlin.io.println` / `java.util.logging.Logger` を import していない
+  - `Napier.*` 呼び出しでメールアドレス文字列が含まれていない (regex `@(?!example\.com)` で warning)
+
+## Gotchas
+
+- **wasm-js では `printStackTrace()` 不可**。`Napier.e("...", throwable = e)` 経由で扱う、Napier の wasm 実装は stacktrace を string 化する
+- **logcat (Android) は release build で多くが filter される**。重要なログは `level: info` 以上に
+- **redaction は呼び出し側責任**。Napier 自体は filter しない、書く時に注意 (`pii.md` / `secrets.md` 参照)
+- **`Napier.base()` を複数回呼ぶと全部 attach される**。multi-target でも 1 回のみが原則
+- Cloud Run 側で `severity: ERROR` の log が Cloud Logging に流れた場合 Slack alert が飛ぶ運用を将来検討 (Phase C)
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0020 (PII 最小化)
+- Napier: https://github.com/AAkira/Napier
+- `.claude/rules/{error-handling,pii,secrets,backend-auth}.md`

--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -1,0 +1,106 @@
+---
+id: rules-markdown
+title: Markdown 表記規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*.md"
+related_adrs:
+  - ADR-0027
+---
+
+# markdown.md — Markdown 表記規約
+
+> 本リポジトリの全 Markdown (`docs/**` / `.claude/rules/**` / `.github/**` / `*.md`) に
+> 適用する表記規約。**日本語化**は `template-language.md` を Single Source of Truth とし、
+> 本 rule は CommonMark / GFM の機械検証可能な表記ルールに集中する。
+
+## 見出し
+
+- `#` (h1) は **ファイル冒頭の 1 つのみ** (frontmatter の後)
+- `##` (h2) からは複数可、レベル飛ばし禁止 (`#` → `###` は NG)
+- 末尾コロン / ピリオド禁止、識別子 (SPEC-NNN-N) はそのまま
+- **日本語必須** (`template-language.md` 参照、ADR 0027)、code 識別子 / 英語固有名詞は OK
+
+## frontmatter
+
+- YAML frontmatter は **ファイル先頭** (`---` で開閉)
+- 配列は **block 形式必須** (`docs-structure.md` frontmatter 規約):
+
+  ```yaml
+  related_adrs:
+    - ADR-0001
+    - ADR-0011
+  ```
+
+- flow 形式 `[A, B]` は禁止 (機械検証で reject、A6)
+- 必須キーは docs 種別ごとに定義 (`docs-structure.md` §frontmatter 必須キー表 参照)
+
+## リンク
+
+- 外部 URL: `[label](https://...)` の通常リンク (タイトル属性不要)
+- 内部リンク: ファイル相対パス (`[label](../adr/ADR-0001-adr-charter.md)`) を推奨
+- 識別子参照: `ADR-0001` / `EPIC-NNN` / `SPEC-NNN-N` は **裸書き** (リンクなし) で OK、必要時のみリンク化
+
+## code block
+
+- 言語指定必須 (` ```kotlin ` / ` ```sql ` / ` ```text `)
+- 言語不明 / プレーンテキストは ` ```text ` を明示 (mt は不可)
+- 行数は **30 行以内** を目安、超える場合はファイル参照 (`file_path:line` 形式) に置換
+
+## 表
+
+- 列ヘッダ必須 (`| col1 | col2 |` + `|---|---|`)
+- 列幅は max ~3 列推奨、4 列以上は別の表現 (リスト / 別表) を検討
+- 表中の改行は `<br/>` で明示 (CommonMark の table extension で標準)
+
+## list
+
+- 順序なしは `-`、順序ありは `1.` (Markdown auto-renumbering に任せる、明示番号も OK)
+- ネストは **半角スペース 2 つ** インデント
+- 1 行で長くなる場合は `- foo:` + 改行 + インデント + 説明文
+
+## 強調
+
+- 強調: `**bold**` (`__bold__` 禁止)
+- 斜体: `*italic*` (`_italic_` 禁止)
+- 取り消し線: `~~strikethrough~~` (使う場面少)
+- code: `` `inline_code` ``
+
+## 識別子・パス・コード
+
+- パス / ファイル名: `` `core/data/Repository.kt` `` (inline code)
+- 識別子: `ADR-0001` / `SPEC-IDOL-001-3` (裸書き可、code wrap も可)
+- コード断片: 設計書本文 (`docs/{requirements,specifications}/**`) には **コードを書かない** (§4.6 のコード禁止原則)、`file_path:line` のみ許容
+
+## blockquote
+
+- 注意書き / 引用: `>`
+- 多段引用は `>>` でネスト (CommonMark の table-extension に従う)
+
+## 機械検証 (A6 で導入)
+
+- **markdownlint-cli2** + 設定ファイル (`.markdownlint-cli2.jsonc`、A6 で配置) で以下を検証:
+  - 見出しレベル飛ばし禁止 (MD001)
+  - 行末 trailing space (MD009)
+  - 同一見出し重複禁止 (MD024)
+  - リンク URL 検証 (MD034 / MD039)
+  - フェンス言語指定必須 (MD040)
+- **Gradle カスタムタスク** で frontmatter / 5 行 summary / 日本語見出しを検証 (`docs-structure.md` §機械検証 参照)
+- Konsist は Kotlin file 専用のため Markdown 検証には使えない (§5.2)
+
+## Gotchas
+
+- **`<br>` / `<br/>` の混在**: GFM では `<br/>` を推奨 (XHTML 互換)
+- **table 内の `|` エスケープ**: `\|` で明示
+- **行末空白 2 つで改行** は GFM 標準だが、可読性のため明示的に `<br/>` を推奨
+- **`---` の用途**: frontmatter 開閉 / 水平線で同じ syntax、frontmatter は **ファイル先頭** のみ
+- 日本語 / 英語混在時、半角スペース挿入の有無で見た目が変わる: 「ADR 0001 を参照」は半角スペース、「`ADR-0001`を参照」は不要 (識別子は inline code 扱い)
+
+## 関連
+
+- ADR 0027 (docs 構造 + 日本語化方針)
+- CommonMark: https://commonmark.org/
+- GFM: https://github.github.com/gfm/
+- `.claude/rules/{template-language,docs-structure}.md`
+- `.markdownlint-cli2.jsonc` (A6 で配置)

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -1,0 +1,101 @@
+---
+id: rules-naming
+title: 命名規約 (Kotlin / Compose / Test)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*.kt"
+  - "**/*.kts"
+related_adrs:
+  - ADR-0002
+  - ADR-0003
+---
+
+# naming.md — 命名規約 (Kotlin / Compose / Test)
+
+> Kotlin Coding Conventions に準拠 + 本プロジェクト固有の suffix 規約を規定。
+> ViewModel / UiState / Composable / Repository / Client / Test の命名を統一し、
+> Konsist 検証 (A6) と人間レビューの両方で機械的に判定可能にする。
+
+## 一般 (Kotlin Coding Conventions 準拠)
+
+| 種別 | 規約 | 例 |
+|---|---|---|
+| package | 全小文字、ドメイン階層 (`net.subroh0508.colormaster.<module>.<feature>`) | `net.subroh0508.colormaster.features.search.viewmodel` |
+| class / interface / object | パスカルケース、名詞 | `IdolColorsRepository`、`SearchIdolsViewModel` |
+| function | キャメルケース、動詞始まり (一部例外あり) | `searchByName(query: String)`、`onAction(action: ...)` |
+| Composable function | パスカルケース | `SearchIdolsScreen`、`IdolListItem` |
+| property / val / var | キャメルケース、名詞 | `uiState`、`idolColorsRepository` |
+| const val (top-level / object) | UPPER_SNAKE_CASE | `MAX_RESULTS_PER_PAGE` |
+| 型パラメータ | 単一文字 or 短い大文字 | `T`、`K`、`V`、`TIdol` (将来の bound 化時のみ) |
+
+## suffix 規約
+
+| suffix | 用途 | 例 |
+|---|---|---|
+| `ViewModel` | `androidx.lifecycle.ViewModel` 派生 (`viewmodel.md`) | `SearchIdolsViewModel` |
+| `UiState` | `data class` 画面状態 (`ui-state.md`) | `SearchIdolsUiState` |
+| `UiAction` | `sealed interface` 画面入力 (`ui-state.md`) | `SearchIdolsUiAction` |
+| `Screen` | `@Composable` 画面 (`composable.md`) | `SearchIdolsScreen` |
+| `Route` | `@Composable` Route wrapper (ViewModel 解決) / `@Serializable` 型 (Nav 3 destination) | `SearchIdolsRoute` |
+| `Repository` | interface in `core/model` (`repository.md`) | `IdolColorsRepository` |
+| `Default*Repository` | 既定実装 in `core/data` | `DefaultIdolColorsRepository` |
+| `Fake*Repository` | テスト用 fake in `core/data/commonTest` | `FakeIdolColorsRepository` |
+| `Client` | network interface in `core/network` (`network-client.md`) | `ImasparqlClient` |
+| `Dto` | network DTO (`network-client.md`) | `IdolDto` |
+| `Spec` | Kotest spec (`kotlin-test.md`) | `SearchIdolsViewModelSpec` |
+| `Test` | (Spek / JUnit 5 残存時のみ、原則 `Spec` に統一) | — |
+
+## ドメインモデル命名 (ColorMaster 固有)
+
+- `Idol` (アイドル)、`IdolId` (値オブジェクト、`@JvmInline value class`)
+- `Brand` (THE iDOLM@STER ブランド: 765 / シンデレラ / ミリオン / SideM / シャイニーカラーズ / 学園)
+- `Color` (アイドル固有色、`ColorHex` 値オブジェクト)
+- `Tan(担当)` / `Oshi(推し)` (DB のローマ字でなくドメイン用語で日本語の意図を保持)
+
+詳細用語は `docs/glossary.md` (A2-4 で本格化) を参照。
+
+## ファイル名
+
+- **1 ファイル 1 top-level 宣言を原則** とする (例外: `data class` と `companion object` の同居、`sealed interface` とそのサブタイプ)
+- ファイル名は **top-level 宣言の名前と一致** (`SearchIdolsViewModel.kt` 内に `class SearchIdolsViewModel`)
+- 例外: `Route.kt` (`object SearchIdolsRoute` + `data class IdolDetailRoute` 等、機能内の Route を 1 ファイルに集約)、`*Mapper.kt` (DTO → ドメイン mapping 関数群)
+
+## テスト命名
+
+```kotlin
+class SearchIdolsViewModelSpec : DescribeSpec({
+    describe("dispatch(QueryChanged)") {
+        it("updates uiState.query") { ... }
+        context("when query is empty") {
+            it("clears results") { ... }
+        }
+    }
+})
+```
+
+- 実装クラス + `Spec` (例: `SearchIdolsViewModelSpec`)
+- 配置: 実装と同じ package 階層の `commonTest` (`kotlin-test.md` 参照)
+- ペアリングは Konsist `test-paired-class.md` で検証
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証 (R-22):
+  - suffix と配置の整合 (`*ViewModel.kt` が `core/features/**/viewmodel/` 配下)
+  - DTO は `*Dto` suffix + `@Serializable`
+  - top-level `class` 名とファイル名一致 (Kotlin 標準だが、Konsist で再検証)
+- **Detekt 規約** で命名 lint (A6 で `detekt-formatting` 導入時)
+
+## Gotchas
+
+- **`*Manager` / `*Helper` / `*Util` suffix は避ける** (責務不明瞭、Repository / Service / Mapper に分解)
+- **`Default*` prefix は Repository 実装のみ**。他の context (例: Default config) は別 suffix (`*Config` / `*Settings`)
+- **Hungarian notation 禁止** (`strQuery` / `lstResults` 等)
+- 旧 Decompose 由来の `*Component` / `*Store` (ADR 0005 撤去前の遺物) は削除済、再導入は別 ADR
+
+## 関連
+
+- ADR 0002 / 0003 (アーキ + モジュール構造)
+- Kotlin Coding Conventions: https://kotlinlang.org/docs/coding-conventions.html
+- `.claude/rules/{viewmodel,ui-state,composable,navigation,repository,network-client,kotlin-test,test-paired-class}.md`
+- `docs/glossary.md` (A2-4 で本格化)

--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -1,0 +1,111 @@
+---
+id: rules-navigation
+title: Navigation 3 + Route 型の実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/Route.kt"
+  - "**/navigation/**/*.kt"
+  - "core/features/**/*Route.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0005
+---
+
+# navigation.md — Navigation 3 + Route 型の実装規約
+
+> Compose Multiplatform 上で `androidx.navigation` (Navigation 3) を採用 (ADR 0002)。
+> Decompose 由来の `ComponentContext` ベース navigation は撤去済 (ADR 0005)。
+> Route は **type-safe** な `@Serializable` data class / data object で定義し、
+> graph 上で `composable<RouteType>` により安全に解決する。
+
+## Route 定義
+
+```kotlin
+@Serializable
+data object SearchIdolsRoute
+
+@Serializable
+data class IdolDetailRoute(val idolId: String)
+
+@Serializable
+data class SearchResultRoute(val query: String, val brand: Brand? = null)
+```
+
+- 配置: `core/features/<feature>/src/commonMain/.../navigation/Route.kt` (機能ごとに 1 ファイル)
+- **`@Serializable` 必須** (Navigation 3 の type-safe args 解決のため、`kotlinx.serialization` plugin)
+- 引数なし → `data object`、引数あり → `data class`
+- 引数型は **primitive + `@Serializable` data class** に限定
+
+## Graph 構築
+
+```kotlin
+@Composable
+fun AppNavHost(
+    navController: NavHostController = rememberNavController(),
+) {
+    NavHost(
+        navController = navController,
+        startDestination = SearchIdolsRoute,
+    ) {
+        composable<SearchIdolsRoute> {
+            SearchIdolsRoute(
+                onNavigateToDetail = { idolId ->
+                    navController.navigate(IdolDetailRoute(idolId.value))
+                },
+            )
+        }
+        composable<IdolDetailRoute> { entry ->
+            val route: IdolDetailRoute = entry.toRoute()
+            IdolDetailRoute(idolId = IdolId(route.idolId))
+        }
+    }
+}
+```
+
+- `composable<RouteType>` で type-safe に destination 登録
+- `entry.toRoute<RouteType>()` で引数を decode
+- `*Route` (Screen wrapper) を登録、`*Screen` 直接ではない (`composable.md` 参照)
+
+## SavedStateHandle との連携
+
+```kotlin
+class IdolDetailViewModel(
+    private val repository: IdolColorsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val route: IdolDetailRoute = savedStateHandle.toRoute()
+    // route.idolId を使用
+}
+```
+
+- ViewModel は `SavedStateHandle.toRoute<RouteType>()` で Route を復元
+- Navigation 3 が `SavedStateHandle` に args を inject する仕組みを利用 (`androidx.navigation.toRoute`)
+- ViewModel のテスト時は `SavedStateHandle(mapOf(...))` で fixture を組む
+
+## deep link (将来検討)
+
+- Phase A では deep link 未対応
+- 必要時に別 ADR で「Custom URL scheme 採用」「path mapping 規約」を起こす
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証 (R-22):
+  - `Route.kt` 内の Route 定義は `@Serializable` annotation 付与
+  - Route 引数は primitive (`String` / `Int` / `Long` / `Boolean`) または `@Serializable` data class
+  - `commonMain` の Route 定義に `android.*` / `androidx.*` (除く `androidx.navigation` の `@Serializable` 互換) が混入していない
+
+## Gotchas
+
+- **`navigate()` の引数に文字列パスを直書きしない**。`navigate(IdolDetailRoute(idolId.value))` 形式のみ許容
+- **Route 引数に `@Composable` / `Color` / `Modifier` 等の Compose 型を含めない**。シリアライズ不能
+- **大量の引数を Route に乗せない**。`Set<IdolId>` 等の collection は SavedStateHandle に乗せず、ViewModel が repository から取得する設計に
+- **`popBackStack()` / `navigateUp()` の動作差**: `popBackStack` は graph 最下層なら no-op、`navigateUp` は parent destination に戻る。意図に合わせて選択
+- Decompose の `Store` API は撤去済 (ADR 0005)、再導入は別 ADR
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0005 (Decompose 撤去)
+- `.claude/rules/{viewmodel,composable,ui-state}.md`
+- `docs/architecture/sequences.md` (A2-5 で本格化、画面遷移シーケンス図)

--- a/.claude/rules/network-client.md
+++ b/.claude/rules/network-client.md
@@ -1,0 +1,129 @@
+---
+id: rules-network-client
+title: Network Client の実装規約 (Ktor)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/network/**/*Client*.kt"
+  - "core/network/**/Http*.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0007
+  - ADR-0009
+  - ADR-0011
+  - ADR-0014
+---
+
+# network-client.md — Network Client の実装規約 (Ktor)
+
+> Compose Multiplatform 配下で **Ktor Client** を共通実装に採用 (ADR 0002)。
+> プラットフォーム別 engine は `expect/actual` で切り替え (Android: OkHttp / wasm-js: JS Fetch / Desktop: CIO)。
+> Repository に依存される側で、ドメインモデル変換は Repository 側で行う (`repository.md` 参照)。
+
+## 配置と命名
+
+| 種別 | 配置 | 命名 |
+|---|---|---|
+| Client interface (commonMain) | `core/network/<api>/src/commonMain/.../*Client.kt` | `<API>Client.kt` (例: `ImasparqlClient.kt` / `AuthClient.kt`) |
+| 実装 (`expect/actual` 用) | 同上 + `androidMain` / `wasmJsMain` / `desktopMain` の `expect/actual` Client factory | `<API>Client.<platform>.kt` |
+| HttpClient factory | `core/network/<api>/src/<platform>Main/.../di/*HttpClient.kt` | `Android*HttpClient.kt` / `Js*HttpClient.kt` / `Desktop*HttpClient.kt` |
+| DTO | `core/network/<api>/src/commonMain/.../dto/*Dto.kt` | `<Entity>Dto.kt` |
+
+## Client interface
+
+```kotlin
+interface ImasparqlClient {
+    suspend fun searchByName(query: String): List<IdolDto>
+    suspend fun findById(id: String): IdolDto?
+}
+```
+
+- **`suspend fun` 必須**、戻り値は DTO (network 層の型)
+- ドメインモデル (`Idol`) の変換は Repository 側、本層では DTO のまま
+- 例外は `IOException` / `ResponseException` (Ktor) / `SerializationException` をそのまま投げる (`error-handling.md` 参照)
+
+## HttpClient 設定
+
+```kotlin
+fun HttpClientConfig<*>.commonConfig() {
+    install(ContentNegotiation) {
+        json(Json { ignoreUnknownKeys = true })
+    }
+    install(HttpTimeout) {
+        requestTimeoutMillis = 30_000
+        connectTimeoutMillis = 10_000
+    }
+    install(Logging) {
+        level = if (BuildKonfig.IS_DEBUG) LogLevel.HEADERS else LogLevel.NONE
+        sanitizeHeader { it == HttpHeaders.Authorization }
+    }
+}
+```
+
+- **TLS 1.2+ 必須**、HTTP は禁止 (公開 endpoint も localhost 開発除く)
+- timeout: request 30s / connect 10s (適宜調整可、ただし設定なし禁止)
+- Authorization ヘッダは Logging plugin で **sanitize** (PII / Secrets が log に出ない)
+
+## プラットフォーム engine
+
+| Target | Engine | 備考 |
+|---|---|---|
+| Android | OkHttp | `io.ktor:ktor-client-okhttp` + Android SSL session cache |
+| wasm-js | JS Fetch | `io.ktor:ktor-client-js`、HTTPS のみ、CORS 必須 |
+| Desktop (JVM) | CIO | `io.ktor:ktor-client-cio` (純 Kotlin、wasm でも理論上動くが Android 排他に注意) |
+
+- **OkHttp は Wasm 非互換** (`wasm-compat.md` 参照)、`core/network` の commonMain で `okhttp3.*` を import しない
+- engine 選択は `core/network/<api>/build.gradle.kts` で source set ごとに dependency を分ける
+
+## DTO 規約
+
+```kotlin
+@Serializable
+data class IdolDto(
+    val id: String,
+    val name: String,
+    @SerialName("brand_id") val brandId: String?,
+)
+```
+
+- **`@Serializable` 必須** (`kotlinx.serialization`)
+- snake_case ⇄ camelCase は `@SerialName` で明示
+- `null` 許容フィールドはサーバ仕様に従い、デフォルト値は **必要時のみ** 設定 (silently 0 / "" は誤認の元)
+
+## Backend API (`colormaster-api.yaml`) との対応
+
+- OpenAPI 3.1 spec (`docs/api/colormaster-api.yaml`) と DTO / endpoint 名を **1:1 対応**
+- spec 変更時は DTO を同 PR 内で更新、CI で diff 検証 (将来の Lint 候補)
+- 認証 endpoint は `backend-auth.md` 参照 (GIS ID Token / JWKS)
+
+## im@sparql endpoint (ADR 0014)
+
+- ローカル開発時は Fuseki Docker (`docker-compose.local.yml` / runbook)
+- 本番は外部 im@sparql ホスティング (URL は `BuildKonfig.IMASPARQL_BASE_URL`)
+- 切り替えは build config 経由、コード分岐は禁止
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `core/network/**/*Client.kt` (commonMain) は `suspend fun` のみ public、`Flow` 公開は許容 (購読型 endpoint のみ)
+  - DTO は `@Serializable` annotation 付与
+  - commonMain で `okhttp3.*` / `java.net.*` / `android.*` を import していない
+- **Gradle カスタムタスク** で `docs/api/colormaster-api.yaml` と DTO クラス名の整合検証 (将来候補)
+
+## Gotchas
+
+- **commonMain で `HttpClient(OkHttp) { ... }` を直書きしない**。`expect/actual` でプラットフォーム別 factory に分離
+- **wasm-js は HTTPS のみ**、HTTP endpoint は CORS / mixed content で動かない
+- **TLS 証明書 pinning は不要** (公開 endpoint のみ、自前 CA なし)
+- **Authorization header は必ず sanitize**、CI log / レビューコメントに出さない (`secrets.md` redaction 参照)
+- Firebase 関連 Client (`core/network/firestore/*`) は撤去予定 (ADR 0011)、`removed-modules.md` 参照
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0007 (im@sparql upstream-driven 同期)
+- ADR 0009 (Backend Cloud Run)
+- ADR 0011 (Firebase → GIS 移行)
+- ADR 0014 (im@sparql ローカル Fuseki)
+- `.claude/rules/{repository,backend-auth,sparql,wasm-compat,secrets,error-handling}.md`
+- `docs/api/colormaster-api.yaml` (A2-5 で本格化)

--- a/.claude/rules/no-firebase.md
+++ b/.claude/rules/no-firebase.md
@@ -1,0 +1,87 @@
+---
+id: rules-no-firebase
+title: Firebase 系の新規追加禁止
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "build.gradle.kts"
+  - "**/build.gradle.kts"
+  - "gradle/libs.versions.toml"
+  - ".claude/skills/feature-request/**"
+  - ".claude/skills/dependency-upgrade/**"
+related_adrs:
+  - ADR-0011
+---
+
+# no-firebase.md — Firebase 系の新規追加禁止
+
+> ADR 0011 (Firebase → GIS 移行) に基づき、Firebase 系の **新規追加を禁止** する規約。
+> 既存 import 検出は `firebase-boundary.md` (Konsist の Kotlin source パターン) と
+> **二段運用**: 本ファイルは Skill が依存追加 / 機能起草する **事前ガード**、
+> `firebase-boundary.md` は CI / Konsist による **事後検証**。
+> 責務分担と改名再評価方針は EPIC-A2 `decisions.md` 参照。
+
+## 禁止対象
+
+新規追加禁止 (build スクリプト / 依存 catalog / コード import):
+
+| カテゴリ | 具体例 |
+|---|---|
+| Firebase Authentication | `com.google.firebase:firebase-auth-*` / `dev.gitlive:firebase-auth-*` (Kotlin Multiplatform Firebase) |
+| Firebase Firestore / Realtime DB | `firebase-firestore-*` / `firebase-database-*` |
+| Firebase Functions | `firebase-functions-*` |
+| Firebase Analytics / Crashlytics / Performance | `firebase-analytics-*` / `firebase-crashlytics-*` / `firebase-perf-*` |
+| Firebase Messaging | `firebase-messaging-*` |
+| Firebase Remote Config | `firebase-config-*` |
+| Firebase Hosting / Cloud Build for Firebase | `firebase.json` 配置、`firebase deploy` 等のスクリプト |
+| Google Services plugin | `com.google.gms.google-services` |
+
+## 代替案 (ADR 0011 に基づく置き換え)
+
+| Firebase の用途 | 採用代替 | 関連 ADR |
+|---|---|---|
+| 認証 (Auth) | Google Identity Services (GIS) + Backend で ID Token 検証 | ADR 0011, 0008 |
+| データストア (Firestore) | Backend SQLite + Litestream + R2 | ADR 0008 |
+| 静的ホスティング (Hosting) | Cloudflare Pages | ADR 0022 |
+| アナリティクス | (採用未定、必要時に別 ADR で再評価) | — |
+| FCM (Push 通知) | (機能未要件化、必要時に別 ADR) | — |
+
+## Skill 事前ガード
+
+`feature-request` / `bug-fix` / `refactor` / `dependency-upgrade` Skill は、**依存追加 / コード生成
+の起草段階で本 rule を参照** し、以下を満たすか確認:
+
+- [ ] 提案する build スクリプト変更に Firebase 系の add / implementation / api 行が含まれていないか
+- [ ] 提案するコードに `import com.google.firebase.*` / `import dev.gitlive.firebase.*` が含まれていないか
+- [ ] 「認証」「データ同期」を扱う場合、GIS / Backend / SQLite のいずれかを採用しているか
+
+違反検出時は **起草段階で reject** (Plan / Epic 起票前)、代替案を提示する。
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証 (build script 系、§5.2):
+  - `**/build.gradle.kts` / `gradle/libs.versions.toml` に Firebase 系の coordinate が出現していない
+  - `gradle/libs.versions.toml` の `[libraries]` セクションに `firebase` 文字列を含む key が存在しない
+  - `firebase.json` / `firestore.rules` 等のファイルがリポジトリに存在しない
+- **Konsist** で Kotlin source の import 検証 (`firebase-boundary.md` 側で担保、本 rule では build 側のみ)
+
+## 例外と再評価
+
+- 既存の Firebase 関連参照は `firebase-boundary.md` でエスケープ用ホワイトリストを管理 (移行完了まで段階的)
+- 将来必要になった機能 (FCM / Crashlytics 等) は **新 ADR を起こして禁止解除** を明示。本 rule の更新と build 検証の例外追加は ADR 採択後
+
+## Gotchas
+
+- **Firebase 系の lib を 1 行追加するだけでも Konsist / Gradle 検証が落ちる**。誤って `Renovate` PR で追加されないよう、`renovate.json5` の `packageRules` で Firebase 系を `disabled` にする (A6 / dependency-upgrade Skill 本格化時に実装)
+- **`com.google.gms.google-services` plugin の `apply` も禁止**。Firebase なしで残ると build 失敗を誘発
+- `dev.gitlive:firebase-*` (Kotlin Multiplatform 用 Firebase wrapper) も同様に禁止 (KMP プロジェクトで紛れ込みやすい)
+- 本 rule は **新規追加禁止** のみ規定、既存 import の検出と削除は `firebase-boundary.md` の責務 (改名は A3 で再評価、EPIC-A2 `decisions.md` 参照)
+
+## 関連
+
+- ADR 0011 (Firebase → GIS 移行)
+- ADR 0008 (Backend SQLite + Litestream + R2)
+- ADR 0022 (Cloudflare Pages + R2)
+- `.claude/rules/firebase-boundary.md` (既存 import 検出、Konsist 検証)
+- `.claude/rules/{gradle,backend-auth,removed-modules}.md`
+- EPIC-A2 `decisions.md` (二段運用の判断記録)

--- a/.claude/rules/pii.md
+++ b/.claude/rules/pii.md
@@ -7,7 +7,6 @@ last_updated: 2026-05-17
 # Claude Code セッション起動時に常時ロードする (公式 docs: paths 未指定 = unconditional load)。
 related_adrs:
   - ADR-0020
-  - ADR-0011
 ---
 
 # pii.md — PII 保護とアクセス制御
@@ -37,12 +36,13 @@ related_adrs:
 `code-reviewer` / `pr-retrospective` / `harness-meta` などの Skill が出力する際は、
 以下のパターンを検出してマスクする (`[REDACTED-PII]` 等のプレースホルダに置換):
 
-| パターン | 置換例 |
-|---|---|
-| メールアドレス (除く `@example.com`) | `[REDACTED-EMAIL]` |
-| `https://lh*.googleusercontent.com/...` | `[REDACTED-AVATAR-URL]` |
-| `sub` claim の値 (典型的に数字 21 桁) | `[REDACTED-UID]` |
-| IP アドレス | `[REDACTED-IP]` |
+| パターン | 検出 regex | 置換 |
+|---|---|---|
+| メールアドレス (除く `@example.com`) | `[a-zA-Z0-9._%+-]+@(?!example\.com)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` | `[REDACTED-EMAIL]` |
+| GIS avatar URL | `https://lh[0-9]+\.googleusercontent\.com/[^\s]+` | `[REDACTED-AVATAR-URL]` |
+| `sub` claim の値 (典型的に数字 21 桁) | `\b\d{21}\b` | `[REDACTED-UID]` |
+| IPv4 アドレス | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (除く `127.0.0.1` / `0.0.0.0` / プライベートレンジは context により残す判断) | `[REDACTED-IP]` |
+| IPv6 アドレス | `\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b` | `[REDACTED-IP]` |
 
 ## テスト fixture の規約
 

--- a/.claude/rules/pii.md
+++ b/.claude/rules/pii.md
@@ -1,13 +1,13 @@
 ---
 id: rules-pii
 title: PII 保護とアクセス制御
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 # 注意: PII 保護は全 PR で必ず遵守すべき安全網のため `paths` を意図的に設定せず、
 # Claude Code セッション起動時に常時ロードする (公式 docs: paths 未指定 = unconditional load)。
-related_plan: docs/harness/plan.md §3.8 / ADR 0020
 related_adrs:
   - ADR-0020
+  - ADR-0011
 ---
 
 # pii.md — PII 保護とアクセス制御
@@ -52,14 +52,31 @@ related_adrs:
 
 ## 機械検証 (A6 で導入)
 
-- **trufflehog** による全 PR 差分の secret-scan
-- Konsist で「テスト fixture の `@example.com` ドメイン以外の検出」(R-21)
-- Gradle カスタムタスクで「`data/users.db*` の追跡禁止」「Dockerfile 内 `COPY data/users.db` 禁止」
+- **trufflehog** による全 PR 差分の secret-scan (`.github/workflows/secret-scan.yml`)
+- Konsist で以下を検証 (Kotlin source 限定、R-21):
+  - テスト fixture (`**/*Test.kt`, `**/*Spec.kt`) のメールアドレス文字列が `@example.com` ドメインで終わる
+  - `data class User` 等の `users.db` スキーマ対応クラスに `email` / `displayName` / `picture` フィールドが存在しない (uid のみ)
+- Gradle カスタムタスクで Markdown / Dockerfile を検証 (Konsist 不可):
+  - `data/users.db*` の追跡禁止 (`git ls-files` チェック)
+  - Dockerfile 内 `COPY data/users.db` パターン禁止
+  - learning ファイル / PR description に redaction 漏れ検出 (`@(?!example\.com)` 等のパターン)
+
+## Skill 出力前のチェックリスト
+
+`code-reviewer` / `pr-retrospective` / `harness-meta` / `harness-evolution` が出力する前に以下を確認:
+
+- [ ] CI ログ抜粋 / `gh pr view` 出力 / MCP 結果に PII が含まれていないか
+- [ ] 「Reviewed by X」「Authored by Y」等の自然文に display name が混入していないか
+- [ ] スタックトレース / エラーメッセージに `sub` claim 値が含まれていないか
+- [ ] スクリーンショット (Roborazzi baseline) に表示名 / メール / アバター URL が含まれていないか
+
+検出時は **`[REDACTED-*]` プレースホルダに置換** してから出力。
 
 ## 権限ロール
 
 - 当面 **owner 1 名のみ** (ADR 0020)
 - 複数人体制になったら別 ADR で `developer` / `releaser` を追加
+- GitHub repo 設定 (Settings → Collaborators) と Cloudflare / GCP の IAM ロールも owner のみで運用、複数化時に別 runbook (`docs/runbooks/permissions.md`) を整備
 
 ## 関連
 

--- a/.claude/rules/plan.md
+++ b/.claude/rules/plan.md
@@ -1,0 +1,136 @@
+---
+id: rules-plan
+title: Plan ファイル命名規約 / 状態遷移
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "docs/plans/*.md"
+  - ".claude/skills/plan-author/**"
+related_adrs:
+  - ADR-0027
+---
+
+# plan.md — Plan ファイル命名規約 / 状態遷移
+
+> Plan は **単一 PR で完結する取り組み** の意思決定・進捗を 1 ファイルで管理する記録。
+> Epic と異なり「複数 PR にまたがる構造化された取り組み」は対象外 (`epic.md` 参照)。
+> 起票は `plan-author` Skill 経由、ロードマップ追跡対象外 (R-34、PR レビュー & merge で完結)。
+
+## いつ Plan を起こすか
+
+- 1 PR で完結する単機能追加・バグ修正・リファクタ・依存更新等
+- 複数 PR が必要だと判明したら **Epic に昇格** (`status: promoted` + `promoted_to: EPIC-NNN`)
+- 単発の commit で済むタイポ修正・コメント追加等は Plan 不要
+
+## いつ Epic に昇格させるか
+
+| 兆候 | 対応 |
+|---|---|
+| 期待される変更行数が 1,000 行を超える / 触るファイル数が 30 を超える | Epic 昇格を検討 |
+| レビュー aspect (spec / arch / test / security / etc.) のうち 3 以上が大きく走る | Epic 昇格 |
+| 仕様変更が複数 SPEC に波及 | Epic 昇格 |
+| 単独 PR で完結する見込みが立たない | Epic 昇格 |
+
+昇格時は元 Plan の `status` を `promoted`、`promoted_to: EPIC-NNN` に更新し、`docs/epics/EPIC-NNN-<slug>/` を `epic-author` Skill で生成。Plan ファイル自体は履歴保持のため削除しない。
+
+## 命名規約
+
+- ファイル名: `PLAN-NNN-<kebab-case-slug>.md` (3 桁ゼロパディング、Epic と独立採番)
+- 例: `PLAN-001-adr-0001-0027-batch-draft.md` / `PLAN-007-add-search-by-brand.md`
+- 採番は `docs/plans/INDEX.md` で連番管理、欠番は実装前なら整理可
+
+## ステータス語彙
+
+| 値 | 意味 |
+|---|---|
+| `proposed` | 起票済み、未着手 |
+| `in-progress` | 着手中 (Draft PR open など) |
+| `completed` | 完了 (PR マージ済) |
+| `abandoned` | 取り下げ (理由を Plan 本体に記載) |
+| `promoted` | Epic に昇格 (frontmatter `promoted_to: EPIC-NNN` 必須) |
+
+## frontmatter 必須キー
+
+```yaml
+---
+id: PLAN-NNN
+title: <日本語タイトル>
+type: feature-request | bug-fix | refactor | dependency-upgrade | chore | docs | harness
+status: proposed | in-progress | completed | abandoned | promoted
+related_pr: <PR 番号、起票時は null>
+related_epic: EPIC-NNN | null
+related_specs:
+  - SPEC-IDOL-001-3
+related_adrs:
+  - ADR-0017
+expected_modules:
+  - <touch 予定のファイル / ディレクトリ glob>
+created_at: YYYY-MM-DD
+completed_at: YYYY-MM-DD | null
+promoted_to: EPIC-NNN | null
+---
+```
+
+block 形式必須 (`.claude/rules/docs-structure.md` frontmatter 規約と整合)。要素ゼロのみ `[]` 許容。
+
+## 本文構造 (docs/plans/template.md と整合)
+
+```markdown
+# <タイトル>
+
+> **5 行以内 summary**: 目的 / 主な変更 / 影響範囲
+
+## 目的
+
+## 背景
+
+## アプローチ
+
+## 受け入れ基準 (AC)
+
+- [ ] AC-1: <検証可能な条件>
+
+## スコープ外
+
+## メモ
+```
+
+## INDEX.md 更新規約
+
+- 起票時 / status 変更時 / Epic 昇格時に `docs/plans/INDEX.md` を更新
+- `plan-author` Skill が自動更新するが、手動編集も許容
+- 行構造: `| PLAN-NNN | タイトル | type | status | related_epic | 起票日 |`
+
+## Plan ⇄ Epic ⇄ ADR の責務分離
+
+| 種別 | スコープ | 主な記録 |
+|---|---|---|
+| Plan | 1 PR | アプローチ / AC / 単独の意思決定 |
+| Epic | 複数 PR | 構成 PR 一覧 / 横断 AC / 細粒度決定 (`decisions.md`) / Open Questions |
+| ADR | 不変 | アーキテクチャ的に重要な決定 (`.claude/rules/adr.md` §起票基準) |
+
+「Epic にすべきか Plan に留めるか迷ったら Plan で起票し、必要に応じて promote」を基本方針とする。
+
+## 機械検証 (A6 で導入)
+
+- Gradle カスタムタスクで以下を検証 (§5.2):
+  - frontmatter 必須キーの存在 (`id`, `title`, `type`, `status`, `created_at` 等)
+  - `id` の正規表現 (`^PLAN-\d{3}$`)
+  - `INDEX.md` 行と Plan 本体の status 整合
+  - `promoted` 時に `promoted_to` が `EPIC-NNN` 形式で実在
+- `template-language.md` の日本語必須も合わせて適用
+
+## Gotchas
+
+- **Plan は `roadmap-tracker` の取り込み対象外** (R-34)。`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` には Plan を列挙しない
+- **Epic 配下 PR は Plan を起こさない**。Epic ロードマップの構成 PR 行で管理し、PR description で AC を記述する
+- `status: promoted` 時の Plan ファイルは履歴として残す。**ファイル削除や rename は禁止** (古い PR の参照が壊れるため)
+- type 列の値は `.claude/rules/commit-message.md` の Conventional Commits type と一致させる (`feat` → `feature-request`、`fix` → `bug-fix` 等のマッピングは PR description の type で揃える)
+
+## 関連
+
+- `docs/harness/plan.md` §4.1 (Epic と Plan の区別)
+- `docs/plans/INDEX.md`
+- `docs/plans/template.md` (Plan 本体テンプレ)
+- `.claude/skills/plan-author/SKILL.md`
+- `.claude/rules/{epic,adr,roadmap,docs-structure,commit-message}.md`

--- a/.claude/rules/r2-litestream.md
+++ b/.claude/rules/r2-litestream.md
@@ -1,0 +1,134 @@
+---
+id: rules-r2-litestream
+title: R2 + Litestream replicate / restore 規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "litestream.yml"
+  - "scripts/cloud-run-start.sh"
+  - "backend/**"
+  - ".github/workflows/deploy-backend.yml"
+related_adrs:
+  - ADR-0008
+  - ADR-0021
+  - ADR-0022
+---
+
+# r2-litestream.md — R2 + Litestream replicate / restore 規約
+
+> Backend SQLite (`users.db`) を **Litestream で Cloudflare R2 に continuous replicate** (ADR 0008)。
+> 起動時に R2 から restore して disaster recovery を実現。本格化は Phase C5 だが本 rule で起草。
+> **R2 token TTL 90 日** (ADR 0021)、bucket は private (`db-protection.md` 参照)。
+
+## アーキテクチャ
+
+```text
+[Cloud Run Container]
+    Backend (Ktor Server)
+        ↓ writes
+    /data/users.db (SQLite, WAL mode)
+        ↑ Litestream WAL replication
+[Cloudflare R2]
+    bucket: colormaster-users-db-backup (private)
+        objects: /users.db/wal-XXXXXXXX
+```
+
+- **Litestream**: SQLite WAL を S3 互換 storage に continuous replicate
+- **R2**: S3 互換 API、egress 無料 (Cloudflare 内 Cloud Run からの read は別 region 経由でも安価)
+- **Disaster Recovery**: Cloud Run コンテナ完全再作成時も R2 から restore で復旧
+
+## Litestream 設定 (`litestream.yml`)
+
+```yaml
+dbs:
+  - path: /data/users.db
+    replicas:
+      - type: s3
+        endpoint: ${R2_ENDPOINT}
+        bucket: colormaster-users-db-backup
+        path: users.db
+        region: auto
+        access-key-id: ${R2_ACCESS_KEY_ID}
+        secret-access-key: ${R2_SECRET_ACCESS_KEY}
+        sync-interval: 10s
+        retention: 720h         # 30 日保持
+        retention-check-interval: 1h
+```
+
+- **`endpoint`**: R2 endpoint URL (例: `https://<account-id>.r2.cloudflarestorage.com`)
+- **`region: auto`** (R2 は region 概念なし、auto で OK)
+- **`sync-interval: 10s`**: WAL を 10 秒ごとに R2 へ flush (RPO ~10 秒)
+- **`retention: 720h`**: 30 日保持、それ以前は削除 (cost control)
+
+## R2 bucket 設定
+
+| 項目 | 値 | 根拠 |
+|---|---|---|
+| Bucket name | `colormaster-users-db-backup` | 本番用 |
+| Visibility | **private** | PII 含む、絶対公開禁止 (`db-protection.md` / `pii.md`) |
+| Lifecycle rule | 90 日経過オブジェクト削除 | コスト管理 |
+| CORS | 無効 | Backend のみアクセス、ブラウザ不要 |
+| Bucket policy | Backend Service Token のみ allow | アクセス最小化 |
+
+## R2 API Token
+
+- **TTL 90 日** (ADR 0021)、定期ローテーション (`secrets.md` 参照)
+- 権限: 該当 bucket の `Object Read / Write` のみ (他 bucket / dashboard 操作不可)
+- Cloud Run 側は **Google Cloud Secret Manager** に格納、起動時に env var で参照 (`cloud-run-deploy.md`)
+
+## restore フロー
+
+```bash
+# scripts/cloud-run-start.sh (cloud-run-deploy.md と統合)
+litestream restore -if-replica-exists -config /etc/litestream.yml /data/users.db
+```
+
+- **`-if-replica-exists`**: 初回起動 (R2 に何もない) でも fail しない
+- restore 完了後に Backend 起動
+- restore 中の Backend 起動はしない (`start.sh` で sequential)
+
+## replicate フロー
+
+```bash
+litestream replicate -config /etc/litestream.yml &
+```
+
+- Backend と並走 (background)
+- Cloud Run コンテナ shutdown 時に SIGTERM を受信 → Litestream が graceful shutdown (WAL flush 完了まで待つ)
+
+## 機械検証 (A6 / C5 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `litestream.yml` の bucket / endpoint が environment variable 経由 (hardcode 禁止)
+  - `litestream.yml` 内に access key 直書きがない (Secret Manager 経由)
+- **CI** で Litestream バイナリの SHA256 検証 (sig pinning、A6 で追加)
+
+## バックアップ検証
+
+- 月次で **Litestream restore リハーサル** を runbook (`docs/runbooks/release.md` または新規 `docs/runbooks/db-restore-drill.md`、Phase C5) で実施
+- R2 → 別の test 環境に restore → schema / row count sanity check
+- 検証結果は `docs/runbooks/db-restore-drill.md` の履歴セクションに記録
+
+## 機械検証 (Phase C5 で導入)
+
+- **Health check endpoint** (`/healthz`) で R2 connectivity check 含めるか検討
+- Cloud Run 起動時 Litestream restore failure → Cloud Run の startup probe で fail させ、再起動
+
+## Gotchas
+
+- **WAL mode 必須**: SQLite を WAL mode で動かす (`PRAGMA journal_mode=WAL;`)、Litestream の前提
+- **`users.db-shm` / `users.db-wal` は restore 時に自動再生成** される、別途扱う必要なし
+- **`sync-interval` を短くしすぎると R2 PUT request 数が増えコスト増**、`10s` を初期値とし運用後に調整
+- **R2 endpoint と access key の漏洩** は即座に bucket access が破綻するため、Secret Manager と GitHub Secrets の二重管理 + 90 日ローテ (`secrets.md`)
+- **Litestream version pinning**: Dockerfile で固定 version (`v0.3.13` 等) を取得、auto-update は禁止 (compatibility 検証必須)
+- **R2 → Cloud Run の egress**: 同 region でないため latency に注意 (~10ms 程度を見込む)
+
+## 関連
+
+- ADR 0008 (Backend SQLite + Litestream + R2)
+- ADR 0021 (R2 token TTL 90 日)
+- ADR 0022 (Cloudflare Pages + R2)
+- Litestream: https://litestream.io/
+- Cloudflare R2: https://developers.cloudflare.com/r2/
+- `.claude/rules/{db-protection,sqlite-data-file,cloud-run-deploy,secrets,backend-auth,cloudflare-pages}.md`
+- `docs/runbooks/secrets-rotation.md` (Phase A〜C で本格化)

--- a/.claude/rules/removed-modules.md
+++ b/.claude/rules/removed-modules.md
@@ -1,0 +1,81 @@
+---
+id: rules-removed-modules
+title: 撤去 module 一覧と再導入禁止規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/build.gradle.kts"
+  - "settings.gradle.kts"
+  - "**/*.kt"
+  - ".firebaserc"
+  - "firebase.json"
+related_adrs:
+  - ADR-0005
+  - ADR-0011
+  - ADR-0012
+---
+
+# removed-modules.md — 撤去 module 一覧と再導入禁止規約
+
+> 本プロジェクトで **明示的に撤去された module / lib** の一覧、撤去理由、関連 ADR、
+> 再導入時の手続きを規定。撤去状態を機械的に維持し、誤って復活させないためのガード。
+
+## 撤去対象一覧
+
+| 名称 | 撤去理由 | 撤去 ADR | 残骸 (撤去進行中) | 検出 rule |
+|---|---|---|---|---|
+| Decompose (`com.arkivanov.decompose:*`) | KMP Navigation の代替を `androidx.navigation` (Nav3) に統一 | ADR 0005 | なし (撤去完了) | `viewmodel.md` / `navigation.md` |
+| 旧 JS app (`js/app/`) | Wasm 統一でブラウザ target を 1 つに | ADR 0012 | `js/app/` ディレクトリ残存 (削除予定) | `wasm-compat.md` |
+| Firebase Authentication SDK | GIS (Google Identity Services) + Backend 検証に移行 | ADR 0011 | `core/network/auth/` 内に一部依存残存 | `firebase-boundary.md` / `no-firebase.md` |
+| Firebase Firestore | Backend SQLite + Litestream + R2 に移行 | ADR 0008 / 0011 | `core/network/firestore/` 残存 (削除予定) | `firebase-boundary.md` / `no-firebase.md` |
+| Firebase Hosting | Cloudflare Pages に移行 | ADR 0011 / 0022 | `firebase.json` / `.firebaserc` 残存 (削除予定) | `cloudflare-pages.md` |
+| Firebase 系全般 (Analytics / Crashlytics / Messaging / Config / Functions) | 採用方針外 | ADR 0011 | (もし import 残存していれば) | `no-firebase.md` / `firebase-boundary.md` |
+| `com.google.gms.google-services` plugin | Firebase SDK 撤去に伴い不要 | ADR 0011 | (Android module 内 plugin 適用箇所) | `no-firebase.md` |
+
+## 撤去進行中 module の追跡
+
+撤去完了まで以下を実施:
+
+1. 該当 module / lib への `@Deprecated` annotation 付与 (Kotlin source の場合)
+2. `firebase-boundary.md` の allowlist に **期限付き** で追加
+3. 代替実装の Plan / Epic を起票 (`PLAN-NNN-remove-*` または `EPIC-NNN-firebase-migration` 等)
+4. 撤去 PR 内で本 rule の一覧と allowlist を更新
+5. 削除完了後、本 rule の「残骸」列を「なし」に変更
+
+## 再導入時の手続き
+
+**撤去された module を再導入する場合は以下を必須**:
+
+1. **新 ADR を起こす** (再導入理由 + 代替案再評価 + 影響範囲)
+2. 元の撤去 ADR を `superseded by` でリンク
+3. 撤去 rule (`no-firebase.md` / `firebase-boundary.md` 等) の例外条項を更新
+4. 撤去 module 一覧から削除 (本 rule)
+5. 撤去検証ロジック (`firebase-boundary.md` Konsist test) を緩和または削除
+6. 人間 approve 必須、auto-merge 禁止 (`docs/harness/plan.md` R-15)
+
+「便利だから戻す」では再導入させない。**「以前撤去した時より状況が変わった」根拠の明示** が必要。
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `import com.arkivanov.decompose.*` が production source に存在しない
+  - `import com.google.firebase.*` / `import dev.gitlive.firebase.*` が production source に存在しない (`firebase-boundary.md` allowlist 例外あり)
+- **Gradle カスタムタスク** で以下を検証 (§5.2):
+  - `gradle/libs.versions.toml` に Decompose / Firebase 系 coordinate が含まれない
+  - `js/app/` ディレクトリが存在しない (撤去完了後)
+  - `firebase.json` / `.firebaserc` / `google-services.json` が存在しない (撤去完了後)
+
+## Gotchas
+
+- **撤去 PR 内で「全削除」しない**。段階的に (lib 依存 → import 残骸 → module ディレクトリ → 設定 file の順) 削除し、各段階で動作確認
+- **transitively pulled な撤去 lib** に注意 (例: 他 lib が Decompose を transitive dependency として持つ)。`./gradlew :module:dependencies` で確認
+- **撤去 ADR を `deprecated` にしない**。撤去後も「過去にこれを使っていた、こう撤去した」記録として `accepted` 状態を保つ
+- 一度撤去した module を blame 履歴から消すために `git filter-repo` 等を使わない (履歴改変は別 ADR 必須)
+
+## 関連
+
+- ADR 0005 (Decompose 撤去)
+- ADR 0011 (Firebase → GIS 移行)
+- ADR 0012 (旧 JS 実装撤去)
+- `.claude/rules/{no-firebase,firebase-boundary,navigation,cloudflare-pages,backend-auth}.md`
+- `docs/adr/README.md` (ADR 索引)

--- a/.claude/rules/repository.md
+++ b/.claude/rules/repository.md
@@ -1,0 +1,104 @@
+---
+id: rules-repository
+title: Repository 層の実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/model/**/*Repository*.kt"
+  - "core/data/**/*Repository*.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0003
+  - ADR-0008
+  - ADR-0010
+---
+
+# repository.md — Repository 層の実装規約
+
+> Clean Architecture 風の interface 分離: **interface は `core/model`**、
+> **implementation は `core/data`** に配置する (ADR 0003)。ViewModel は interface に依存し、
+> data 層は network / local DB の詳細を隠蔽する (ADR 0002 / 0008 / 0010)。
+
+## 配置と命名
+
+| 種別 | 配置 | 命名 |
+|---|---|---|
+| Repository interface | `core/model/src/commonMain/kotlin/net/subroh0508/colormaster/model/*Repository.kt` | `<ドメイン>Repository.kt` (例: `IdolColorsRepository.kt`) |
+| 既定実装 | `core/data/src/commonMain/kotlin/net/subroh0508/colormaster/data/Default*Repository.kt` | `Default<ドメイン>Repository.kt` (例: `DefaultIdolColorsRepository.kt`) |
+| テスト用 fake | `core/data/src/commonTest/.../Fake*Repository.kt` | `Fake<ドメイン>Repository.kt` |
+
+## interface の構造
+
+```kotlin
+interface IdolColorsRepository {
+    suspend fun searchByName(query: String): List<Idol>
+    suspend fun findById(id: IdolId): Idol?
+    fun observeAll(): Flow<List<Idol>>
+}
+```
+
+- **`suspend fun` で one-shot 取得**、**`Flow<T>` で継続購読**
+- 戻り値は **`Result<T>` ではなく直接 `T` を返し**、例外は呼び出し側 (ViewModel) で `runCatching` する (`error-handling.md` 参照)
+- ドメインモデル (`Idol` / `IdolId` / `Brand` 等) のみを返す。`Response` / `DTO` 等の network 層型を露出しない
+
+## 既定実装の構造
+
+```kotlin
+class DefaultIdolColorsRepository(
+    private val sparqlClient: ImasparqlClient,
+    private val sqlDelightDb: ColormasterDatabase,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : IdolColorsRepository {
+
+    override suspend fun searchByName(query: String): List<Idol> =
+        withContext(ioDispatcher) {
+            sparqlClient.searchByName(query).map { it.toIdol() }
+        }
+}
+```
+
+- constructor 注入で `Client` (`core/network/*`) と `SqlDelight` を受領
+- `suspend` 関数では `withContext(ioDispatcher)` で IO スレッドに切り替え
+- DTO → ドメインモデル変換は **mapping 関数** (`fun *Dto.toIdol(): Idol`) で集約
+
+## 依存関係
+
+- **interface は外部依存ゼロ** (`core/model` は network / data に依存しない)
+- 既定実装は `core/network/*` (Client) と `core/database/*` (SqlDelight) に依存可
+- **ViewModel は interface のみに依存**、`Default*Repository` を直接参照しない
+
+## キャッシュ戦略
+
+| 種別 | 場所 | TTL |
+|---|---|---|
+| アイドル情報マスタ (`Idol`) | `data/idols.db` (SqlDelight、ローカルファイル) | 同期 PR 経由で更新 (`sync-job.md`) |
+| ユーザーデータ (`MyIdols`) | Backend SQLite (`users.db`) + memory cache (TTL 15 分) | ADR 0008 / 0020 |
+| GIS userinfo (display name / email / picture) | memory cache のみ (TTL 15 分、PII 最小化) | `pii.md` 参照 |
+
+- 永続化が必要な PII は **`uid` のみ** (ADR 0020)
+- memory cache は `MutableStateFlow<Map<K,V>>` を Repository 内に保持、TTL 切れで再取得
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証:
+  - `core/model/**/*Repository.kt` は `interface` のみ (class 禁止)
+  - `core/data/**/Default*Repository.kt` は対応する interface を実装している
+  - `core/model` モジュールが `core/network` / `core/data` を import していない
+  - Repository interface の戻り値型に `Response` / `Dto` 等の network 層型が含まれない
+
+## Gotchas
+
+- **`Result<T>` を返さない**。例外を投げ、呼び出し側 (ViewModel) が `runCatching` で wrap (`error-handling.md` 参照)
+- **Repository 内で UI 関連処理をしない** (`Snackbar` 表示 / Navigation 等は呼び出し側)
+- **`Default*Repository` を ViewModel が直接型として参照しない**。DI (Koin 等) で interface 解決
+- **CoroutineDispatcher のテスト容易性**: constructor デフォルト引数で `Dispatchers.Default` を受け取り、テストでは `TestDispatcher` を注入
+- 旧 Firebase Firestore 経由の Repository (`core/network/firestore/*`) は撤去予定 (ADR 0011)、現行コードに残る場合は `removed-modules.md` 参照
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0003 (feature-first モジュール構造)
+- ADR 0008 (Backend SQLite + Litestream + R2)
+- ADR 0010 (アイドル情報 SQLite in-repo)
+- `.claude/rules/{viewmodel,network-client,sql-delight,error-handling,pii}.md`
+- `docs/architecture/layers.md` / `docs/architecture/data-flow.md` (A2-5 で本格化)

--- a/.claude/rules/roadmap.md
+++ b/.claude/rules/roadmap.md
@@ -1,13 +1,15 @@
 ---
 id: rules-roadmap
 title: ロードマップ Markdown 規約 (roadmap-tracker Skill 操作規約)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "docs/harness/roadmap.md"
   - "docs/epics/**/roadmap.md"
   - ".claude/skills/roadmap-tracker/**"
-related_plan: docs/harness/plan.md §5.3 / R-34 / R-35 / R-36
+related_adrs:
+  - ADR-0017
+  - ADR-0027
 ---
 
 # roadmap.md — ロードマップ Markdown 規約

--- a/.claude/rules/rules-index.md
+++ b/.claude/rules/rules-index.md
@@ -1,7 +1,7 @@
 ---
 id: rules-index
 title: rules 索引
-status: skeleton
+status: living
 last_updated: 2026-05-17
 # 注意: 索引そのものは小さく、AI が他 rule を発見する起点として
 # 起動時に常時ロードしておくのが望ましいため `paths` を意図的に未設定。
@@ -37,7 +37,8 @@ last_updated: 2026-05-17
 | 値 | 意味 |
 |---|---|
 | `skeleton (B0)` | B0 (PR #117) で配置済の骨格。本文薄め、Gotchas / 関連リンクは揃っている。本格化フェーズで肉付け |
-| `planned (X)` | まだ実体なし。フェーズ X (例: A2-2、A2-3、A3、A6、A7、Phase C) で新規作成予定 |
+| `stable (X)` | フェーズ X (例: A2-1、A2-2) で本格化済み。実装・運用に耐える本文と Gotchas が揃っている |
+| `planned (X)` | まだ実体なし。フェーズ X (例: A2-3、A3、A6、A7、Phase C) で新規作成予定 |
 | `living` | 索引・ロードマップ等で常に更新される文書 |
 
 ## カテゴリ別索引
@@ -46,28 +47,44 @@ last_updated: 2026-05-17
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `plan.md` | planned (A2-2) | Plan ファイルの命名規約 / 状態遷移 |
-| `epic.md` | planned (A2-2) | Epic ディレクトリ構成 / 状態遷移 |
-| `roadmap.md` | skeleton (B0、A2-3 で本格化) | `roadmap-tracker` Skill の操作規約 |
-| `adr.md` | skeleton (B0、A2-2 で本格化) | ADR 起票基準 / 採番 / 起票すべき例・他の記録方法にすべき例 |
+| `plan.md` | stable (A2-2) | Plan ファイルの命名規約 / 状態遷移 / Epic 昇格条件 |
+| `epic.md` | stable (A2-2) | Epic ディレクトリ構成 / 状態遷移 / 補助ファイル責務 |
+| `roadmap.md` | stable (A2-2) | `roadmap-tracker` Skill の操作規約 |
+| `adr.md` | stable (A2-2) | ADR 起票基準 / 採番 / 起票すべき例・他の記録方法にすべき例 |
 
 ### アーキテクチャ層別
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `viewmodel.md` / `ui-state.md` / `composable.md` / `navigation.md` / `repository.md` / `network-client.md` | planned (A2-2) | 層ごとの実装規約 |
+| `viewmodel.md` | stable (A2-2) | `androidx.lifecycle.ViewModel` 継承 / StateFlow 公開 / SavedStateHandle |
+| `ui-state.md` | stable (A2-2) | `*UiState` data class / `*UiAction` sealed interface |
+| `composable.md` | stable (A2-2) | Preview 必須 / `*Screen(uiState, onAction)` 引数規約 / design tokens 強制 |
+| `navigation.md` | stable (A2-2) | Navigation 3 / `Route.kt` / `@Serializable` type-safe args |
+| `repository.md` | stable (A2-2) | interface in `core/model` / impl in `core/data` |
+| `network-client.md` | stable (A2-2) | Ktor Client / OkHttp / JS Fetch / TLS / timeout |
 
 ### 横断的関心事
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `naming.md` / `error-handling.md` / `logging.md` / `i18n.md` / `wasm-compat.md` / `firebase-boundary.md` | planned (A2-2) | 横断的なコーディング規約 |
+| `naming.md` | stable (A2-2) | Kotlin / Compose / Test 命名 / suffix 規約 |
+| `error-handling.md` | stable (A2-2) | `Result<T>` / `runCatching` / 例外伝播ポリシー |
+| `logging.md` | stable (A2-2) | Napier / level / PII redaction |
+| `i18n.md` | stable (A2-2) | `strings.xml` / compose-resources / 日本語 first |
+| `wasm-compat.md` | stable (A2-2) | wasmJs 制約 / Coroutines `Dispatchers.Default` / OkHttp 除外 |
+| `firebase-boundary.md` | stable (A2-2) | 既存 Firebase import 検出 / Konsist 検証 (二段運用、`no-firebase.md` 参照) |
 
 ### ファイルタイプ別 / テスト
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `gradle.md` / `kotlin-test.md` / `screenshot-test.md` / `sql-delight.md` / `sparql.md` / `test-paired-class.md` / `markdown.md` | planned (A2-2、Gradle / Konsist / markdownlint 設定の本格化は A6/A7) | 各ファイル種別の規約 |
+| `gradle.md` | stable (A2-2、Gradle カスタムタスクの本格化は A6) | `build.gradle.kts` 規約 / version catalog / convention plugin |
+| `kotlin-test.md` | stable (A2-2、Konsist 統合は A6) | Kotest DescribeSpec / fixture / `runTest` |
+| `screenshot-test.md` | stable (A2-2、Roborazzi 設定の本格化は A10) | 4 パターン baseline (mobile/desktop × Light/Dark) |
+| `sql-delight.md` | stable (A2-2) | `*.sq` ファイル規約 / migration / driver `expect/actual` |
+| `sparql.md` | stable (A2-2) | SPARQL prefix / im@sparql クエリ規約 / injection 対策 |
+| `test-paired-class.md` | stable (A2-2、Konsist 統合は A6) | 実装 ⇄ テストクラスペアリング検証 |
+| `markdown.md` | stable (A2-2、markdownlint-cli2 統合は A6) | Markdown 表記規約 |
 | `coverage-100.md` | planned (A7) | Line/Branch 段階達成規約 (指標 A) |
 | `spec-traceability.md` | planned (A7) | `@Spec` annotation / Spec coverage 規約 (指標 B) |
 | `mutation-testing.md` | planned (A7) | PITest 運用規約 (指標 C) |
@@ -120,27 +137,32 @@ last_updated: 2026-05-17
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `markdown.md` | planned (A2-2、markdownlint-cli2 統合は A6) | Markdown 表記規約 |
+| `markdown.md` | stable (A2-2、markdownlint-cli2 統合は A6) | Markdown 表記規約 |
 | `template-language.md` | skeleton (B0、A2-1 で常時ロード化 / A2-3 で本格化) | 全テンプレ Markdown は日本語 (ADR 0027) |
 
 ### 同期 / Backend
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `sync-job.md` / `sqlite-data-file.md` / `cloud-run-deploy.md` / `removed-modules.md` / `backend-auth.md` | planned (A2-2、Skill 起草 / Phase C 実装で参照) | Backend / 同期 / 撤去モジュールの規約 |
+| `sync-job.md` | stable (A2-2、Phase B-C で workflow 実装) | im@sparql 同期 workflow + 生成 PR ラベル |
+| `sqlite-data-file.md` | stable (A2-2) | `data/idols.db` (commit 可) vs `users.db` (禁止) の境界 |
+| `cloud-run-deploy.md` | stable (A2-2、Phase C7 で本格デプロイ) | Cloud Run service / Dockerfile / WIF |
+| `removed-modules.md` | stable (A2-2) | 撤去 module 一覧 (Decompose / Firebase / 旧 JS app) |
+| `backend-auth.md` | stable (A2-2) | GIS ID Token / JWKS / uid 抽出 |
 
 ### セキュリティ / 個人情報
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `pii.md` | skeleton (B0 常時ロード、A2-2 で本格化) | PII の定義・最小化・redaction 強制 |
-| `secrets.md` | skeleton (B0 常時ロード、A2-2 で本格化) | Secrets 管理 (`.env` / GitHub Secrets / Secret Manager) |
-| `db-protection.md` | skeleton (B0、A2-1 で `.dockerignore` TODO 追記 / A2-2 で本格化) | `users.db` の commit / イメージ焼込み禁止、R2 private |
-| `no-firebase.md` | planned (A2-2) | Firebase 系の新規追加禁止規約 (既存 import 検出は `firebase-boundary.md`、責務分担は EPIC-A2 `decisions.md` 参照) |
-| `cloudflare-pages.md` | planned (A2-2 で起草、C7 で本格化) | Cloudflare Pages デプロイ規約 |
-| `r2-litestream.md` | planned (A2-2 で起草、C5 で本格化) | Litestream replicate / restore、R2 endpoint |
+| `pii.md` | stable (A2-2、常時ロード) | PII の定義・最小化・redaction 強制 |
+| `secrets.md` | stable (A2-2、常時ロード) | Secrets 管理 (`.env` / GitHub Secrets / Secret Manager) |
+| `db-protection.md` | stable (A2-2) | `users.db` の commit / イメージ焼込み禁止、R2 private |
+| `no-firebase.md` | stable (A2-2) | Firebase 系の新規追加禁止 (Skill 事前ガード、`firebase-boundary.md` と二段運用、EPIC-A2 `decisions.md` 参照) |
+| `cloudflare-pages.md` | stable (A2-2、C7 で本格デプロイ) | Cloudflare Pages デプロイ規約 |
+| `r2-litestream.md` | stable (A2-2、C5 で本格運用) | Litestream replicate / restore、R2 endpoint、TTL ローテーション |
 
 ## 関連
 
 - `docs/harness/plan.md` §5.0.3 (rules 一覧)
 - `CLAUDE.md` §lookup-table (編集対象 ⇄ rules の対応)
+- EPIC-A2 `README.md` / `decisions.md` (A2-1〜A2-5 分割、本格化のフェーズ計画)

--- a/.claude/rules/screenshot-test.md
+++ b/.claude/rules/screenshot-test.md
@@ -1,0 +1,108 @@
+---
+id: rules-screenshot-test
+title: スクリーンショットテスト規約 (Roborazzi)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*ScreenshotTest.kt"
+  - "**/screenshots/**"
+  - "**/composable/**/*.kt"
+related_adrs:
+  - ADR-0004
+  - ADR-0023
+---
+
+# screenshot-test.md — スクリーンショットテスト規約 (Roborazzi)
+
+> **Roborazzi** (Compose JVM 上で Robolectric なしで動く screenshot test ライブラリ) を採用 (ADR 0004 / 0023)。
+> JVM Compose Desktop + Android 想定で **4 パターン (mobile/desktop × Light/Dark) baseline** を維持。
+> wasmJs 固有 actual は対象外 (JVM のみ実行)、UI 凍結三本柱 (ADR 0023) の一角を担う。
+
+## 4 パターン baseline
+
+| 解像度 | テーマ | 用途 |
+|---|---|---|
+| Mobile (360 × 640) | Light | Android スマホ縦向き |
+| Mobile (360 × 640) | Dark | 同上、ダークテーマ |
+| Desktop (1280 × 800) | Light | Desktop / Web (Wasm) |
+| Desktop (1280 × 800) | Dark | 同上、ダークテーマ |
+
+- 全 `*Screen.kt` Composable について 4 パターン baseline を生成
+- baseline 画像は `<module>/src/jvmTest/screenshots/<Screen>/<pattern>.png` に格納 (git LFS は使わない、PNG をリポジトリ commit)
+
+## テスト構造
+
+```kotlin
+class SearchIdolsScreenshotTest {
+    @get:Rule val roborazziRule = createRoborazziRule()
+
+    @Test
+    fun searchIdolsScreen_mobile_light() = captureRoboImage {
+        AppTheme(darkTheme = false) {
+            Box(Modifier.size(360.dp, 640.dp)) {
+                SearchIdolsScreen(
+                    uiState = SearchIdolsUiState(query = "幻奏", results = listOf(/* fixture */)),
+                    onAction = {},
+                )
+            }
+        }
+    }
+    // ... mobile_dark / desktop_light / desktop_dark
+}
+```
+
+- 配置: `<module>/src/jvmTest/kotlin/.../*ScreenshotTest.kt`
+- `captureRoboImage` を 4 回呼ぶ (1 test = 1 pattern) or parameterized
+- fixture は `kotlin-test.md` 規約に従う (uid / email は dummy)
+
+## baseline 更新フロー (human approve 必須)
+
+1. UI / design tokens を変更
+2. `./gradlew :module:recordRoborazziDebug` で baseline 上書き
+3. PR に差分画像を含む
+4. **人間レビュアーが baseline 更新を承認** (`code-reviewer` の visual-regression aspect が diff を可視化、最終承認は人間)
+5. auto-merge 禁止 (`docs/harness/plan.md` R-15)
+
+## CI での verify
+
+- CI (`.github/workflows/ci.yml`) で `./gradlew verifyRoborazziDebug` を起動
+- baseline と diff があれば PR check 失敗、差分画像を artifact として upload
+- `code-reviewer` の visual-regression aspect が `*.diff.png` を読んで構造化コメントを post
+
+## 対象スコープと除外
+
+| 対象 | 含む / 除く |
+|---|---|
+| `core/features/**/composable/*Screen.kt` | ✅ 含む |
+| `core/features/**/composable/*Item.kt` / `*Card.kt` (共通 component) | △ 主要 component のみ (5+ 画面で使用される widget) |
+| `*Route.kt` (ViewModel 解決 wrapper) | ❌ 含まない (state-less でないため) |
+| wasm-js 固有 `expect/actual` の Composable | ❌ JVM 実行不可、Konsist で個別検証 |
+
+## design tokens 整合
+
+- 全 screenshot test で `AppTheme` (design tokens 適用) を必ずラップ
+- DESIGN.md の Semantic token (`MaterialTheme.colorScheme.*`) を経由した値でレンダリング
+- hex / sp / dp 直書きは Composable 内で禁止 (`composable.md` / `design-tokens.md` 参照)
+
+## 機械検証 (A6 / A7 / A10 で導入)
+
+- **Konsist** で以下を検証 (R-22):
+  - `core/features/**/composable/*Screen.kt` に対応する `*ScreenshotTest.kt` が `jvmTest` に存在 (`test-paired-class.md` 統合)
+  - `*ScreenshotTest.kt` 内に 4 パターン (mobile/desktop × Light/Dark) の `captureRoboImage` 呼び出し
+- **Roborazzi verify** で baseline 整合性を CI 検証
+
+## Gotchas
+
+- **Roborazzi は JVM のみ** (Wasm / iOS screenshot は対象外)。Wasm 互換性は Konsist + 手動検証で担保
+- **baseline 更新時はファイルサイズ膨張に注意**。PNG ロスレスでも 4 パターン × 数十画面で MB 級に
+- **OS / JDK / フォントの違いで diff が出る**ことがある。CI 環境 (Ubuntu + JDK 17 + Noto Sans CJK) を固定
+- **Compose Multiplatform の bug fix で minor diff が出る**ことがある。lib version 更新 PR は baseline 更新も同 PR 内で
+- 一括 baseline 更新は **段階的に**、一度に全画面更新すると review 不能になる
+
+## 関連
+
+- ADR 0004 (テスト戦略概観)
+- ADR 0023 (UI/UX 凍結 三本柱)
+- Roborazzi: https://github.com/takahirom/roborazzi
+- `.claude/rules/{composable,design-tokens,ui-snapshot,ui-inventory,behavior-preservation,kotlin-test,test-paired-class}.md`
+- `.claude/skills/ui-snapshot/SKILL.md`

--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -1,13 +1,14 @@
 ---
 id: rules-secrets
 title: Secrets 管理
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 # 注意: Secrets 管理は全ファイル編集で遵守すべき安全網のため `paths` を意図的に
 # 設定せず、Claude Code セッション起動時に常時ロードする。
-related_plan: docs/harness/plan.md §3.8 / ADR 0021
 related_adrs:
   - ADR-0021
+  - ADR-0017
+  - ADR-0024
 ---
 
 # secrets.md — Secrets 管理
@@ -38,19 +39,48 @@ related_adrs:
 
 ## ローテーション
 
-- **R2 token TTL 90 日** (ADR 0021)
-- 漏洩時 / 退職時 / 漏洩疑い時は即時ローテーション
+| 対象 | 周期 | 契機 |
+|---|---|---|
+| R2 access token | 90 日 | TTL 満了 / 漏洩疑い / 退職 |
+| Cloudflare API token (Pages デプロイ用) | 90 日 | 同上 |
+| GitHub Personal Access Token (Renovate / Actions 用) | 90 日 | 同上 |
+| Google Cloud service account key (Cloud Run 用) | 180 日 / 漏洩時即時 | TTL 満了 / 漏洩 |
+| GIS Client Secret | ローテ不要 (Public Client Flow) | — |
+| MCP OAuth トークン (ローカル Claude Code 安全領域) | Claude 側管理 | 自動 |
+
 - 手順は `docs/runbooks/secrets-rotation.md` に整備 (Phase A〜C で本格化)
+- ローテ実施記録は GitHub Issues `rotation:` ラベルで履歴管理 (将来検討)
 
 ## 漏洩検出
 
-- **trufflehog** を A6 で CI 導入、全 PR 差分をスキャン
-- 検出時は immediate rotate + history rewrite (`git filter-repo`)
+- **trufflehog** を A6 で CI 導入、全 PR 差分をスキャン (`.github/workflows/secret-scan.yml`)
+- 検出時の対応フロー:
+  1. immediate rotate (該当キーを Cloudflare / GCP / GitHub Secrets で再発行)
+  2. history rewrite (`git filter-repo --invert-paths --path <file>`)
+  3. force push (master のみ、collaborator 全員に通知)
+  4. 別 ADR で「漏洩 → ローテ完了」を記録 (incident postmortem)
+
+## redaction 強制 (Skill 出力前)
+
+`code-reviewer` / `pr-retrospective` / `harness-meta` / `harness-evolution` が PR description /
+learning / ADR / レビューコメントを出力する前に以下を検出してマスク:
+
+| パターン | 置換 |
+|---|---|
+| `(?i)(api[-_]?key|token|secret|password)\s*[:=]\s*["']?\S+` | `[REDACTED-SECRET]` |
+| `AKIA[0-9A-Z]{16}` (AWS access key) | `[REDACTED-AWS-KEY]` |
+| `ghp_[0-9A-Za-z]{36}` (GitHub PAT) | `[REDACTED-GH-PAT]` |
+| Bearer token / JWT (`eyJ` で始まる長文字列) | `[REDACTED-JWT]` |
+
+詳細は `pii.md` redaction 表と統合運用 (PII と Secrets は同じ Skill チェックポイントで検証)。
 
 ## Gotchas
 
 - **Skill が CI ログ / MCP 結果を learning / レビューコメントに含める場合は redaction 必須** (R-26)
 - 「.env を `.env.example` に間違えてコピー」事故防止のため、`.env.example` には **キーのみ + ダミー値**
+- `.env` を `.env.example` から再生成する手順は runbook (`docs/runbooks/local-development.md`) に集約
+- **Claude Code 内の MCP OAuth トークンは `.claude/oauth-tokens*` に保存される想定**。`.gitignore` で `.claude/oauth-tokens*` を除外する規約を維持し、commit 検証は trufflehog の追加パターンで担保
+- GitHub Actions で `secrets.GITHUB_TOKEN` 以外を参照する箇所は **必ず明示** (`workflow_run` 等の権限境界を意識、ADR 0017 で Actions から Claude API を呼ばない原則と整合)
 
 ## 関連
 

--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -74,6 +74,15 @@ learning / ADR / レビューコメントを出力する前に以下を検出し
 
 詳細は `pii.md` redaction 表と統合運用 (PII と Secrets は同じ Skill チェックポイントで検証)。
 
+## 機械検証 (A6 で導入)
+
+- **trufflehog** で全 PR 差分の secret scan (`.github/workflows/secret-scan.yml`、上記「漏洩検出」と統合)
+- **Gradle カスタムタスク** で以下を検証:
+  - `.env.example` に **キーのみ + ダミー値** が記載され、実値混入なし (regex で `=.{16,}` のような長文字列を warning)
+  - `gradle/libs.versions.toml` / `**/build.gradle.kts` 内に hardcode された access key / token がない (regex `(?i)(api[-_]?key|token|secret|password)\s*[:=]\s*["'][^"']{8,}["']`)
+  - `.gitignore` に `.env*` / `*-credentials.json` / `service-account*.json` / `.claude/oauth-tokens*` が含まれる
+- **GitHub Actions secret scanning** が repo 設定で有効化されている (Settings → Code security)
+
 ## Gotchas
 
 - **Skill が CI ログ / MCP 結果を learning / レビューコメントに含める場合は redaction 必須** (R-26)

--- a/.claude/rules/sparql.md
+++ b/.claude/rules/sparql.md
@@ -1,0 +1,124 @@
+---
+id: rules-sparql
+title: SPARQL クエリ実装規約 (im@sparql)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/network/imasparql/**/*.kt"
+  - "**/sparql/**/*.sparql"
+  - "**/sparql/**/*.rq"
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+---
+
+# sparql.md — SPARQL クエリ実装規約 (im@sparql)
+
+> アイドル情報 (THE iDOLM@STER ドメイン) の取得元として **im@sparql** (RDF / SPARQL endpoint) を使用 (ADR 0007 / 0014)。
+> 本 rule は SPARQL クエリの prefix 規約・命名・テスト方針を規定する。
+> ローカル開発は Fuseki Docker、本番は外部 im@sparql ホスティング (`docs/runbooks/sync-imasparql.md`)。
+
+## prefix 規約
+
+```sparql
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX imas:   <https://sparql.crssnky.xyz/imasrdf/RDFs/detail/>
+PREFIX imass:  <https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#>
+```
+
+- 必須 prefix: `rdf` / `rdfs` / `schema` / `imas` / `imass`
+- 追加 prefix が必要な場合は **ファイル先頭にまとめて宣言**、クエリ内に inline しない
+- prefix URI は **im@sparql 公式定義に従う** (https://im-sparql.com/)、変更時は ADR 起票
+
+## クエリ命名
+
+```sparql
+# search_idols_by_name.sparql
+PREFIX ...
+
+SELECT ?idol ?name ?nameKana ?brand ?color
+WHERE {
+    ?idol a imas:Idol ;
+          schema:name ?name ;
+          imass:nameKana ?nameKana ;
+          imas:Brand ?brand ;
+          imas:Color ?color .
+    FILTER(CONTAINS(?nameKana, ?query))
+}
+ORDER BY ?nameKana
+LIMIT 50
+```
+
+- ファイル名: **snake_case + .sparql / .rq** (`search_idols_by_name.sparql`)
+- 配置: `core/network/imasparql/src/commonMain/resources/sparql/*.sparql`
+- 1 ファイル 1 query を原則 (再利用性 / テスト容易性)
+
+## SPARQL ベストプラクティス
+
+- **SELECT 句で variable 名を明示** (`SELECT *` 禁止、結果型が変わる)
+- **OPTIONAL** で必須 / 任意プロパティを区別
+- **LIMIT 必須** (im@sparql endpoint の負荷軽減、デフォルト 50)
+- **FILTER は最後** (絞り込み効率)、`?var = "value"` より `STR(?var) = "value"` で型不一致を回避
+- **DISTINCT は必要時のみ** (高コスト)
+
+## Kotlin からの呼び出し (Ktor)
+
+```kotlin
+class ImasparqlClient(private val httpClient: HttpClient) {
+
+    suspend fun searchByName(query: String): List<IdolDto> {
+        val sparql = loadSparqlResource("sparql/search_idols_by_name.sparql")
+            .replace(":query", "\"$query\"")  // パラメータ置換
+
+        val response = httpClient.get("$baseUrl/query") {
+            parameter("query", sparql)
+            header(HttpHeaders.Accept, "application/sparql-results+json")
+        }
+        return response.body<SparqlResultsDto>().toIdolDtos()
+    }
+}
+```
+
+- SPARQL 結果は **SPARQL 1.1 Results JSON** で受信 (`application/sparql-results+json`)
+- パラメータは **文字列置換** (`SPARQL injection リスクあり`、エスケープ規約は本 rule §セキュリティ参照)
+- Endpoint URL は `BuildKonfig.IMASPARQL_BASE_URL` から取得 (`network-client.md` 参照)
+
+## セキュリティ (SPARQL injection 対策)
+
+- ユーザー入力 (`query`) を SPARQL クエリに埋め込む際は **escape 必須**:
+  - `"` → `\"`
+  - `\` → `\\`
+  - 改行 / タブ文字を除去
+- 可能なら **prepared query** (im@sparql エンドポイント側の機能) を利用
+- 不正な SPARQL syntax は endpoint 側で reject されるが、過度な負荷 (re-evaluation loop) を誘発する DoS 攻撃に注意 → `LIMIT` 必須
+
+## テスト方針
+
+- **ローカル開発**: Fuseki Docker (`docs/runbooks/local-imasparql.md`、A2-4 で本格化) を起動して fixtures データで実 SPARQL 実行
+- **CI**: MockEngine (Ktor) で SPARQL Results JSON を mock 返却、Client の結果 mapping のみ検証
+- 統合テスト (実 endpoint 叩く) は **手動 / 同期 PR の Renovate 確認時** に限定
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `core/network/imasparql/src/commonMain/resources/sparql/*.sparql` の prefix が必須セットを含む
+  - `LIMIT` 句が必須クエリ (SELECT) に存在
+  - parameter 置換用 placeholder (`:query` 等) が Kotlin source 側と整合
+
+## Gotchas
+
+- **im@sparql endpoint の rate limit** に注意 (1 req/sec 程度を推奨)、`core/network/imasparql` で client-side rate limiter (`Mutex` + delay) を実装
+- **SPARQL Results JSON の `value` 型は string** だが、`type: "uri"` / `type: "literal"` の区別がある。mapping で考慮
+- **`OPTIONAL` 句が深くネストすると遅い**。フラットに書く
+- 同期 PR (アイドル情報の自動取り込み) のクエリは `sync-job.md` 規約に従う、結果は `idols.db` に commit
+
+## 関連
+
+- ADR 0007 (im@sparql upstream-driven 同期)
+- ADR 0014 (im@sparql ローカル Fuseki)
+- im@sparql: https://sparql.crssnky.xyz/
+- SPARQL 1.1: https://www.w3.org/TR/sparql11-query/
+- `.claude/rules/{network-client,sync-job,sqlite-data-file}.md`
+- `docs/runbooks/local-imasparql.md` / `docs/runbooks/sync-imasparql.md`

--- a/.claude/rules/sql-delight.md
+++ b/.claude/rules/sql-delight.md
@@ -1,0 +1,146 @@
+---
+id: rules-sql-delight
+title: SqlDelight (SQLite) 実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*.sq"
+  - "**/sqldelight/**"
+  - "core/database/**/*.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0008
+  - ADR-0010
+---
+
+# sql-delight.md — SqlDelight (SQLite) 実装規約
+
+> KMP 対応の type-safe SQLite ラッパー **SqlDelight 2.x** を採用 (ADR 0002)。
+> アイドル情報マスタ (`data/idols.db`、in-repo) とユーザーデータ (`users.db`、Backend) の
+> 両方で使用 (ADR 0008 / 0010)。**users.db の取り扱いは `db-protection.md` を厳守**。
+
+## 配置
+
+| 種別 | 場所 |
+|---|---|
+| 共通スキーマ (`*.sq`) | `core/database/src/commonMain/sqldelight/net/subroh0508/colormaster/database/*.sq` |
+| Generated code | `<module>/build/generated/sqldelight/code/<DbName>/` (自動生成、commit しない) |
+| Driver factory (`expect/actual`) | `core/database/src/<platform>Main/.../driver/*Driver.kt` |
+| Migration 関数 (将来) | `core/database/src/commonMain/sqldelight/.../migrations/*.sqm` |
+
+## `*.sq` ファイル規約
+
+```sql
+CREATE TABLE Idol (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    name_kana TEXT NOT NULL,
+    brand_id TEXT NOT NULL,
+    color_hex TEXT NOT NULL,
+    FOREIGN KEY (brand_id) REFERENCES Brand(id)
+);
+
+CREATE INDEX idol_brand_id_idx ON Idol(brand_id);
+
+selectAll:
+SELECT * FROM Idol ORDER BY name_kana;
+
+selectByBrand:
+SELECT * FROM Idol WHERE brand_id = :brand_id ORDER BY name_kana;
+
+insertIdol:
+INSERT INTO Idol(id, name, name_kana, brand_id, color_hex)
+VALUES (?, ?, ?, ?, ?);
+```
+
+- テーブル名: **PascalCase** (`Idol`、`Brand`、`UserMyIdol`)
+- カラム名: **snake_case** (`brand_id`、`color_hex`)
+- query name: **camelCase** + 動詞始まり (`selectAll`、`insertIdol`、`updateColor`)
+- パラメータ: 名前付き引数 (`:brand_id`) または位置引数 (`?`)、可読性のため 3 個以上は名前付き
+
+## driver の `expect/actual`
+
+```kotlin
+// commonMain
+expect class DatabaseDriverFactory {
+    fun createDriver(): SqlDriver
+}
+
+// androidMain
+actual class DatabaseDriverFactory(private val context: Context) {
+    actual fun createDriver(): SqlDriver =
+        AndroidSqliteDriver(ColormasterDatabase.Schema, context, "colormaster.db")
+}
+
+// wasmJsMain (Web Worker driver)
+actual class DatabaseDriverFactory {
+    actual fun createDriver(): SqlDriver = WebWorkerDriver(...)
+}
+
+// desktopMain (JDBC SQLite)
+actual class DatabaseDriverFactory {
+    actual fun createDriver(): SqlDriver =
+        JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+}
+```
+
+- platform 別 driver は `wasm-compat.md` の方針に従う
+- テストでは `JdbcSqliteDriver.IN_MEMORY` を使用、actual file は触らない
+
+## Repository からの利用
+
+```kotlin
+class DefaultIdolColorsRepository(
+    private val db: ColormasterDatabase,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : IdolColorsRepository {
+
+    override suspend fun searchByName(query: String): List<Idol> =
+        withContext(ioDispatcher) {
+            db.idolQueries.selectByName("%$query%").executeAsList().map { it.toIdol() }
+        }
+}
+```
+
+- query は `.executeAsList()` / `.executeAsOne()` / `.executeAsOneOrNull()` で同期取得 (suspend 内で呼ぶ)
+- 継続購読は `.asFlow().mapToList(...)` (`app.cash.sqldelight:coroutines-extensions`)
+- ドメインモデルへの変換は mapping 関数 (`fun Idol.toIdol(): Idol`、generated row → ドメイン)
+
+## 2 つの DB の使い分け
+
+| DB 名 | スキーマ | 用途 | 配置 |
+|---|---|---|---|
+| `idols.db` (`ColormasterDatabase`) | Idol / Brand / Color | アイドル情報マスタ (read-only) | `data/idols.db` (リポジトリ commit、Docker image 焼込) |
+| `users.db` (`UserDatabase`) | UserMyIdol / UserSession | ユーザーデータ (uid のみ + my idols) | Backend 内、Litestream で R2 replicate |
+
+- `idols.db` は Git 内 SQLite、コンテナイメージにも焼込 (ADR 0010)、`.dockerignore` で除外しない
+- **`users.db` は absolutely 禁止** (commit / イメージ焼込 / 公開、`db-protection.md` 厳守)
+
+## migration
+
+- スキーマ変更時は `migrations/<version>.sqm` を追加 (SqlDelight 公式の version-based migration)
+- アイドル情報 (`idols.db`) は **migration 不要** (sync job で全件再生成、`sync-job.md` 参照)
+- ユーザーデータ (`users.db`) は migration 必要、Litestream restore との互換性を確認
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証 (§5.2):
+  - `*.sq` ファイル内に PII fields (`email TEXT` / `display_name TEXT`) が含まれない (`users.db` スキーマのみ対象、ADR 0020)
+  - `*.sq` の query name に typo (UPPERCASE / snake_case) がない
+- **SqlDelight 自身** が compile 時に SQL syntax / type 安全性を検証
+
+## Gotchas
+
+- **`*.sq` の generated code は `build/generated/sqldelight/` に出力**、commit しない
+- **複数 `*.sq` ファイル間で同名 query は不可** (`selectAll` を複数 file で定義 → compile error)
+- **driver の `Schema.create` は初回起動時のみ呼ぶ**、毎回 drop しない (テストは `IN_MEMORY` で都度作成 OK)
+- **`Flow` 経由の query は active subscription が必要**、ViewModel scope 外で collect しない
+- Backend (Cloud Run) は Linux JDBC SQLite + Litestream WAL replicate、ローカル開発は `JdbcSqliteDriver.IN_MEMORY` または `:file:` で差し替え可
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform)
+- ADR 0008 (Backend SQLite + Litestream + R2)
+- ADR 0010 (アイドル情報 SQLite in-repo)
+- SqlDelight: https://cashapp.github.io/sqldelight/
+- `.claude/rules/{repository,db-protection,sqlite-data-file,sync-job,r2-litestream,wasm-compat}.md`

--- a/.claude/rules/sqlite-data-file.md
+++ b/.claude/rules/sqlite-data-file.md
@@ -1,0 +1,79 @@
+---
+id: rules-sqlite-data-file
+title: SQLite データファイルの取り扱い
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "data/**"
+  - "Dockerfile"
+  - ".dockerignore"
+related_adrs:
+  - ADR-0008
+  - ADR-0010
+  - ADR-0020
+---
+
+# sqlite-data-file.md — SQLite データファイルの取り扱い
+
+> 本リポジトリで扱う SQLite データベースファイルの **コミット可否 / イメージ焼込可否 /
+> アクセス制御** を明確化する規約。`db-protection.md` (`users.db` 限定の安全網) と
+> `sql-delight.md` (スキーマ実装) の中間の運用規約。
+
+## 対象 DB ファイル
+
+| ファイル | 用途 | リポジトリ commit | Docker image 焼込 | 取り扱い |
+|---|---|---|---|---|
+| `data/idols.db` | アイドル情報マスタ (read-only) | ✅ OK | ✅ OK | sync job で更新、PR レビュー必須 |
+| `data/users.db` | ユーザーデータ (uid のみ + my idols) | ❌ **禁止** | ❌ **禁止** | Backend 起動時に Litestream から restore |
+| `data/users.db-wal` / `data/users.db-shm` | SQLite WAL / SHM (Litestream replication 中) | ❌ **禁止** | ❌ **禁止** | Litestream が R2 へ continuous replicate |
+
+## `data/idols.db` の運用
+
+- **配置**: リポジトリ root `data/idols.db`
+- **更新**: `.github/workflows/sync-imasparql.yml` (`sync-job.md` 参照)
+- **スキーマ**: SqlDelight `.sq` ファイル (`sql-delight.md` 参照)、migration 不要 (全件再生成)
+- **アクセス**: ClientApp (Android / Wasm / Desktop) が `core/database` 経由で読み取り、書き込み禁止
+- **Backend からも参照**: Backend (Cloud Run) は同じ `idols.db` をコンテナイメージから読み取り (read-only)
+
+## `data/users.db` の禁止運用
+
+- **絶対 commit しない**: `.gitignore` で `data/users.db*` を除外 (B0 で配置済)
+- **絶対イメージに焼込まない**: `.dockerignore` で `data/users.db*` を除外 (`db-protection.md` の必須項目)
+- **Backend 起動時に Litestream restore**: コンテナ起動スクリプトで R2 から WAL を pull、`/data/users.db` を hydrate
+- **アクセスは Backend のみ**: ClientApp は直接アクセス不可、Backend API 経由 (`backend-auth.md` 参照)
+
+## ローカル開発時の `users.db`
+
+- 開発者ごとに別ファイル (`.gitignore` 対象、共有禁止)
+- 初回起動時に空の `users.db` を Backend が生成 (schema migration 自動実行)
+- PII 含めない fixture data は `scripts/fixtures/seed-users.sql` (将来、`@example.com` ドメインのみ) で投入
+
+## Backup と Restore
+
+- **Backup**: Litestream が WAL を R2 bucket (`colormaster-users-db-backup`) に continuous replicate (`r2-litestream.md` 参照)
+- **Restore**: Backend 起動時に Litestream `restore` コマンドで R2 から最新状態を hydrate
+- **Disaster Recovery**: Cloud Run コンテナ完全再作成時も R2 から restore で復旧 (RPO ~1 分、RTO ~30 秒)
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `git ls-files data/users.db*` の結果が空 (commit 検知)
+  - `Dockerfile` 内に `COPY data/users.db` パターンが存在しない
+  - `.dockerignore` に `data/users.db*` / `.env*` / `*-credentials.json` 全てが含まれる (`db-protection.md` 必須項目)
+  - `data/idols.db` のスキーマが期待通り (`Idol` テーブル存在 + 件数 > 0)
+- **trufflehog** で全 PR 差分の secret scan、`users.db` を含む差分を block
+
+## Gotchas
+
+- **SQLite WAL モードの `users.db-wal` / `users.db-shm` も commit 禁止**。`.gitignore` で `data/users.db*` (`*` glob で全 suffix カバー)
+- **`data/idols.db` は git LFS を使わない**。ファイルサイズが大きくなったら別 ADR で LFS 採用検討 (現状 ~MB 以下を想定)
+- **本番イメージで `data/idols.db` の整合性検証**: コンテナ起動時に `PRAGMA integrity_check` を実行、failure 時は Cloud Run health check で unhealthy 返答
+- ローカル開発者間で `users.db` の sharing は禁止 (PII 漏洩リスク)、テスト用は **個人ローカル のみ**
+
+## 関連
+
+- ADR 0008 (Backend SQLite + Litestream + R2)
+- ADR 0010 (アイドル情報 SQLite in-repo)
+- ADR 0020 (PII 保護)
+- `.claude/rules/{db-protection,sql-delight,sync-job,r2-litestream,backend-auth,cloud-run-deploy,secrets,pii}.md`
+- `docs/runbooks/local-development.md` (A2-4 で本格化)

--- a/.claude/rules/sync-job.md
+++ b/.claude/rules/sync-job.md
@@ -1,0 +1,102 @@
+---
+id: rules-sync-job
+title: im@sparql 同期ジョブ規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".github/workflows/sync-imasparql.yml"
+  - "scripts/sync-imasparql/**"
+  - "data/idols.db"
+related_adrs:
+  - ADR-0007
+  - ADR-0010
+  - ADR-0014
+---
+
+# sync-job.md — im@sparql 同期ジョブ規約
+
+> im@sparql endpoint からアイドル情報を取得し、`data/idols.db` (SqlDelight 用 SQLite ファイル) を
+> 更新する **upstream-driven 同期** (ADR 0007) の運用規約。GitHub Actions の scheduled workflow
+> で動作し、生成された PR を **Renovate ラベル** で `pr-poller` 経由 `dependency-upgrade` Skill が処理。
+
+## 同期トリガー
+
+| トリガー | 頻度 | workflow |
+|---|---|---|
+| Scheduled (cron) | 週次 (日曜 02:00 JST) | `.github/workflows/sync-imasparql.yml` |
+| Manual (`workflow_dispatch`) | 必要時 | 同上 (手動 dispatch) |
+| im@sparql 側更新検知 (将来) | webhook | (Phase C で検討) |
+
+## ジョブ構成
+
+```yaml
+# .github/workflows/sync-imasparql.yml (概略)
+on:
+  schedule:
+    - cron: '0 17 * * 6'  # 土曜 17:00 UTC = 日曜 02:00 JST
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - checkout
+      - run: scripts/sync-imasparql/run.sh
+      - name: Create PR
+        if: ${{ env.has_diff == 'true' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sync/imasparql-${{ env.timestamp }}
+          labels: renovate, sync-imasparql
+          title: "sync(imasparql): weekly idol data update"
+```
+
+- スクリプト本体は `scripts/sync-imasparql/run.sh` (新規追加予定、Phase B-C で本格化)
+- 生成 PR には **`renovate` + `sync-imasparql` ラベル** を付与し、`pr-poller` の `dependency-upgrade` 経由で AI レビュー
+
+## 同期処理ステップ
+
+1. `core/network/imasparql` の SPARQL クエリを起動し、`Idol` / `Brand` / `Color` 全件取得
+2. ローカル一時 SQLite DB を作成 (`/tmp/idols-new.db`)
+3. 既存 `data/idols.db` と差分比較 (SQL diff)
+4. 差分があれば `data/idols.db` を上書き → `git add data/idols.db`
+5. PR 作成 (差分 summary は workflow log + PR description)
+
+## アイドル情報 SQLite (`idols.db`) の取り扱い
+
+- **リポジトリに commit OK** (read-only データ、ADR 0010)
+- **コンテナイメージにも焼込 OK** (Dockerfile で `COPY data/idols.db /app/data/`)
+- スキーマ migration は **不要** (sync で全件再生成 = drop & recreate)
+- ユーザーデータ DB (`users.db`) との明確な区別は `db-protection.md` / `sqlite-data-file.md` 参照
+
+## 同期 PR のレビューフロー
+
+1. `pr-poller` (ローカル Claude Code) が `renovate` ラベル PR を検出
+2. `dependency-upgrade` Skill が PR 内容を解析
+   - diff のサイズ / 影響アイドル数 / Brand 追加検知
+3. 自動承認可能な変更 (アイドル追加のみ等) → `Approve` & merge 待ち
+4. 注意必要な変更 (既存アイドル削除 / Brand カラー変更等) → 人間承認待ちでコメント post
+
+## 機械検証 (A6 で導入)
+
+- **Gradle カスタムタスク** で以下を検証:
+  - `data/idols.db` のスキーマが `core/database/src/commonMain/sqldelight/.../*.sq` と整合
+  - sync 後の DB に `Idol` テーブルが空でない (smoke check)
+- **Workflow** 内で `sqlite3 data/idols.db "SELECT COUNT(*) FROM Idol"` で件数 sanity check (0 件なら fail)
+
+## Gotchas
+
+- **im@sparql endpoint の rate limit** を遵守 (1 req/sec)、複数クエリは sequential 実行
+- **sync で `users.db` を touch しない**。ジョブの権限スコープから明示的に除外 (`db-protection.md` 厳守)
+- **diff が大きすぎる PR は warning** (例: 10% 以上のアイドル削除) → 人間レビュー強制
+- **同期失敗時の通知**: workflow failure → GitHub Issues 自動起票 (将来、Phase C で実装)
+- ローカル開発で sync 試験する場合は **Fuseki Docker** (`docs/runbooks/local-imasparql.md`、A2-4 で本格化) を使用
+
+## 関連
+
+- ADR 0007 (im@sparql upstream-driven 同期)
+- ADR 0010 (アイドル情報 SQLite in-repo)
+- ADR 0014 (im@sparql ローカル Fuseki)
+- `.claude/rules/{sparql,sqlite-data-file,db-protection,pr-poller}.md`
+- `.claude/skills/dependency-upgrade/SKILL.md`
+- `docs/runbooks/sync-imasparql.md` (A2-4 で本格化)

--- a/.claude/rules/test-paired-class.md
+++ b/.claude/rules/test-paired-class.md
@@ -1,0 +1,103 @@
+---
+id: rules-test-paired-class
+title: 実装 ⇄ テストクラスペアリング検証
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "**/*.kt"
+  - "**/*Spec.kt"
+related_adrs:
+  - ADR-0004
+  - ADR-0013
+---
+
+# test-paired-class.md — 実装 ⇄ テストクラスペアリング検証
+
+> 主要な実装クラスに対し **1 対 1 のテストクラス** が存在することを Konsist で検証する規約。
+> 「テスト書き忘れ」の機械検知と、命名規約 (`*ViewModel` ⇄ `*ViewModelSpec`) の機械強制を担う。
+
+## ペアリング対象
+
+| 実装側 | テスト側 | 配置 |
+|---|---|---|
+| `*ViewModel.kt` | `*ViewModelSpec.kt` | 同 module の `commonTest` |
+| `Default*Repository.kt` | `Default*RepositorySpec.kt` | 同 module の `commonTest` |
+| `*Client.kt` (network) | `*ClientSpec.kt` | 同 module の `commonTest` (MockEngine 使用) |
+| `*Screen.kt` (Composable) | `*ScreenshotTest.kt` | 同 module の `jvmTest` (Roborazzi、`screenshot-test.md`) |
+| `*UseCase.kt` (将来) | `*UseCaseSpec.kt` | 同 module の `commonTest` |
+| `*Mapper.kt` (DTO 変換) | `*MapperSpec.kt` | 同 module の `commonTest` |
+
+## ペアリング対象外 (テスト不要 / 別検証で代替)
+
+| 種別 | 理由 |
+|---|---|
+| `*UiState.kt` / `*UiAction.kt` | data class / sealed interface のみ、振る舞いなし |
+| `Route.kt` (Navigation Route 定義) | `@Serializable` data class のみ |
+| `*Dto.kt` | `@Serializable` data class のみ |
+| `expect class` の宣言 (`commonMain`) | actual 実装側でテスト |
+| `package-info.kt` / 拡張関数のみのファイル | 個別 Spec ではなく、関連 Spec 内で検証 |
+| `Application.kt` / `MainActivity.kt` 等のエントリポイント | E2E / smoke test で代替 |
+
+## 命名規約 (Konsist で強制)
+
+```kotlin
+// 実装
+class SearchIdolsViewModel(...) : ViewModel() { ... }
+
+// テスト (同 package 階層、suffix Spec)
+class SearchIdolsViewModelSpec : DescribeSpec({ ... })
+```
+
+- テストクラス名は **`<実装クラス名>Spec`** (suffix `Spec` 固定)
+- 旧 JUnit / Spek の `*Test` suffix は **新規禁止**、`*Spec` に統一 (Kotest)
+- 配置 package は実装と一致 (例: `net.subroh0508.colormaster.features.search.viewmodel`)
+
+## Konsist 検証ロジック (擬似コード)
+
+```kotlin
+@Test
+fun `every ViewModel has a paired Spec`() {
+    val viewModels = Konsist.scopeFromProduction()
+        .classes()
+        .withSuffix("ViewModel")
+        .filter { !it.isAbstract && it.parentClass()?.name == "ViewModel" }
+
+    val specs = Konsist.scopeFromTest()
+        .classes()
+        .withSuffix("Spec")
+        .map { it.name }
+
+    viewModels.assertTrue { vm ->
+        "${vm.name}Spec" in specs
+    }
+}
+```
+
+- 対象ペアごとに同様の Konsist test を `core/<module>/src/commonTest/konsist/` に配置
+- 検証は `./gradlew check` 経由で CI 実行
+
+## Coverage 段階達成 (ADR 0013) との連動
+
+- 1 ペア = 「最低限のテストファイル存在」確認のみ、内容の網羅性 (line / branch coverage) は **kover** で別途検証 (`coverage-100.md`、A7 で本格化)
+- 「ペアリング欠如 → CI 失敗」が最初のガードレール、coverage 100% は段階的に目指す
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で上記ペアリングを検証 (R-21):
+  - 実装ファイルが存在し、対応する Spec ファイルが存在しない → CI 失敗
+  - 逆方向 (Spec ファイルだけ存在し実装がない) も検出して error 化
+  - 例外は **annotation で明示** (`@SkipPairedSpec` を実装側に付与、理由を comment 必須)
+
+## Gotchas
+
+- **`@SkipPairedSpec` の濫用に注意**。理由 (`@SkipPairedSpec("data class only, no behavior")`) を必須化、code-reviewer の test-quality aspect で再評価
+- **Composable は `*ScreenshotTest` で代替**、`*Spec` (unit test) は不要 (state-less な前提)
+- **interface の Spec は不要**、実装クラスの Spec で振る舞いを検証
+- ペアリング検証が「テストを書いた感」だけで終わらないよう、line / branch / mutation coverage と合わせて品質を担保
+
+## 関連
+
+- ADR 0004 (テスト戦略)
+- ADR 0013 (Line/Branch 段階達成)
+- Konsist: https://docs.konsist.lemonappdev.com/
+- `.claude/rules/{kotlin-test,screenshot-test,coverage-100,spec-traceability,naming}.md`

--- a/.claude/rules/ui-state.md
+++ b/.claude/rules/ui-state.md
@@ -1,0 +1,115 @@
+---
+id: rules-ui-state
+title: UiState / UiAction の実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/features/**/*UiState.kt"
+  - "core/features/**/*UiAction.kt"
+  - "feature/**/*UiState.kt"
+  - "feature/**/*UiAction.kt"
+related_adrs:
+  - ADR-0002
+---
+
+# ui-state.md — UiState / UiAction の実装規約
+
+> Compose Multiplatform + UDF (Unidirectional Data Flow) パターンに基づき、
+> `*UiState` data class と `*UiAction` sealed interface の構造・命名・更新方法を規定する。
+> ViewModel と Screen の境界 contract として機能 (`viewmodel.md` / `composable.md` 参照)。
+
+## 配置と命名
+
+- 配置: `core/features/<feature>/src/commonMain/kotlin/net/subroh0508/colormaster/features/<feature>/viewmodel/*UiState.kt` (および `*UiAction.kt`)
+- 命名: ViewModel と 1:1 対応
+  - `SearchIdolsViewModel` ⇄ `SearchIdolsUiState` + `SearchIdolsUiAction`
+  - `MyIdolsViewModel` ⇄ `MyIdolsUiState` + `MyIdolsUiAction`
+
+## UiState 構造
+
+```kotlin
+data class SearchIdolsUiState(
+    val query: String = "",
+    val results: List<Idol> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: Throwable? = null,
+)
+```
+
+- **`data class` で immutable** (`val` フィールドのみ)
+- 全フィールドにデフォルト値を持たせる (`MutableStateFlow(SearchIdolsUiState())` で初期化可能にする)
+- フィールド型は **primitive / `List<T>` / `Map<K,V>` / `Idol` 等のドメインモデル** に限定
+- **`Flow<T>` / `Job` / `CoroutineScope` / `Composable` を含めない** (シリアライズ不能 + Compose 再構成性壊れる)
+
+## UiAction 構造
+
+```kotlin
+sealed interface SearchIdolsUiAction {
+    data class QueryChanged(val query: String) : SearchIdolsUiAction
+    data object SearchClicked : SearchIdolsUiAction
+    data class IdolToggled(val idolId: IdolId) : SearchIdolsUiAction
+}
+```
+
+- **`sealed interface` で網羅性チェック可能** (when 式の exhaustive 判定)
+- 引数なしは `data object`、引数ありは `data class` (Kotlin 1.9+ の `data object` 文法)
+- 命名は **過去形・命令形** (`QueryChanged` / `SearchClicked` / `RetryRequested`)、現在形は避ける
+
+## UiState の更新
+
+ViewModel 内で:
+
+```kotlin
+private fun handleQueryChanged(query: String) {
+    _uiState.update { it.copy(query = query, error = null) }
+}
+```
+
+- **`MutableStateFlow.update { it.copy(...) }`** で atomic に更新
+- 直接 `_uiState.value = ...` は競合状態を生むため避ける
+- 複数フィールド更新は **1 つの `update` 内で行う** (途中状態を流さない)
+
+## one-shot event の扱い
+
+```kotlin
+data class SearchIdolsUiState(
+    ...
+    val navigateToDetailEvent: Event<IdolId>? = null,
+)
+
+// Screen 側
+LaunchedEffect(uiState.navigateToDetailEvent) {
+    uiState.navigateToDetailEvent?.consume { idolId -> onNavigate(idolId) }
+}
+```
+
+- **`SharedFlow` で event を流すパターンは原則禁止** (`viewmodel.md` 参照)
+- `Event<T>` ラッパー (consume 後 null 化) を UiState に含める
+- Screen が consume したら ViewModel に `EventConsumed` action を dispatch して UiState を null 化
+
+## 派生フィールドの扱い
+
+- 派生フィールド (例: `val hasResults: Boolean = results.isNotEmpty()`) は **computed property** で書く (`get() = results.isNotEmpty()`)
+- ただし Compose 側で頻繁に参照する場合は `data class` フィールドとして persist (`copy(hasResults = results.isNotEmpty())`) も許容、好みで判断
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を検証 (R-21):
+  - `*UiState` は `data class` で全フィールド `val` (immutable)
+  - `*UiState` フィールド型に `Flow<*>` / `Job` / `CoroutineScope` / `@Composable` が含まれない
+  - `*UiAction` は `sealed interface` (top-level)
+  - `*UiAction` のサブタイプは `data class` または `data object` のみ
+  - `*ViewModel` ⇄ `*UiState` ⇄ `*UiAction` の 1:1 対応 (`SearchIdols*` の prefix が揃う)
+
+## Gotchas
+
+- **`UiState` を共有 (`SharedFlow.shareIn`) しない**。ViewModel 内に閉じる
+- **`UiState` の equality は data class の auto-generated equals に依存**。`List<Idol>` の中身が `Idol`(data class) になっていない場合、再構成判定が壊れる
+- ドメインモデル (`Idol` 等) の追加フィールドが increasing しすぎると **UiState の全フィールド差分判定がコスト化**。必要に応じて画面用 ViewObject (`SearchIdolsItem`) を導入
+- **`UiAction` のサブタイプ数が 10 を超えたら画面分割を検討**。1 つの ViewModel が抱えすぎている兆候
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- `.claude/rules/{viewmodel,composable,navigation,error-handling}.md`
+- `docs/architecture/state-machines.md` (A2-5 で本格化)

--- a/.claude/rules/viewmodel.md
+++ b/.claude/rules/viewmodel.md
@@ -1,0 +1,106 @@
+---
+id: rules-viewmodel
+title: ViewModel 層の実装規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/features/**/*ViewModel.kt"
+  - "feature/**/*ViewModel.kt"
+related_adrs:
+  - ADR-0002
+  - ADR-0003
+  - ADR-0005
+---
+
+# viewmodel.md — ViewModel 層の実装規約
+
+> Compose Multiplatform + 共通 ViewModel (ADR 0002) に基づき、`core/features/<feature>/`
+> 配下に配置される `*ViewModel.kt` の構造・公開 API・依存関係を規定する。
+> Decompose を撤去済 (ADR 0005)、Navigation 3 + `androidx.lifecycle.ViewModel` を使用。
+
+## 配置と命名
+
+- 配置: `core/features/<feature>/src/commonMain/kotlin/net/subroh0508/colormaster/features/<feature>/viewmodel/*ViewModel.kt`
+- 命名: `<機能>ViewModel.kt` (パスカルケース末尾 `ViewModel`)
+- 例: `SearchIdolsViewModel.kt` / `MyIdolsViewModel.kt` / `PenlightViewModel.kt`
+
+## 構造
+
+```kotlin
+class SearchIdolsViewModel(
+    private val repository: IdolColorsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchIdolsUiState())
+    val uiState: StateFlow<SearchIdolsUiState> = _uiState.asStateFlow()
+
+    fun dispatch(action: SearchIdolsUiAction) { ... }
+}
+```
+
+- **`androidx.lifecycle.ViewModel` を継承** (KMP `lifecycle-viewmodel` artifact 経由で共通使用)
+- **公開 API は `uiState: StateFlow<*UiState>` と `dispatch(action: *UiAction)` のみ**
+- `_uiState: MutableStateFlow` は private、外部から直接 mutate しない
+- `viewModelScope` で coroutine を起動、明示的な `Job` 管理は避ける (cancel は ViewModel ライフサイクルに任せる)
+
+## 依存関係
+
+| 種別 | 注入方法 | 例 |
+|---|---|---|
+| Repository (interface) | constructor 注入 | `private val repository: IdolColorsRepository` |
+| `SavedStateHandle` | constructor 注入 (Navigation 3 args 受領) | `savedStateHandle: SavedStateHandle` |
+| `CoroutineDispatcher` (テスト容易性のため) | constructor デフォルト引数 (`Dispatchers.Default`) | `private val dispatcher: CoroutineDispatcher = Dispatchers.Default` |
+
+- **直接 `Client` (Ktor / OkHttp 等) を注入しない**。必ず Repository 経由
+- **直接 `Context` (Android) / `Activity` (Android) を注入しない**。Wasm / Desktop 互換性が壊れる
+- `core/model` (Repository interface) と `core/usecase` (将来追加可) のみ依存可、`core/data` 直接依存は禁止
+
+## UiAction 処理
+
+```kotlin
+fun dispatch(action: SearchIdolsUiAction) {
+    when (action) {
+        is SearchIdolsUiAction.QueryChanged -> handleQueryChanged(action.query)
+        SearchIdolsUiAction.SearchClicked -> handleSearchClicked()
+    }
+}
+```
+
+- `when` は exhaustive (sealed interface により網羅性チェック)
+- 副作用は `viewModelScope.launch { ... }` で非同期実行、UiState 更新は `_uiState.update { it.copy(...) }`
+
+## エラーハンドリング
+
+- Repository 呼び出しは `runCatching { ... }` で wrap、`onSuccess` / `onFailure` で分岐
+- 失敗時は UiState の `error: Throwable?` フィールドに保持、Screen 側で `Snackbar` 表示
+- 詳細は `.claude/rules/error-handling.md` 参照
+
+## SavedStateHandle 規約
+
+- Navigation 3 の type-safe args を `savedStateHandle.toRoute<RouteType>()` で受領 (`navigation.md` 参照)
+- 検索クエリ等の `restored on process death` 状態は `savedStateHandle["query"] = value` で保存
+- 大量データ (検索結果リスト等) は `SavedStateHandle` に保存しない (10KB 上限の Android 制約)
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で以下を強制 (R-20):
+  - `feature/**/*ViewModel.kt` および `core/features/**/*ViewModel.kt` は `androidx.lifecycle.ViewModel` を継承
+  - 公開プロパティ (`val` で `public` 可視性) は `uiState: StateFlow<*UiState>` のみ (`dispatch(...)` を除く)
+  - `_uiState` は `private` で `MutableStateFlow`
+  - constructor に `Client` 系 (`core/network/*Client*`) の型を持たない
+
+## Gotchas
+
+- **`SharedFlow` / `EventFlow` で one-shot event を流すパターンは原則禁止**。UiState に `oneShotEvent: Event?` フィールドを置き、Screen 側で `LaunchedEffect(uiState.oneShotEvent) { ... }` で消費する
+- **`ViewModel` 内で `Composable` を呼ばない**。Compose と ViewModel の境界は厳密
+- **`viewModelScope` 外で coroutine を起動しない**。`GlobalScope.launch` 禁止、テスト容易性が壊れる
+- 旧 Decompose 由来の `ComponentContext` / `Store` API は撤去済 (ADR 0005)。再導入時は別 ADR
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform + Nav3 + 共通 ViewModel)
+- ADR 0003 (feature-first モジュール構造)
+- ADR 0005 (Decompose 撤去)
+- `.claude/rules/{ui-state,composable,navigation,repository,error-handling}.md`
+- `docs/architecture/layers.md` (A2-5 で本格化)

--- a/.claude/rules/wasm-compat.md
+++ b/.claude/rules/wasm-compat.md
@@ -1,0 +1,128 @@
+---
+id: rules-wasm-compat
+title: wasm-js 互換性規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "core/**/commonMain/**/*.kt"
+  - "core/**/wasmJsMain/**/*.kt"
+  - "feature/**/commonMain/**/*.kt"
+  - "**/build.gradle.kts"
+related_adrs:
+  - ADR-0002
+  - ADR-0012
+---
+
+# wasm-compat.md — wasm-js 互換性規約
+
+> Compose Multiplatform の wasm-js target に対応するため、`commonMain` で
+> Wasm 非互換 API (`okhttp3.*` / `java.awt.*` / `android.*` 等) を参照しない規約を強制する。
+> 旧 Decompose 撤去 (ADR 0005) + 旧 JS 実装撤去 (ADR 0012) に伴い、`wasmJs` target に統一。
+
+## Wasm 非互換 API (commonMain で禁止)
+
+| カテゴリ | 禁止 import 例 | 理由 |
+|---|---|---|
+| OkHttp | `okhttp3.*` | Wasm 非サポート (JS Fetch 経由) |
+| Android SDK | `android.content.*` / `android.os.*` / `android.util.*` | Android only |
+| AWT / Swing | `java.awt.*` / `javax.swing.*` | Desktop only |
+| Java IO (一部) | `java.io.File` / `java.nio.file.*` | Wasm fs 限定的サポート |
+| Java reflection (一部) | `java.lang.reflect.*` | wasm-js は reflection サポート限定 |
+| Coroutines `Dispatchers.IO` | `kotlinx.coroutines.Dispatchers.IO` | wasm-js は `IO` dispatcher 未提供、`Default` を使う |
+| Thread | `java.lang.Thread` / `kotlin.concurrent.thread` | wasm-js は単一スレッド |
+
+## プラットフォーム別の置き換え
+
+| 機能 | commonMain (Wasm 互換) | プラットフォーム別 (`expect/actual`) |
+|---|---|---|
+| HTTP | `Ktor Client` (engine は expect) | OkHttp (Android) / JS Fetch (Wasm) / CIO (Desktop) |
+| 永続化 | `SqlDelight` (`core/database`) | Driver: `AndroidSqliteDriver` / `WebWorkerDriver` (Wasm) / `JdbcSqliteDriver` (Desktop) |
+| 設定保存 | `multiplatform-settings` | `SharedPreferencesSettings` (Android) / `StorageSettings` (Wasm) |
+| 並行処理 | `kotlinx.coroutines` + `Dispatchers.Default` / `Dispatchers.Main` | (デフォルト共通) |
+| ログ | `Napier` | platform-specific antilog |
+
+## CoroutineDispatcher
+
+- **`Dispatchers.IO` を `commonMain` で使わない** (wasm-js 非サポート)
+- IO 系処理は `withContext(Dispatchers.Default)` で代替
+- platform-specific に `IO` を使いたい場合は `expect val ioDispatcher: CoroutineDispatcher` を定義し、`Android`: `Dispatchers.IO` / `wasmJs`: `Dispatchers.Default` で actual 実装
+
+## `expect/actual` 規約
+
+```kotlin
+// commonMain
+expect class HttpClientFactory {
+    fun create(): HttpClient
+}
+
+// androidMain
+actual class HttpClientFactory {
+    actual fun create(): HttpClient = HttpClient(OkHttp) { commonConfig() }
+}
+
+// wasmJsMain
+actual class HttpClientFactory {
+    actual fun create(): HttpClient = HttpClient(Js) { commonConfig() }
+}
+```
+
+- `expect` は **interface ではなく class / fun** を推奨 (Compose Multiplatform 慣例)
+- actual 実装は **platform 専用 API のみ参照**、commonMain の共通設定関数 (`commonConfig`) を呼ぶ
+
+## Compose 互換性
+
+- `@Composable` 関数本体は `commonMain` に置く
+- `androidx.compose.ui.platform.LocalContext` 等の Android 専用 API を `commonMain` で参照しない (`expect/actual` で抽象化)
+- Image / Font / Color resource は `compose-resources` 経由 (Wasm でも動く範囲、`i18n.md` 参照)
+
+## Build 設定
+
+```kotlin
+kotlin {
+    androidTarget()
+    wasmJsTarget {
+        browser {
+            commonWebpackConfig {
+                outputFileName = "colormaster.js"
+            }
+        }
+    }
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.ktor.client.core)
+            // OkHttp は androidMain でのみ
+        }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
+        }
+    }
+}
+```
+
+- **`commonMain` には wasm 非互換 lib を含めない**
+- platform-specific dependency は対応 source set のみ
+
+## 機械検証 (A6 で導入)
+
+- **Konsist** で `commonMain` 配下の Kotlin source に Wasm 非互換 import が含まれていない (R-22):
+  - `okhttp3.*` / `java.awt.*` / `javax.swing.*` / `android.*` / `java.lang.Thread` / `Dispatchers.IO` の参照を warning または error
+- **Gradle カスタムタスク** で build script の dependency 設定:
+  - `commonMain.dependencies { okhttp(...) }` 等の誤配置を検出
+
+## Gotchas
+
+- **`String.format(...)` の locale**: wasm-js では `Locale.US` 等の locale 引数が無視される場合がある。`String.format(Locale.ROOT, ...)` でも安全のため明示
+- **`System.currentTimeMillis()` ⇄ `kotlinx.datetime.Clock.System.now()`**: 後者を commonMain で使用、wasm-js は JS Date 経由
+- **Coroutines `withTimeoutOrNull` は wasm-js でも動く** が、一部 cancellation 動作に差異がある。テストを multi-platform で実行 (`kotlin-test.md` 参照)
+- **Reflection を必要とする lib (一部 DI / kotlinx-serialization の `serializer<T>()`) は wasm-js 制約あり**。`@Serializable` annotation + compile-time generated serializer で対応
+- 旧 JS (`js/app/`) 実装は撤去済 (ADR 0012)、wasmJs に統一。再導入は別 ADR
+
+## 関連
+
+- ADR 0002 (Compose Multiplatform)
+- ADR 0012 (旧 JS 実装撤去)
+- Kotlin Multiplatform Wasm: https://kotlinlang.org/docs/wasm-overview.html
+- `.claude/rules/{network-client,sql-delight,composable,kotlin-test}.md`

--- a/docs/epics/EPIC-A2-rules-docs-extension/progress.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/progress.md
@@ -24,6 +24,8 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-1 PR #121 merge 完了 (commit `feb41b5`、`gh pr merge --merge`) | A2-1 PR #121 |
 | 2026-05-17 | A2-1 Phase 8 (roadmap-tracker 手動代替) 実施 → PR #122 (`harness/roadmap-mirror-a2-1`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md 更新 | PR #122 |
 | 2026-05-17 | A2-1 Phase 9 (worktree cleanup) 実施 → `feature/A2-rules-docs-extension` worktree remove + branch -d | — |
+| 2026-05-17 | A2-2 着手 (worktree `feature/A2-2-rules-impl`、`implementation-workflow` Phase 1 から)。29 件新規 rule + 5 件 skeleton 本格化 + rules-index.md 正規化 | A2-2 PR #125 (A2-4 / A2-5 と並走) |
+| 2026-05-17 | A2-2 Draft PR #125 起票 (37 ファイル / +3,497 行)、code-reviewer 4 aspect 並列 review (test/UI/perf スコープ外) → Critical 0 + Improvement 3 件即時反映 (commit `310e430`) | A2-2 PR #125 |
 | 2026-05-17 | A2-4 着手 (worktree `feature/A2-4-docs-core` で `implementation-workflow` Phase 1 から、A2-2 / A2-5 と並走) | A2-4 PR #123 |
 | 2026-05-17 | A2-5 着手 (worktree `feature/A2-5-docs-arch-api` で `implementation-workflow` Phase 1 から、A2-2 / A2-4 と並走) | A2-5 PR #126 |
 | 2026-05-17 | A2-5: docs/architecture 7 + docs/api 5 = 12 ファイルを 5KB+ に拡充 (合計 +2,005 行)、PR #126 ドラフト起票 (commit `4fc26a2`) | A2-5 PR #126 |
@@ -31,7 +33,8 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-5 fix loop 実施 (commit `de2b1f8`、Critical 4 件解消) → Coordinator が Ready 判定 | A2-5 PR #126 |
 | 2026-05-17 | A2-4 PR #123 merge 完了 → master 取得 → A2-5 PR #126 を rebase (`progress.md` / `roadmap.md` 衝突を A2-4 完了反映と A2-5 着手記録の統合で解決) | A2-5 PR #126 |
 | 2026-05-17 | A2-5 PR #126 Ready 昇格 + merge 完了 (commit `168ef5d`、squash merge、`gh pr merge --squash --admin` で orchestrator 委任 / R-15 代替) | A2-5 PR #126 |
-| 2026-05-17 | A2-5 Phase 8 (roadmap-tracker 手動代替) 実施 → 本 PR (`harness/roadmap-mirror-a2-5`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md の A2-5 完了反映 | 本 PR (A2-5 mirror) |
+| 2026-05-17 | A2-5 Phase 8 (roadmap-tracker 手動代替) 実施 → PR #128 (`harness/roadmap-mirror-a2-5`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md の A2-5 完了反映 | PR #128 |
+| 2026-05-17 | A2-2 master rebase × 2 回実施 (PR #122 / #124 → 2 回目 #123 / #126 / #128 反映)、`docs/epics/EPIC-A2-rules-docs-extension/{roadmap,progress}.md` の conflict を master 側 (A2-4 / A2-5 完了根拠) を保持しつつ A2-2 着手記録を統合する形で解決 | A2-2 PR #125 |
 
 ## マイルストーン
 
@@ -42,6 +45,7 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-4 マージ (docs/ コア + runbooks 拡充) | ✅ 達成 (PR #123) |
 | 2026-05-17 | A2-5 PR ドラフト起票 | ✅ 達成 (PR #126) |
 | 2026-05-17 | A2-5 マージ (docs/architecture + api 拡充) | ✅ 達成 (PR #126、commit `168ef5d`) |
-| (未定) | A2-2 マージ (rules 実装・コード系本格化) | 進行中 (PR #125 DRAFT) |
+| 2026-05-17 | A2-2 Draft PR 起票 + code-reviewer 並列 review 完了 | ✅ 達成 (PR #125、Critical 0) |
+| (未定) | A2-2 マージ (rules 実装・コード系本格化) | 進行中 (PR #125、Ready 昇格 + merge は本ペインで実行中) |
 | (未定) | A2-3 マージ (rules プロセス・ハーネス・UI 系本格化) | 未達 (A2-2 完了後着手予定) |
 | (未定) | EPIC-A2 status → completed | 未達 (3/5 マージ済、残り A2-2 / A2-3) |

--- a/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
@@ -18,7 +18,7 @@ source_epic: EPIC-A2
 | ID | タイトル | status | expected_modules | 完了根拠 |
 |---|---|---|---|---|
 | **A2-1** | A1 レトロ即時消化 + ハーネス即時改善 | completed | EPIC-A2 起票 + `CLAUDE.md` / `.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message,roadmap}.md` / `.claude/skills/code-reviewer/SKILL.md` / `.github/PULL_REQUEST_TEMPLATE/{harness,feature,bugfix}.md` / `docs/adr/README.md` / `docs/harness/{plan,learnings/flaky-tests,learnings/INDEX,learnings/2026-05-17-pr-117,roadmap}.md` / `scripts/install-git-hooks.sh` | PR [#121](https://github.com/subroh0508/colormaster/pull/121) (2026-05-17 マージ、commit `feb41b5`) |
-| **A2-2** | rules 実装・コード系本格化 | proposed | `.claude/rules/{plan,epic,adr,roadmap,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,pii,secrets,db-protection,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream,rules-index}.md` | — |
+| **A2-2** | rules 実装・コード系本格化 | in-progress | `.claude/rules/{plan,epic,adr,roadmap,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,pii,secrets,db-protection,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream,rules-index}.md` | (本 PR #125 で更新) |
 | **A2-3** | rules プロセス・ハーネス・UI系本格化 | proposed | `.claude/rules/{pr-template,branch-naming,merge-readiness,pr-draft-policy,spec-living-sync,harness-meta-criteria,retrospective-format,pr-poller,skill-authoring,harness-evolution,implementation-workflow,code-reviewer-aspects,design-tokens,ui-snapshot,ui-inventory,behavior-preservation,docs-structure,template-language,rules-index}.md` | — |
 | **A2-4** | docs/ コア + runbooks 拡充 | proposed | `docs/{README,glossary,codebase-map}.md`, `docs/security/README.md`, `docs/requirements/{README,template}.md`, `docs/specifications/{README,basic/template,detail/template}.md`, `docs/runbooks/{local-development,testing,i18n,mcp-setup}.md` | — |
 | **A2-5** | docs/architecture + api 拡充 | completed | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md`, `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` | PR [#126](https://github.com/subroh0508/colormaster/pull/126) (2026-05-17 マージ、commit `168ef5d`) |
@@ -65,6 +65,7 @@ A2-1 完了後、A2-2/A2-3 (rules 系) と A2-4/A2-5 (docs 系) は **並走可*
 | 2026-05-17 | EPIC-A2 起票 + A2 を 5 PR に分割 | B0 (96 files / +5408 行) のレビュー負荷が上限近く、A2 全体は B0 を超える規模が想定されるため。A1 レトロ Try「巨大 PR の aspect 並列 review における入力分割」と整合 |
 | 2026-05-17 | A2-1 着手 (現 worktree `feature/A2-rules-docs-extension` を reuse) | A1 レトロ 15 提案のうち消化可能項目を最優先で消化、後続 PR の規約・索引基盤を整える |
 | 2026-05-17 | A2-1 status を in-progress → completed (PR #121 マージ、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、後続 A2-2 / A2-4 並走着手の前提が整う。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
+| 2026-05-17 | A2-1 PR #121 マージ後、A2-2 / A2-4 / A2-5 を並走着手 (本 PR は A2-2、新規 worktree `feature/A2-2-rules-impl`) | A2-2 と A2-4 / A2-5 は touch ファイル重複ゼロ (`.claude/rules/` vs `docs/`)、A2-3 は rules-index.md 連続編集回避のため A2-2 マージ後に着手 |
 | 2026-05-17 | A2-5 着手 (worktree `feature/A2-5-docs-arch-api`) | A2-1 マージ後、A2-2 / A2-4 と並行で docs/architecture + api サブツリーを 12 ファイル 5KB+ に拡充 (touch ファイル重複ゼロ) |
 | 2026-05-17 | A2-5 status を in-progress → completed (PR #126 マージ、commit `168ef5d`) | docs/architecture 7 + docs/api 5 を 5KB+ 本格化、code-reviewer architecture Critical 4 件 fix loop で解消、A2-4 PR #123 merge 後の rebase で `progress.md` / `roadmap.md` 衝突を統合解決。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
 
@@ -72,7 +73,7 @@ A2-1 完了後、A2-2/A2-3 (rules 系) と A2-4/A2-5 (docs 系) は **並走可*
 
 A2-1 / A2-4 / A2-5 マージ済 (PR #121 / #123 / #126)。残りステップ:
 
-1. **A2-2 (rules 実装・コード系本格化)** — PR #125 DRAFT 進行中 (`feature/A2-2-rules-impl`)。Ready 昇格 + code-reviewer → merge
+1. **A2-2 (rules 実装・コード系本格化)** — PR #125 進行中 (`feature/A2-2-rules-impl`)。Ready 昇格 + code-reviewer → merge 中
 2. **A2-3 (rules プロセス・ハーネス・UI 系本格化)** — A2-2 完了後着手 (`.claude/rules/rules-index.md` の連続編集回避のため)
 3. EPIC-A2 完了は A2-2 / A2-3 マージ後 (4/5 → 5/5 で `completed` 昇格、別 mirror PR で記録)
 4. A3 (専用 Skill 群実装) 着手は EPIC-A2 完了後 (ADR + 本格化された rules を参照する Skill 群実装のため)


### PR DESCRIPTION
---
type: harness
related_plan:
related_epic: EPIC-A2
related_adrs:
  - ADR-0001
  - ADR-0002
  - ADR-0003
  - ADR-0005
  - ADR-0006
  - ADR-0007
  - ADR-0008
  - ADR-0009
  - ADR-0010
  - ADR-0011
  - ADR-0012
  - ADR-0013
  - ADR-0014
  - ADR-0016
  - ADR-0017
  - ADR-0020
  - ADR-0021
  - ADR-0022
  - ADR-0023
  - ADR-0024
  - ADR-0027
related_specs: []
expected_modules:
  - .claude/rules/**
  - docs/epics/EPIC-A2-rules-docs-extension/**
---

## 概要

EPIC-A2 配下 2 件目の PR。`.claude/rules/*` のうち **コード・計画・記録・セキュリティ・Backend / 同期系** の計 35 件を「本格化」水準 (frontmatter + 5 行 summary + 規約本文 + 機械検証セクション + Gotchas + 関連) に揃え、A1 レトロ Problem #1「既存ラベル誤宣言 13+ 件」を A2-2 スコープで全消化する。

## 関連

- Plan: なし (Epic 配下 PR、Plan は起こさない)
- Epic: EPIC-A2 (`docs/epics/EPIC-A2-rules-docs-extension/`)
- ADR: 上記 frontmatter のとおり (rules が参照する SSOT)
- 元 learnings: `docs/harness/learnings/2026-05-17-pr-117.md` (B0 レトロ Problem #1)
- 元 PR: A2-1 PR #121 (rules-index status 正規化の前段)

## PR の種別

- [x] **rules / Skill 本格化** (B0 雛形 → 本文充実)
- [ ] A1 レトロ 等の即時消化フォロー PR
- [ ] ハーネス改修 PR (`harness-meta` Skill 起票)
- [ ] 外部研究駆動の改修 PR (`harness-evolution` Skill 起票)
- [ ] レトロ集約 PR
- [ ] その他

## 変更内容

| 区分 | パス | 変更内容 |
|---|---|---|
| rule (新規 29 件) | `.claude/rules/{plan,epic,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream}.md` | 新規作成 |
| rule (本格化 5 件) | `.claude/rules/{adr,roadmap,pii,secrets,db-protection}.md` | B0 skeleton → stable (A2-2) に格上げ、`related_adrs` 整備、`related_plan` 単項目を `related_adrs` 配列に統一、机上検証セクション追記 |
| rule (索引) | `.claude/rules/rules-index.md` | `status` 語彙に `stable (X)` を追加、A2-2 で本格化した 34 ファイル分の状態を `stable (A2-2)` に正規化、`no-firebase.md` を新規追加 |
| docs (Epic) | `docs/epics/EPIC-A2-rules-docs-extension/{progress,roadmap}.md` | A2-1 完了 (PR #121) + A2-2 着手記録、roadmap の完了根拠表に PR #121 を登録 |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 35 | 0 | 0 | 0 |
| `[skill]` | 0 | — | — | — |
| `[template]` | 0 | — | — | — |
| `[remove]` | 0 | — | — | — |

A1 レトロ Problem #1 「『既存』誤宣言 13+ 件」のうち、A2-2 スコープに該当する 34 ファイル分 (新規 29 + skeleton 5) を `stable (A2-2)` に正規化することで全消化。残りの 21 件は A2-3 (プロセス / ハーネス / UI 系) で対応予定。

## 受け入れ基準 (AC)

- [x] AC-1: `.claude/rules/{plan,epic,viewmodel,...,r2-litestream}.md` の 29 新規 rule が「本格化水準」 (frontmatter + 5 行 summary + 3-6 規約セクション + 機械検証 + Gotchas + 関連) を満たす
- [x] AC-2: 既存 skeleton 5 件 (`adr,roadmap,pii,secrets,db-protection`) が `status: stable` に格上げ済、本文加筆も完了
- [x] AC-3: `.claude/rules/rules-index.md` の status ラベルと実体が一致 (A2-2 スコープ範囲内で「既存」誤宣言ゼロ)
- [x] AC-4: 全 rule の frontmatter で `paths` が **block 形式** (`.claude/rules/docs-structure.md` frontmatter 規約)、配列 1 要素でも block 化
- [x] AC-5: 常時ロード (`paths` 未設定) は規定の 4 件のみ (`rules-index` / `pii` / `secrets` / `template-language`)、A2-2 で新規追加なし
- [x] AC-6: 各 rule の `related_adrs` が `paths` で対象とするファイル種別と整合 (例: `cloud-run-deploy.md` が ADR-0009 を参照)
- [x] AC-7: `no-firebase.md` (新規) と既存 `firebase-boundary.md` (本格化) の責務分担を EPIC-A2 `decisions.md` 通り二段運用で実装
- [x] AC-8: EPIC-A2 `progress.md` / `roadmap.md` に A2-1 完了 (PR #121) + A2-2 着手記録を追記
- [ ] AC-9: code-reviewer (4 aspect: spec-conformance / architecture / security / code-quality) のレビューで merge readiness を取得
- [ ] AC-10: 人間 approve (orchestrator) で squash merge

## テスト

- [ ] markdownlint-cli2 グリーン → **A6 以降、本 PR 時点では no-op** (Phase 4 skip)
- [ ] Gradle カスタムタスクの docs 検証グリーン → **A6 以降、本 PR 時点では no-op**
- [x] 既存 commit-msg hook で Conventional Commits 検証グリーン (A2-1 で更新済の 72/100 字 hard limit 内)

## レビュー観点 (code-reviewer 4 aspect 限定)

本 PR は Markdown 規約改定のみで Kotlin / UI / build script に変更なし。レビューは以下 4 aspect に限定:

- **spec-conformance**: 各 rule が参照する ADR (Single Source of Truth) と内容整合、`related_adrs` の網羅性
- **architecture**: rules 間の責務境界 (no-firebase ⇄ firebase-boundary / db-protection ⇄ sqlite-data-file / pii ⇄ secrets) が明確、循環参照なし
- **security**: PII / Secrets / DB 保護 rule の機械検証セクション (A6 で導入される Konsist / Gradle / trufflehog) が漏れなく規定
- **code-quality**: frontmatter の block 形式、Markdown 表記、見出しレベル、Gotchas / 関連リンクの統一感

test-quality / visual-regression / performance / design-tokens は本 PR スコープ外 (UI / コード / パフォーマンスに変更なし)。

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した
- [x] Skill 改修なし
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須)
- [x] PII / Secrets が diff に含まれていない (テスト fixture / メールアドレス / API key の例も全て `@example.com` / `[REDACTED-*]` / `PLACEHOLDER` 形式)
- [x] Epic 配下 PR のため `roadmap-tracker` 自動同期は Phase 8 (merge 後) で発火、本 PR 内でも roadmap.md を手動更新済
- [x] `rules-index.md` の status 語彙 (`skeleton (B0)` / `stable (X)` / `planned (X)` / `living`) を遵守

🤖 Generated with [Claude Code](https://claude.com/claude-code)