### PR TITLE
docs(harness): A2-5 docs/architecture + api 拡充

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -3,34 +3,163 @@ id: api-readme
 title: API 概要 (colormaster-api)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §4
+related_plan: docs/harness/plan.md §3.2 / §3.4
 related_adrs:
+  - ADR-0008
+  - ADR-0009
   - ADR-0011
+  - ADR-0020
 ---
 
 # API 概要
 
-> **5 行以内 summary**: ColorMaster Backend (`colormaster-api`) は GIS ID Token 認証下で
-> `/api/idols/*` (read-only マスタ) と `/api/me/*` (ユーザー個別データ) を提供する。
-> 詳細仕様の Single Source of Truth は `colormaster-api.yaml` (OpenAPI 3.1)。
-> 個別エンドポイントの解説は `auth.md` / `idols.md` / `me.md` を参照。本格化は C5。
+> **5 行以内 summary**: ColorMaster Backend (`colormaster-api`) は Cloud Run 上の Ktor
+> Server で稼働し、`/api/idols/*` (read-only 公開マスタ) と `/api/me/*` (GIS Bearer
+> 認証必須) を提供する。スキーマの SoT は `colormaster-api.yaml` (OpenAPI 3.1)。
+> エンドポイント別の散文解説は `auth.md` / `idols.md` / `me.md`。本格化は C5。
+
+## ベース URL
+
+| 環境 | URL | 備考 |
+|---|---|---|
+| 本番 | `https://colormaster-api.example.com` | Cloud Run、C7 でデプロイ確定 |
+| ローカル | `http://localhost:8080` | `./gradlew :backend:server:run` で起動 |
+| Preview | (環境変数で切替) | Cloud Run の preview revision、URL は CI 出力 |
 
 ## エンドポイント分類
 
-| グループ | 認証 | 詳細 |
+| グループ | 認証 | 用途 | 詳細 docs |
+|---|---|---|---|
+| `/api/idols/*` | 不要 (公開マスタ) | アイドル / ブランド / カラーパレットの read-only 取得 | [idols.md](idols.md) |
+| `/api/brands` | 不要 | ブランド一覧 | [idols.md](idols.md) |
+| `/api/colors` | 不要 | カラーパレット一覧 | [idols.md](idols.md) |
+| `/api/me/*` | GIS ID Token (Bearer) 必須 | 担当・推し一覧 / プロファイル / ユーザー削除 | [me.md](me.md) |
+| `/health` | 不要 | Cloud Run ヘルスチェック (Litestream lag 含む) | (本ファイル末尾) |
+
+## 認証方式 (詳細は `auth.md`)
+
+- 全 `/api/me/*` で `Authorization: Bearer <GIS ID Token>` 必須
+- Backend は Google JWKS で署名検証 + `iss` / `aud` / `exp` を検証
+- `sub` claim を `uid` として扱い、Backend memory に **15 分** GIS userinfo cache を持つ
+- ID Token は GIS が発行する exp (通常 1 時間) で失効、クライアントは再取得
+- 詳細は ADR 0011 (GIS 統一) / `.claude/rules/backend-auth.md` (A2-2 で本格化)
+
+## バージョニング
+
+- **URI バージョニング不採用**: `/v1/api/idols` 等は使わず、互換性を破壊する変更時のみ
+  別エンドポイント (`/api/idols2` 等) を追加して旧をしばらく並走 + ADR 起票で記録
+- **OpenAPI の `info.version`** を semver で進める (`0.0.0-skeleton` → `0.1.0-alpha` → `1.0.0`)
+- 後方非互換変更は **必ず ADR 起票** (`adr.md` 起票基準: §4.5-3 外部サービス変更)
+
+## 標準応答ヘッダ
+
+| ヘッダ | 値 | 適用範囲 |
 |---|---|---|
-| `/api/idols/*` | 不要 (公開マスタ) | `idols.md` |
-| `/api/me/*` | GIS ID Token (Bearer) 必須 | `me.md` |
-| `/auth/*` | GIS フロー | `auth.md` |
+| `Content-Type` | `application/json; charset=utf-8` | 全 endpoint |
+| `Cache-Control` | `public, max-age=86400` | `/api/idols/*` `/api/brands` `/api/colors` (read-only マスタ) |
+| `Cache-Control` | `private, no-store` | `/api/me/*` (個人データ、CDN キャッシュ禁止) |
+| `Cache-Control` | `no-store` | `/health` |
+| `X-Request-Id` | UUID v4 | 全 endpoint (ログ追跡用、Skill 出力では redaction 不要) |
+
+## 標準エラー応答
+
+全エンドポイント共通で以下の JSON schema を返す (`colormaster-api.yaml` の `components/schemas/Error` 定義):
+
+```json
+{
+  "error": {
+    "code": "string (machine-readable)",
+    "message": "string (human-readable, 日本語)",
+    "details": { ... 任意の追加情報 ... }
+  }
+}
+```
+
+### ステータスコード規約
+
+| コード | 用途 | 例 |
+|---|---|---|
+| 200 | 成功 (GET) | アイドル一覧取得 |
+| 201 | 作成成功 (POST) | 担当追加 |
+| 204 | 削除成功 (DELETE) | 担当削除 / ユーザー削除 |
+| 400 | リクエスト不正 | クエリパラメータ型不正、body schema 違反 |
+| 401 | 認証必要 / 失敗 | ID Token なし / 期限切れ / 署名不正 |
+| 403 | 認可失敗 | 他人の uid のデータに触れようとした |
+| 404 | リソース不存在 | `/api/idols/{id}` で id 不存在 |
+| 429 | レート制限 | (Phase C で導入検討) |
+| 500 | サーバ内部エラー | DB 破損 / 想定外 exception |
+| 503 | 一時的不可 | JWKS 取得失敗 / Litestream restore 中 / R2 unreachable |
+
+### エラーコード語彙 (代表)
+
+| `code` | HTTP | 意味 |
+|---|---|---|
+| `unauthorized` | 401 | 認証必要 / 失敗 |
+| `token_expired` | 401 | ID Token 期限切れ (再取得を促す) |
+| `forbidden` | 403 | uid 不一致 |
+| `not_found` | 404 | リソース不存在 |
+| `bad_request` | 400 | リクエスト不正 |
+| `validation_failed` | 400 | body schema 違反 (details に違反フィールド) |
+| `internal_error` | 500 | サーバ内部エラー (details は redaction、PII 含めない) |
+| `service_unavailable` | 503 | 一時的不可 (Retry-After ヘッダ併用) |
+
+## レート制限 (Phase C で導入検討)
+
+- 現状は **未導入** (個人プロジェクト規模、Cloud Run の無料枠で十分)
+- 将来導入時は Cloudflare Rate Limiting または Backend の Ktor `RateLimit` plugin を採用検討
+- 採用時は ADR 起票 (§4.5-3 外部サービス / -5 中核方針)
+
+## CORS
+
+- `/api/idols/*` `/api/brands` `/api/colors` は **全 origin 許可** (`Access-Control-Allow-Origin: *`)
+- `/api/me/*` は **明示的な allowlist** (`https://colormaster.example.com` 等のみ) — wasmJs クライアントのデプロイ先と一致
+- preflight (`OPTIONS`) は Ktor の CORS plugin で処理
+- 詳細は `.claude/rules/backend-auth.md` (A2-2 で本格化)
+
+## 健全性チェック (`/health`)
+
+```json
+{
+  "status": "ok | degraded | down",
+  "checks": {
+    "users_db": "ok",
+    "litestream_lag_seconds": 2,
+    "jwks_cache_age_seconds": 1800
+  }
+}
+```
+
+- Cloud Run の `livenessProbe` / `readinessProbe` で参照
+- `litestream_lag_seconds` が閾値超で `degraded`、これがアラート発火基準 (C7 で整備)
+- 詳細は `infrastructure.md` の「モニタリング」セクション
+
+## ロギング (PII 配慮、`pii.md` 準拠)
+
+- **構造化ログ** (JSON line) を Cloud Logging に出力
+- `uid` は ログに含めて良い (内部識別子だが PII 同等取扱、redaction 不要)
+- `email` / `name` / `picture` / IP / Authorization ヘッダの **生値はログ禁止** (`.claude/rules/logging.md` で機械検証、A2-2)
+- error level ログは PII fields を `[REDACTED-*]` プレースホルダで置換してから出力
 
 ## Single Source of Truth
 
-- **`colormaster-api.yaml`** (OpenAPI 3.1) — 全リクエスト/レスポンス JSON スキーマ
-- 各 `<endpoint>.md` は **使い方 / 設計判断 / 例外パターン** を散文で記述 (リクエスト/レスポンス JSON は yaml 側に集約)
+| ファイル | 役割 |
+|---|---|
+| **`colormaster-api.yaml`** (OpenAPI 3.1) | **全リクエスト/レスポンス JSON スキーマの SoT**、エラー schema、security scheme |
+| `auth.md` / `idols.md` / `me.md` | 使い方 / 設計判断 / 例外パターン / PII 取扱 (yaml に書きにくい散文) |
+| ADR 0008 / 0011 / 0020 | データ永続化 / 認証 / PII 保護の決定根拠 |
+
+`*.md` 側ではリクエスト/レスポンス JSON 例を **重複記載しない** (yaml に集約、変更時の同期コスト回避)。
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- `backend/server/` は Gradle module 骨格のみ、API 実装は **未着手** (C5 で本格化)
+- `colormaster-api.yaml` は `info.version: 0.0.0-skeleton`、A2-5 で paths / schemas を骨格分は拡張、本格実装時に `0.1.0-alpha` に bump
+- `/api/me/*` は GIS 認証 + `users.db` 未実装のため動作不可、`/api/idols/*` も `idols.db` から読むハンドラ未実装
 
 ## 関連
 
-- ADR 0011 (GIS 統一認証 + Firebase 撤去)
-- ADR 0009 (Cloud Run デプロイ)
-- `docs/architecture/{overview,data-flow,infrastructure}.md`
-- `docs/specifications/basic/SPEC-*.md` (C5 で個別作成)
+- `colormaster-api.yaml` (OpenAPI 3.1 SoT)
+- `auth.md` / `idols.md` / `me.md`
+- ADR 0008 (Backend SQLite + Litestream + R2) / 0009 (Cloud Run) / 0011 (GIS 統一) / 0020 (PII 保護)
+- `.claude/rules/{backend-auth,network-client,logging,error-handling,pii}.md`
+- `../architecture/{overview,data-flow,infrastructure,sequences}.md`

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -3,49 +3,153 @@ id: api-auth
 title: 認証 API (GIS 統一)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3.2 / ADR 0011
+related_plan: docs/harness/plan.md §3.2 / §3.8
 related_adrs:
   - ADR-0011
   - ADR-0020
+  - ADR-0021
 ---
 
 # 認証 API (GIS 統一)
 
-> **5 行以内 summary**: 全 target で Google Identity Services (GIS) に統一。フロントが
-> ID Token を取得 → Backend が JWKS で検証 → uid (sub claim) を抽出して認可に用いる。
-> Firebase Auth は完全撤廃 (`dev.gitlive:firebase-*` / `core/network/auth/` を C5 で削除)。
-> 本格実装は C5 (EPIC-003)。
+> **5 行以内 summary**: 全 target で Google Identity Services (GIS) に統一。フロント
+> (Android / iOS / wasmJs) で ID Token を取得 → Backend が JWKS で検証 → uid (sub claim)
+> を抽出して認可に用いる。Firebase Auth は完全撤廃 (`dev.gitlive:firebase-*` /
+> `core/network/auth/` を C5 で削除)。本格実装は C5 (EPIC-003)、本ファイルは規約 + 設計判断。
 
-## 認証フロー (骨格、C5 で本格化)
+## 認証フロー (5 ステップ)
 
-1. フロント (Android / iOS / wasmJs) で GIS ID Token を取得
-2. Backend の `/api/me/*` エンドポイントに `Authorization: Bearer <ID Token>` で送信
-3. Backend は JWKS (`https://www.googleapis.com/oauth2/v3/certs`) で署名検証
-4. 検証成功なら `sub` claim (Google Account ID、内部的に `uid` と呼ぶ) を抽出
-5. `requireUid()` ヘルパで uid を context として伝播
+```mermaid
+sequenceDiagram
+    actor User
+    participant Client as Client (Android/iOS/wasmJs)
+    participant GIS as Google Identity Services
+    participant API as Backend (Cloud Run)
+    participant JWKS as Google JWKS endpoint
+
+    User->>Client: サインイン操作
+    Client->>GIS: requestIdToken(clientId, scopes=[openid, email, profile])
+    GIS-->>User: 同意画面 + アカウント選択
+    User->>GIS: 同意
+    GIS-->>Client: ID Token (JWT, exp ~1 時間)
+    Client->>Client: secure storage に Token 保存
+    Client->>API: GET /api/me/profile\nAuthorization: Bearer <ID Token>
+    API->>JWKS: GET /oauth2/v3/certs (cache 6 時間)
+    JWKS-->>API: 公開鍵 JWK セット
+    API->>API: JWT 署名 + iss/aud/exp 検証 → uid 抽出
+    API-->>Client: 200 {uid, name?, picture?}
+```
+
+### ステップ詳細
+
+1. **フロント側で ID Token 取得** — 各 target ごとに GIS SDK を呼ぶ
+   - Android: `GoogleSignIn` / `Identity.getSignInClient()`
+   - iOS: `GIDSignIn` (Google Identity SDK for iOS)
+   - wasmJs: GIS JavaScript Library (`google.accounts.id.initialize/prompt`)
+2. **Backend へ Bearer 送信** — `Authorization: Bearer <ID Token>` ヘッダで `/api/me/*` を呼ぶ
+3. **Backend の JWKS 検証** — `https://www.googleapis.com/oauth2/v3/certs` で取得した公開鍵で JWT 署名を検証 (cache 6 時間)
+4. **claim 検証** — `iss == https://accounts.google.com` / `aud == <Backend で許可した client_id 群>` / `exp` 未来
+5. **uid 抽出** — `sub` claim を `Uid` value class に変換、`requireUid()` ヘルパで context に格納
 
 ## エンドポイント
 
-| パス | 用途 | 状態 |
-|---|---|---|
-| (フロント側 GIS フロー) | ID Token 取得 | 各 platform で実装 (C5/C8/C9) |
-| (Backend 側 JWKS 検証) | 自動 (middleware) | C5 で実装 |
-| `/api/me/profile` | uid から GIS userinfo を memory cache TTL 15 分付きで返す | C5 で実装 |
+| パス | 認証 | 用途 | 状態 |
+|---|---|---|---|
+| (フロント側 GIS フロー) | — | ID Token 取得 | 各 platform で C5 / C8 / C9 で実装 |
+| (Backend の JWKS 検証ミドルウェア) | — | 自動検証 (全 `/api/me/*` 共通) | C5 で実装 |
+| `GET /api/me/profile` | Bearer | uid + GIS userinfo (memory cache TTL 15 分) を返す | C5 |
+| `DELETE /api/me` | Bearer | ユーザーアカウント削除 (uid + favorites 物理削除) | C5 |
+
+## JWKS 検証規約 (`.claude/rules/backend-auth.md` で本格化、A2-2)
+
+- **検証必須項目**:
+  - 署名 (RS256、Google JWKS の公開鍵)
+  - `iss` (`https://accounts.google.com` のみ許容)
+  - `aud` (Backend で許可した client_id allowlist、env で設定)
+  - `exp` (現在時刻より未来)
+  - `iat` (clock skew 許容 5 分)
+- **検証失敗時**: 全て 401 を返却、エラー応答に **詳細を含めない** (`code: unauthorized` のみ)
+- **JWKS cache**: Google が返す `Cache-Control: max-age=21600` (6 時間) に従い、Backend memory cache に保存。期限切れ時は背景で再取得 (stale-while-revalidate)
+- **JWKS 取得失敗時**: `503 service_unavailable` + `Retry-After: 60` ヘッダ、クライアントは exponential backoff で retry
+
+## `requireUid()` 規約
+
+Backend `/api/me/*` 系の全ハンドラは `requireUid()` を呼んで `Uid` を取得する必要がある。
+Konsist で機械検証 (A2-2 + A6 で本格化、`.claude/rules/backend-auth.md`):
+
+```kotlin
+// 例 (C5 で実装、ここでは規約のみ)
+get("/api/me/profile") {
+    val uid = call.requireUid()      // ← 必須
+    val profile = profileService.get(uid)
+    call.respond(profile)
+}
+```
+
+- `requireUid()` は内部で JWKS 検証 → claim 抽出 → `Uid` 化を行い、失敗時は `respondError(401)` で短絡
+- ハンドラ本体は `requireUid()` 後の uid を **uid フィルタ条件** として全 DB クエリに使う
+- uid 単位での所有権チェックを必須化 (他人の uid のデータには触れない、403)
 
 ## エラーケース
 
-- ID Token 期限切れ → 401 + クライアントに再取得を促す
-- JWKS 取得失敗 → 503 (一時的) + リトライ案内
-- `sub` claim 不在 → 401
+| ケース | HTTP | `error.code` | クライアント挙動 |
+|---|---|---|---|
+| `Authorization` ヘッダ不在 | 401 | `unauthorized` | サインインへ誘導 |
+| Bearer 形式不正 | 401 | `unauthorized` | 同上 |
+| 署名検証失敗 | 401 | `unauthorized` | 同上 + log (運用通知) |
+| `iss` / `aud` 不一致 | 401 | `unauthorized` | 同上 |
+| `exp` 切れ | 401 | `token_expired` | クライアントは GIS で新規 ID Token 取得後 retry |
+| `iat` clock skew 過大 | 401 | `unauthorized` | クライアント端末時刻ずれを疑う、サインアウト誘導 |
+| JWKS 取得失敗 | 503 | `service_unavailable` | exponential retry (最大 3 回) |
+| `sub` claim 不在 | 401 | `unauthorized` | サインアウト誘導 |
+| uid 不一致 (他人のデータ操作) | 403 | `forbidden` | ローカル状態を破棄、サインアウト誘導 |
 
 ## PII 取扱
 
-- DB に保存する PII は **uid のみ** (`.claude/rules/pii.md` 参照)
-- 表示用の display name / email / picture は GIS userinfo から都度取得 + memory cache TTL 15 分
+- **DB に保存する PII は `uid` のみ** (ADR 0020、`.claude/rules/pii.md`)
+- `email` は **クライアントに返さない** (Backend は GIS userinfo から取得するが、レスポンスに含めない)
+- `name` / `picture` は表示用にレスポンスに含めるが、**memory cache TTL 15 分** のみ
+- ID Token 自体はログに **平文出力禁止** (`Authorization` ヘッダごとマスク)
+- エラー応答に `details` を含める場合も PII フィールドを含めない (`pii.md` redaction 規約)
+
+## クライアント側の Token 管理
+
+| target | secure storage |
+|---|---|
+| Android | EncryptedSharedPreferences (Jetpack Security) |
+| iOS | Keychain |
+| wasmJs | Memory only (sessionStorage / cookie は使わない、XSS リスク) |
+| JVM Desktop | テスト用のみ、永続化なし |
+
+- ID Token は **永続化を最小化** (Android / iOS は EncryptedSharedPreferences / Keychain、wasmJs は memory)
+- exp 失効時に refresh は **しない** (refresh token は使わず、GIS のサイレントログインに任せる)
+- サインアウト時は secure storage から削除 + Backend `/api/me/profile` の cache も破棄
+
+## Firebase 撤去 (ADR 0011 / `.claude/rules/{firebase-boundary,no-firebase}.md`)
+
+- `dev.gitlive:firebase-{app,auth,firestore}` の依存削除 (C5)
+- `core/network/auth/` (Firebase Auth 連携層) を撤去 (C5)
+- `core/network/firestore/` を撤去、`/api/me/*` 経由のアクセスに統一 (C5)
+- `firebase.json` / `.firebaserc` を C7 で Cloudflare Pages 移行と同時に削除
+- 新規追加禁止規約は `.claude/rules/no-firebase.md` (A2-2 で本格化)、Skill 起草時の事前ガード
+
+## ローカル開発時の認証
+
+- ローカル Backend (`./gradlew :backend:server:run`) は **mock JWKS** を提供する開発モードを実装 (C5)
+- mock モードでは `Authorization: Bearer dev-<uid>` を許容、JWKS 検証をスキップして `uid` を即座に抽出
+- 本番ビルドでは mock モードを無効化 (`if (BuildConfig.DEBUG)` 相当のガード、Konsist で検証)
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- `backend/server/` の認証ミドルウェアは **未実装** (C5)
+- `core/network/auth/` は **Firebase Auth 経由の旧実装** が現存 (C5 で撤去)
+- GIS Client ID は **未発行** (C5 着手時に GCP コンソールで発行)
+- 本ファイルが記述する仕様は **C5 完了後の最終形**
 
 ## 関連
 
-- ADR 0011 (GIS 統一認証 + Firebase 撤去)
-- ADR 0020 (PII 保護: uid のみ DB 保存)
-- `.claude/rules/{backend-auth,pii,no-firebase}.md`
-- `docs/api/colormaster-api.yaml` (security scheme)
+- ADR 0011 (GIS 統一認証 + Firebase 撤去) / 0020 (PII 保護: uid のみ DB 保存) / 0021 (Secrets 管理)
+- `.claude/rules/{backend-auth,pii,no-firebase,firebase-boundary,secrets}.md`
+- `colormaster-api.yaml` (security scheme `bearerAuth`)
+- `me.md` (uid を使う API 詳細)
+- `../architecture/sequences.md` (ユースケース 1: ログインのフロー図)

--- a/docs/api/colormaster-api.yaml
+++ b/docs/api/colormaster-api.yaml
@@ -3,63 +3,453 @@ info:
   title: colormaster-api
   version: 0.0.0-skeleton
   description: |
-    ColorMaster Backend API (skeleton). 本格定義は C5 (EPIC-003) で実装。
+    ColorMaster Backend API (skeleton)。本格実装は C5 (EPIC-003) 完了時に
+    info.version を 0.1.0-alpha に bump、1.0 達成は Phase C 全体完了時。
     認証は GIS ID Token (Bearer) 必須 (/api/me/*)、/api/idols/* は公開マスタ。
+    詳細は docs/api/README.md と関連 .md (auth/idols/me) を参照。
 servers:
   - url: https://colormaster-api.example.com
     description: 本番 (Cloud Run、C7 でデプロイ予定)
   - url: http://localhost:8080
-    description: ローカル開発
+    description: ローカル開発 (./gradlew :backend:server:run)
+
+tags:
+  - name: idols
+    description: アイドル / ブランド / カラーパレット (公開 read-only マスタ)
+  - name: me
+    description: ユーザー個人データ (担当・推し / プロファイル、GIS 認証必須)
+  - name: health
+    description: ヘルスチェック
+
 paths:
+  /health:
+    get:
+      tags: [health]
+      summary: ヘルスチェック
+      operationId: health
+      responses:
+        '200':
+          description: 健全
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+
   /api/idols:
     get:
-      summary: アイドル一覧取得 (公開、骨格)
+      tags: [idols]
+      summary: アイドル一覧取得 (公開)
       operationId: listIdols
+      parameters:
+        - $ref: '#/components/parameters/BrandFilter'
+        - $ref: '#/components/parameters/ColorFilter'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
       responses:
         '200':
           description: アイドル一覧
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  idols:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-  /api/me/favorites:
+                $ref: '#/components/schemas/IdolList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/idols/{id}:
     get:
-      summary: ユーザーの担当・推し一覧取得 (要認証、骨格)
-      operationId: listMyFavorites
-      security:
-        - bearerAuth: []
+      tags: [idols]
+      summary: 個別アイドル詳細取得 (公開)
+      operationId: getIdol
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: IdolId (im@sparql RDF 識別子 slug)
       responses:
         '200':
-          description: 担当一覧
+          description: アイドル詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Idol'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/idols/search:
+    get:
+      tags: [idols]
+      summary: アイドル検索 (公開、name / nameRuby / brand / colorName 全文)
+      operationId: searchIdols
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 100
+          description: 検索クエリ (必須)
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          description: 検索結果
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdolList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/brands:
+    get:
+      tags: [idols]
+      summary: ブランド一覧取得 (公開)
+      operationId: listBrands
+      responses:
+        '200':
+          description: ブランド一覧
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  favorites:
+                  brands:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        idolId:
-                          type: string
-                        addedAt:
-                          type: string
-                          format: date-time
+                      $ref: '#/components/schemas/Brand'
+
+  /api/colors:
+    get:
+      tags: [idols]
+      summary: カラーパレット一覧取得 (公開)
+      operationId: listColors
+      responses:
+        '200':
+          description: カラーパレット一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  colors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ColorPalette'
+
+  /api/me/profile:
+    get:
+      tags: [me]
+      summary: 自身のプロフィール取得 (uid + GIS userinfo cache 経由)
+      operationId: getMyProfile
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: プロフィール
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/me/favorites:
+    get:
+      tags: [me]
+      summary: 担当・推し一覧取得
+      operationId: listMyFavorites
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [tantou, oshi]
+          description: フィルタ (省略時は両方)
+      responses:
+        '200':
+          description: 担当・推し一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FavoriteList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      tags: [me]
+      summary: 担当・推し追加
+      operationId: addMyFavorite
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FavoriteCreateRequest'
+      responses:
+        '201':
+          description: 作成成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Favorite'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/me/favorites/{idolId}:
+    delete:
+      tags: [me]
+      summary: 担当・推し削除
+      operationId: deleteMyFavorite
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: idolId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 削除成功
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/me:
+    delete:
+      tags: [me]
+      summary: ユーザー削除 (users.db から uid と favorites を物理削除)
+      operationId: deleteMyAccount
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: 削除成功
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: GIS ID Token (Backend で JWKS 検証して sub 抽出)
+      description: |
+        GIS ID Token。Backend で Google JWKS (https://www.googleapis.com/oauth2/v3/certs)
+        により署名 + iss / aud / exp を検証し、sub claim を uid として抽出。
+        詳細は docs/api/auth.md を参照。
+
+  parameters:
+    BrandFilter:
+      name: brand
+      in: query
+      required: false
+      schema:
+        type: string
+      description: ブランド ID でフィルタ (例 765AS / CG / ML / SC / SS / SP)
+
+    ColorFilter:
+      name: color
+      in: query
+      required: false
+      schema:
+        type: string
+        pattern: '^#[0-9a-fA-F]{6}$'
+      description: カラー (Hex) でフィルタ
+
+    Page:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      description: ページ番号 (1-origin)
+
+    PageSize:
+      name: pageSize
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+      description: 1 ページあたり件数
+
+  responses:
+    BadRequest:
+      description: リクエスト不正
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: 認証必要 / 失敗
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: リソース不存在
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    Idol:
+      type: object
+      required: [id, brandId, name, nameRuby, color]
+      properties:
+        id:
+          type: string
+          description: IdolId (im@sparql RDF 識別子 slug)
+        brandId:
+          type: string
+          description: 所属ブランド ID
+        name:
+          type: string
+          description: アイドル名 (表示用)
+        nameRuby:
+          type: string
+          description: フリガナ (ソート / 検索用)
+        color:
+          $ref: '#/components/schemas/ColorPalette'
+
+    IdolList:
+      type: object
+      required: [idols, page, pageSize, total]
+      properties:
+        idols:
+          type: array
+          items:
+            $ref: '#/components/schemas/Idol'
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+
+    Brand:
+      type: object
+      required: [id, name, nameEn]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        nameEn:
+          type: string
+
+    ColorPalette:
+      type: object
+      required: [primary, onPrimary]
+      properties:
+        primary:
+          type: string
+          pattern: '^#[0-9a-fA-F]{6}$'
+          description: イメージカラー本体 (#RRGGBB)
+        name:
+          type: string
+          description: カラー名称 (im@sparql に存在する場合のみ)
+        onPrimary:
+          type: string
+          pattern: '^#[0-9a-fA-F]{6}$'
+          description: primary に重ねる文字色 (WCAG コントラスト計算済)
+
+    Profile:
+      type: object
+      required: [uid]
+      properties:
+        uid:
+          type: string
+          description: Google sub claim (内部識別子、表示しない)
+        name:
+          type: string
+          description: GIS userinfo の name (memory cache TTL 15 分)
+        picture:
+          type: string
+          format: uri
+          description: GIS userinfo の picture URL (memory cache TTL 15 分)
+
+    Favorite:
+      type: object
+      required: [idolId, addedAt, kind]
+      properties:
+        idolId:
+          type: string
+        addedAt:
+          type: string
+          format: date-time
+        kind:
+          type: string
+          enum: [tantou, oshi]
+
+    FavoriteList:
+      type: object
+      required: [favorites]
+      properties:
+        favorites:
+          type: array
+          items:
+            $ref: '#/components/schemas/Favorite'
+
+    FavoriteCreateRequest:
+      type: object
+      required: [idolId, kind]
+      properties:
+        idolId:
+          type: string
+        kind:
+          type: string
+          enum: [tantou, oshi]
+
+    Health:
+      type: object
+      required: [status, checks]
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded, down]
+        checks:
+          type: object
+          properties:
+            users_db:
+              type: string
+              enum: [ok, error]
+            litestream_lag_seconds:
+              type: integer
+            jwks_cache_age_seconds:
+              type: integer
+
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: machine-readable code (unauthorized / token_expired / forbidden / not_found / bad_request / validation_failed / internal_error / service_unavailable)
+            message:
+              type: string
+              description: human-readable message (日本語)
+            details:
+              type: object
+              description: 任意の追加情報 (PII 含めない)

--- a/docs/api/idols.md
+++ b/docs/api/idols.md
@@ -1,43 +1,188 @@
 ---
 id: api-idols
-title: アイドル情報 API (/api/idols/*)
+title: アイドル情報 API (/api/idols/* + /api/brands + /api/colors)
 status: skeleton
 last_updated: 2026-05-17
 related_plan: docs/harness/plan.md §3.3
 related_adrs:
   - ADR-0007
   - ADR-0010
+  - ADR-0014
 ---
 
-# アイドル情報 API (/api/idols/*)
+# アイドル情報 API (/api/idols/* + /api/brands + /api/colors)
 
-> **5 行以内 summary**: 公開マスタとしてアイドル / ブランド / イメージカラーを返す read-only API。
-> データソースはコンテナイメージ焼込の `data/idols.db` (SQLite)、上流は im@sparql。
-> 認証不要。本格実装は C3 (EPIC-001) + C5 (EPIC-003)。
+> **5 行以内 summary**: 公開マスタとしてアイドル / ブランド / イメージカラーを返す
+> read-only API。データソースはコンテナイメージ焼込の `data/idols.db` (SQLite)、
+> 上流は im@sparql (RDF / SPARQL)。認証不要、`Cache-Control: public, max-age=86400`
+> で CDN レイヤを許容。本格実装は C3 (`feature/*` 再編) + C5 (Backend ハンドラ実装)。
 
-## エンドポイント (骨格、本格化は C3 / C5)
+## エンドポイント
 
-| メソッド | パス | 用途 |
-|---|---|---|
-| GET | `/api/idols` | アイドル一覧 (ページネーション、ブランド / カラーフィルタ) |
-| GET | `/api/idols/{id}` | 個別アイドル詳細 |
-| GET | `/api/idols/search` | キーワード検索 (名前 / ブランド / カラー) |
-| GET | `/api/brands` | ブランド一覧 |
-| GET | `/api/colors` | カラーパレット一覧 |
+| メソッド | パス | 用途 | 認証 | ステータス |
+|---|---|---|---|---|
+| GET | `/api/idols` | アイドル一覧 (ブランド / カラー フィルタ + ページネーション) | 不要 | C5 で本格実装 |
+| GET | `/api/idols/{id}` | 個別アイドル詳細 | 不要 | C5 |
+| GET | `/api/idols/search` | キーワード検索 (name / nameRuby / brand / colorName 全文) | 不要 | C5 |
+| GET | `/api/brands` | ブランド一覧 | 不要 | C5 |
+| GET | `/api/colors` | カラーパレット一覧 | 不要 | C5 |
+
+スキーマ詳細は `colormaster-api.yaml` を参照。
+
+## クエリパラメータ規約
+
+### `/api/idols` (一覧 + フィルタ)
+
+| パラメータ | 型 | 必須 | デフォルト | 説明 |
+|---|---|---|---|---|
+| `brand` | string | 任意 | (未指定なら全件) | ブランド ID (765AS / CG / ML / SC / SS / SP 等) |
+| `color` | string (`#RRGGBB`) | 任意 | (未指定なら全件) | 完全一致のイメージカラー (Hex 6 桁) |
+| `page` | integer (>=1) | 任意 | 1 | ページ番号 (1-origin) |
+| `pageSize` | integer (1-200) | 任意 | 50 | 1 ページあたり件数 |
+
+- 不正値は `400 bad_request` + `details: { field: "...", reason: "..." }`
+- `brand` と `color` は AND 結合 (両指定時は両方一致)
+
+### `/api/idols/search`
+
+| パラメータ | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `q` | string (1-100 字) | **必須** | 検索クエリ。`name` / `nameRuby` / `brand.name` / `color.name` の **OR 全文** |
+| `page` | integer | 任意 | 同上 |
+| `pageSize` | integer | 任意 | 同上 |
+
+- `q` が空 / 101 字以上 → `400 validation_failed`
+- 検索アルゴリズム: SQLite `LIKE '%q%'` または FTS5 (C5 で決定、`.claude/rules/sql-delight.md` 準拠)
+- 結果はスコアでソートせず、`nameRuby` 昇順固定 (将来 ADR で再検討)
+
+### `/api/idols/{id}`
+
+- `id` は IdolId (im@sparql RDF 識別子 slug、例: `imas_Idol_天海春香` → URL safe slug 化)
+- 存在しない場合は `404 not_found`
+
+## レスポンス形式
+
+`colormaster-api.yaml` の `components/schemas` を参照:
+
+- `IdolList` (idols + page + pageSize + total)
+- `Idol` (id + brandId + name + nameRuby + color)
+- `Brand` (id + name + nameEn)
+- `ColorPalette` (primary + name? + onPrimary)
+
+各 schema の意味とドメイン上の制約は `../architecture/domain-model.md` を参照。
 
 ## キャッシュ戦略
 
-- read-only マスタなので CDN レベルキャッシュ可 (`Cache-Control: public, max-age=86400`)
-- 同期 PR (`docs/runbooks/sync-imasparql.md`) でデータ更新時はデプロイで自動失効
+| レイヤ | 戦略 | TTL | 失効契機 |
+|---|---|---|---|
+| Backend → Client (HTTP) | `Cache-Control: public, max-age=86400` | 24 時間 | デプロイ (同期 PR merge → 新コンテナリリース) で URL ベース失効 |
+| Backend memory | なし (idols.db を直接クエリ) | — | (DB 読み込みコストは無視できる程度) |
+| クライアント Repository | memory cache (全件、起動時取得) | なし | 画面のリフレッシュアクション (将来導入) |
+| CDN (Cloudflare 等) | 採用していない (現状) | — | 将来 ADR で検討 |
 
-## データソース
+- **stale-while-revalidate** は使わない (シンプルな max-age のみ)
+- **ETag / If-Modified-Since** は採用しない (Backend デプロイの SHA で URL は変わらないため意味薄)
+- 必要があれば将来 `Cache-Control: public, max-age=86400, immutable` への昇格を検討
 
-- `data/idols.db` (SQLite、コンテナイメージ焼込)
-- 上流: `imas/imasparql` リポジトリ (RDF)、日次 SHA 監視で差分時のみ PR 自動作成 (ADR 0007)
+## データソースとライフサイクル
+
+```
+imas/imasparql (RDF)
+   ↓ 日次 GitHub Actions cron + SHA 監視 (ADR 0007)
+data/idols.db (リポジトリ commit)
+   ↓ Dockerfile で COPY (ADR 0010)
+Cloud Run コンテナイメージに焼込 (read-only)
+   ↓ Ktor server がクエリ
+HTTP レスポンス (Cache-Control 24 時間)
+```
+
+- 同期は `docs/runbooks/sync-imasparql.md` (C6 で本格化) と `.claude/rules/{sync-job,sparql}.md` を参照
+- Cloud Run コンテナの `idols.db` は読み取り専用、書込みは `users.db` のみ (`me.md`)
+- ローカル開発では Fuseki Docker (ADR 0014) で im@sparql の代替を立てられる (`docs/runbooks/local-imasparql.md`、C6)
+
+## レスポンス例 (JSON、参考)
+
+> 注: 完全なスキーマは `colormaster-api.yaml` を SoT とする。本ファイルでは可読性のために
+> 短い参考例のみ示す (PR レビューでの構造把握用)。
+
+```json
+GET /api/idols?brand=765AS&pageSize=2
+
+200 OK
+Content-Type: application/json; charset=utf-8
+Cache-Control: public, max-age=86400
+
+{
+  "idols": [
+    {
+      "id": "imas_Idol_天海春香",
+      "brandId": "765AS",
+      "name": "天海春香",
+      "nameRuby": "あまみはるか",
+      "color": {
+        "primary": "#E22B30",
+        "name": null,
+        "onPrimary": "#FFFFFF"
+      }
+    },
+    {
+      "id": "imas_Idol_如月千早",
+      "brandId": "765AS",
+      "name": "如月千早",
+      "nameRuby": "きさらぎちはや",
+      "color": {
+        "primary": "#2743D2",
+        "name": null,
+        "onPrimary": "#FFFFFF"
+      }
+    }
+  ],
+  "page": 1,
+  "pageSize": 2,
+  "total": 13
+}
+```
+
+## エラーケース
+
+| HTTP | `error.code` | 発生条件 |
+|---|---|---|
+| 400 | `bad_request` | クエリパラメータ型不正 (`page=abc` 等) |
+| 400 | `validation_failed` | `q` が空 / 過長、`color` が `#RRGGBB` 形式違反 |
+| 404 | `not_found` | `/api/idols/{id}` の id 不存在 |
+| 500 | `internal_error` | DB 破損 / 想定外 exception (details は redaction) |
+
+レート制限は現状なし (将来導入時は `429` 追加 + ADR 起票)。
+
+## 機械検証 (`.claude/rules/`、A2-2 + A6 で本格化)
+
+| 規約 | 検証手段 |
+|---|---|
+| `id` パラメータの slug 文字種 | Konsist でハンドラの正規表現マッチ要求 |
+| Cache-Control 必須 | Konsist で `/api/idols/*` ハンドラの response 設定検証 |
+| `details` フィールドに PII 含めない | Konsist + `.claude/rules/pii.md` redaction 規約 |
+| `idols.db` への書込みなし (read-only) | Konsist で `INSERT / UPDATE / DELETE` 文を `idols.db` 接続から検出 |
+
+## クライアント側の利用パターン (Repository + UseCase、C3 で本格化)
+
+- `IdolRepository.findAll()`: 起動時に全件取得 + memory cache (R-3 越境ルール)
+- `IdolRepository.findByBrand(brandId)`: cache hit 後にフィルタ
+- `IdolRepository.search(query)`: cache が新鮮なら local search、stale なら `/api/idols/search` 呼出
+- `IdolRepository.findById(id)`: cache hit、miss なら `/api/idols/{id}` 呼出
+
+詳細は `../architecture/{data-flow,sequences}.md` の検索ユースケースを参照。
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- `backend/server/` の `/api/idols/*` ハンドラは **未実装** (C5)
+- `data/idols.db` は repo に commit 済、im@sparql 由来データを保持
+- 既存の `core/network/imasparql/` は SPARQL クライアントの骨格、本格化は C6
+- 現存する `core/features/*` の旧画面は `core/network/firestore/` 経由で動作 (C3 + C5 で全置換予定)
 
 ## 関連
 
-- ADR 0007 (im@sparql upstream-driven 同期)
-- ADR 0010 (アイドル情報マスタ SQLite を repo 内 commit)
-- `docs/api/colormaster-api.yaml`
-- `docs/runbooks/sync-imasparql.md`
+- ADR 0007 (im@sparql upstream-driven 同期) / 0010 (idols.db repo 内 commit) / 0014 (ローカル Fuseki)
+- `colormaster-api.yaml` (`/api/idols/*` `/api/brands` `/api/colors` パスとスキーマ SoT)
+- `../architecture/{data-flow,domain-model,sequences}.md`
+- `docs/runbooks/sync-imasparql.md` (C6 で本格化) / `docs/runbooks/local-imasparql.md`
+- `.claude/rules/{sync-job,sparql,sqlite-data-file,sql-delight,network-client}.md`

--- a/docs/api/me.md
+++ b/docs/api/me.md
@@ -8,45 +8,200 @@ related_adrs:
   - ADR-0008
   - ADR-0011
   - ADR-0020
+  - ADR-0021
+  - ADR-0022
 ---
 
 # ユーザーデータ API (/api/me/*)
 
-> **5 行以内 summary**: 認証済ユーザーの担当・推し一覧 / プロフィール参照を扱う。GIS ID Token
-> Bearer 認証必須、Backend 内蔵 SQLite (`users.db`) に uid のみ保存 (PII 最小化)。
-> Litestream で R2 に WAL replicate、起動時 restore。本格実装は C5 (EPIC-003)。
+> **5 行以内 summary**: 認証済ユーザーの担当・推し一覧 / プロフィール参照 / アカウント削除を
+> 扱う。GIS ID Token Bearer 認証必須、Backend 内蔵 SQLite (`users.db`) に **uid のみ** 保存
+> (PII 最小化、ADR 0020)。Litestream で R2 に WAL replicate + 起動時 restore (ADR 0008)。
+> 本格実装は C5 (EPIC-003)、本ファイルは規約 + 設計判断 + スキーマ。
 
-## エンドポイント (骨格、本格化は C5)
+## エンドポイント
 
-| メソッド | パス | 用途 |
+| メソッド | パス | 用途 | 認証 | 主要レスポンス |
+|---|---|---|---|---|
+| GET | `/api/me/profile` | uid + GIS userinfo (memory cache TTL 15 分) | Bearer | `Profile` |
+| GET | `/api/me/favorites` | 担当・推し一覧 (`kind` でフィルタ可) | Bearer | `FavoriteList` |
+| POST | `/api/me/favorites` | 担当・推し追加 | Bearer | `Favorite` (201) |
+| DELETE | `/api/me/favorites/{idolId}` | 担当・推し削除 | Bearer | (204) |
+| DELETE | `/api/me` | ユーザーアカウント削除 (uid + favorites 物理削除) | Bearer | (204) |
+
+スキーマ詳細は `colormaster-api.yaml` を参照。
+
+## 認可規約
+
+- **全エンドポイントで `Authorization: Bearer <GIS ID Token>` 必須**
+- Backend は **`requireUid()` ヘルパで uid を抽出** (`auth.md` 参照)
+- **`requireUid()` を呼ばないハンドラは Konsist 規約違反** (A2-2 + A6 で機械化、`.claude/rules/backend-auth.md`)
+- **uid 単位での所有権チェック**: 全 SQL クエリの WHERE 条件に `uid = :authedUid` を必須化
+  - 他人の uid のデータには触れない (Konsist で `INSERT/UPDATE/DELETE` 文の WHERE 句を検証)
+  - 違反は `403 forbidden` ではなく **そもそも到達不可** な設計とする
+
+## DB スキーマ (`users.db`、PII 最小化 / ADR 0020)
+
+| テーブル | カラム | 制約 | 説明 |
+|---|---|---|---|
+| `users` | `uid` TEXT PK | NOT NULL、length 21 | Google Account ID (sub claim)。**他の PII は保存しない** |
+| `users` | `created_at` INTEGER | NOT NULL | Unix epoch seconds (uid 初回作成時刻) |
+| `favorites` | `uid` TEXT FK → users(uid) | NOT NULL、ON DELETE CASCADE | 所有者 uid |
+| `favorites` | `idol_id` TEXT | NOT NULL | アイドル ID (`idols.db` には外部キー張らない、リポジトリ分離) |
+| `favorites` | `kind` TEXT | CHECK (kind IN ('tantou', 'oshi')) | 担当 / 推し |
+| `favorites` | `added_at` INTEGER | NOT NULL | Unix epoch seconds |
+| `favorites` | (uid, idol_id) | PRIMARY KEY | 重複追加を物理的に防ぐ |
+
+> 補足: `users.db` と `idols.db` は **別 DB ファイル** (前者は private、後者はコンテナ焼込)、
+> SQLite の `ATTACH DATABASE` も使わない。クライアント側で結合表示する場合は両 API を並行
+> 呼出してアプリ層で join (オフライン耐性・キャッシュ戦略の分離のため)。
+
+## ユーザー初回サインイン時の挙動
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Backend
+    participant UsersDb
+
+    Client->>Backend: GET /api/me/profile (Bearer)
+    Backend->>Backend: requireUid() → uid 抽出
+    Backend->>UsersDb: SELECT 1 FROM users WHERE uid = ?
+    alt 未登録 (初回)
+        UsersDb-->>Backend: no row
+        Backend->>UsersDb: INSERT INTO users (uid, created_at) VALUES (?, now)
+        UsersDb-->>Backend: OK (WAL update → Litestream 非同期)
+    else 既登録
+        UsersDb-->>Backend: row exists
+    end
+    Backend-->>Client: 200 {uid, name?, picture?}
+```
+
+- 初回サインイン時に **暗黙的に `users` テーブルに upsert** (専用エンドポイント不要)
+- 副作用: Backend memory cache に `uid → GIS userinfo` を 15 分 TTL で格納
+
+## ユーザー削除フロー (`DELETE /api/me`)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Client
+    participant Backend
+    participant UsersDb
+    participant LS as Litestream
+    participant R2
+
+    User->>Client: 「アカウント削除」確認後タップ
+    Client->>Backend: DELETE /api/me (Bearer)
+    Backend->>Backend: requireUid() → uid 抽出
+    Backend->>UsersDb: DELETE FROM users WHERE uid = ? (CASCADE で favorites も削除)
+    UsersDb-->>Backend: OK
+    Backend-->>Client: 204
+    Client->>Client: secure storage から Token 削除 + cache 破棄
+    Note over LS,R2: 非同期
+    UsersDb->>LS: WAL update
+    LS->>R2: PUT
+```
+
+- **物理削除** (論理削除 / soft delete は採用しない、PII 最小化のため)
+- R2 上の WAL は **古いものから期限切れで自然消滅** (Litestream の retention policy、`.claude/rules/r2-litestream.md` で本格化)
+- 削除後の Token は **クライアントが破棄**、Token 自体の revoke は GIS 側 (Google アカウント設定で revoke 可能、Backend は介入しない)
+- 削除 runbook は `docs/runbooks/user-deletion.md` (C5 + 法務要件があれば前倒し作成)
+
+## エラーケース
+
+| HTTP | `error.code` | 発生条件 |
 |---|---|---|
-| GET | `/api/me/profile` | uid + GIS userinfo (memory cache TTL 15 分) |
-| GET | `/api/me/favorites` | ユーザーの担当・推し一覧 |
-| POST | `/api/me/favorites` | 担当・推し追加 |
-| DELETE | `/api/me/favorites/{idolId}` | 担当・推し削除 |
+| 400 | `validation_failed` | POST body の schema 違反 (`kind` enum 外、`idolId` 空) |
+| 401 | `unauthorized` | Bearer ヘッダ不在 / 署名検証失敗 / iss/aud/exp 違反 |
+| 401 | `token_expired` | ID Token 期限切れ |
+| 403 | `forbidden` | (本来到達不可、Konsist 検証漏れの場合のみ) uid 不一致 |
+| 404 | `not_found` | `DELETE /api/me/favorites/{idolId}` で対象が存在しない |
+| 500 | `internal_error` | DB 破損 / Litestream 異常 (詳細は redaction) |
+| 503 | `service_unavailable` | JWKS 取得失敗 / Litestream restore 中 / R2 unreachable |
 
-## 認可
+## キャッシュ戦略
 
-- 全エンドポイントで `Authorization: Bearer <GIS ID Token>` 必須
-- Backend 側で **`requireUid()` ヘルパ** を呼び出さない実装は Konsist 規約違反 (A6 で機械化、`.claude/rules/backend-auth.md`)
-- uid 単位での所有権チェック (自分以外の uid のデータには触れない)
-
-## DB スキーマ (PII 最小化、ADR 0020)
-
-| テーブル | カラム | 説明 |
+| レイヤ | 戦略 | TTL |
 |---|---|---|
-| `users` | `uid` (PK) | Google Account ID (sub claim)。他の PII は保存しない |
-| `favorites` | `uid`, `idol_id`, `added_at` | 担当・推し一覧 |
+| Backend → Client (HTTP) | `Cache-Control: private, no-store` | 0 (CDN キャッシュ禁止) |
+| Backend memory | GIS userinfo cache (key: uid) | **15 分** (`.claude/rules/pii.md`) |
+| クライアント Repository | 画面表示中の memory cache | 画面遷移で破棄 |
 
-## ユーザー削除
+- **CDN キャッシュは禁止** (個人データ、`private, no-store` を必須)
+- クライアントの長期キャッシュも採用しない (自分のデータの即時反映を優先、stale 化を避ける)
 
-- `/api/me` への DELETE で `users` + `favorites` を物理削除 + R2 上の WAL も古いものから期限切れで自然消滅
-- 削除 runbook は `docs/runbooks/user-deletion.md` (将来作成)
+## レスポンス例 (参考)
+
+```json
+GET /api/me/favorites?kind=tantou
+Authorization: Bearer eyJhbGc...
+
+200 OK
+Content-Type: application/json; charset=utf-8
+Cache-Control: private, no-store
+
+{
+  "favorites": [
+    {
+      "idolId": "imas_Idol_天海春香",
+      "addedAt": "2026-05-10T12:34:56Z",
+      "kind": "tantou"
+    }
+  ]
+}
+```
+
+```json
+POST /api/me/favorites
+Authorization: Bearer eyJhbGc...
+Content-Type: application/json
+
+{ "idolId": "imas_Idol_如月千早", "kind": "oshi" }
+
+201 Created
+Content-Type: application/json; charset=utf-8
+Cache-Control: private, no-store
+
+{
+  "idolId": "imas_Idol_如月千早",
+  "addedAt": "2026-05-17T09:12:34Z",
+  "kind": "oshi"
+}
+```
+
+## 機械検証 (`.claude/rules/`、A2-2 + A6 で本格化)
+
+| 規約 | 検証手段 |
+|---|---|
+| 全 `/api/me/*` ハンドラで `requireUid()` 呼出必須 | Konsist で関数本体パターンマッチ (`backend-auth.md`) |
+| 全 SQL クエリの WHERE に `uid` 含むこと | Konsist で SQLDelight `.sq` ファイルの解析 (`sql-delight.md`) |
+| `users` テーブルに uid 以外の PII カラムを追加禁止 | Konsist で SQLDelight schema をチェック (`pii.md`) |
+| `Cache-Control: private, no-store` 必須 | Konsist でハンドラ response 設定検証 |
+| エラー応答の `details` に PII 含めない | Konsist + pii redaction 規約 |
+| `Dockerfile` で `COPY data/users.db` しない | Konsist で Dockerfile を検証 (`db-protection.md`) |
+
+## PII 取扱 (`.claude/rules/pii.md` 準拠)
+
+- **DB 保存**: `uid` のみ
+- **API レスポンスに含めて良い**: `uid` / `name` / `picture` / `addedAt` / `idolId` / `kind`
+- **API レスポンスに含めない**: `email` / IP / `Authorization` ヘッダ
+- **ログに含めて良い**: `uid` / `idolId` / endpoint パス / HTTP メソッド / status code
+- **ログに含めない**: `name` / `email` / `picture` / `Authorization` ヘッダ生値 / SQL の bind 変数の生値 (uid 以外)
+- **Skill (pr-retrospective / code-reviewer) 出力前**: 上記の含めない項目を `[REDACTED-*]` 置換
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- `backend/server/` の `/api/me/*` ハンドラは **未実装** (C5)
+- `users.db` は **存在しない** (Backend 未稼働、Litestream + R2 連携も未構築)
+- 既存の担当・推しデータは Firebase Firestore (`core/network/firestore/`) 上にある (C5 で migration、ADR で別途記録予定)
+- 本ファイルが記述する仕様は **C5 完了後の最終形**
 
 ## 関連
 
-- ADR 0008 (Backend SQLite + Litestream + R2)
-- ADR 0011 (GIS 統一)
-- ADR 0020 (PII 保護: uid のみ DB 保存)
-- `.claude/rules/{backend-auth,pii,db-protection,r2-litestream}.md`
-- `docs/api/colormaster-api.yaml`
+- ADR 0008 (Backend SQLite + Litestream + R2) / 0011 (GIS 統一) / 0020 (PII 最小化) / 0021 (Secrets 管理) / 0022 (Cloudflare R2)
+- `colormaster-api.yaml` (`/api/me/*` パスとスキーマ SoT)
+- `auth.md` (Bearer 認証 + `requireUid()` 詳細)
+- `../architecture/{data-flow,sequences}.md` (Litestream replicate / restore、担当追加シーケンス)
+- `.claude/rules/{backend-auth,pii,db-protection,r2-litestream,sql-delight,sqlite-data-file}.md`
+- `docs/runbooks/{r2-litestream,user-deletion,secrets-rotation}.md` (C5 で本格化)

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -3,50 +3,167 @@ id: arch-data-flow
 title: データフロー (im@sparql → Backend → Client)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3.3 / §3.4
+related_plan: docs/harness/plan.md §3.2 / §3.3
 related_adrs:
   - ADR-0007
   - ADR-0008
   - ADR-0010
+  - ADR-0014
+  - ADR-0022
 ---
 
 # データフロー
 
-> **5 行以内 summary**: ColorMaster は im@sparql (上流 RDF/SPARQL) から日次で差分を取り込み、
-> Backend 内のアイドル情報 SQLite (`idols.db`、コンテナイメージ焼込) に反映する。
-> ユーザーデータ (`users.db`) は Backend 内蔵 + Litestream で R2 にレプリケート。
-> クライアントは `/api/idols/*` および `/api/me/*` 経由でアクセスする。本格化は A2 + C5 + C6。
+> **5 行以内 summary**: ColorMaster はアイドル情報を im@sparql (RDF) から日次 upstream-driven
+> sync で `data/idols.db` (read-only) に取り込み、ユーザーデータ (担当・推し) は Backend
+> 内蔵 `data/users.db` に保存して Litestream で R2 へ WAL レプリケート / 起動時 restore
+> する。クライアントは `/api/idols/*` (公開) と `/api/me/*` (GIS 認証) 経由でアクセス。
+> 詳細は §3.3 / `runbooks/sync-imasparql.md` / `runbooks/r2-litestream.md` 参照。
 
-## データソース
+## データソース一覧
 
-| ソース | 種別 | 同期戦略 |
-|---|---|---|
-| `imas/imasparql` (RDF) | 上流マスタ | upstream-driven sync (日次 cron、SHA 監視、差分時のみ PR 自動作成、ADR 0007) |
-| `data/idols.db` (SQLite) | 派生マスタ | リポジトリ commit + コンテナイメージ焼込、read-only |
-| `data/users.db` (SQLite) | ユーザーデータ | Backend 内蔵 + Litestream で R2 へ WAL replicate + 起動時 restore (ADR 0008) |
+| ソース | 種別 | 同期戦略 | 保存場所 | 公開範囲 |
+|---|---|---|---|---|
+| `imas/imasparql` (RDF / SPARQL) | 上流マスタ | upstream-driven sync (GitHub Actions 日次 cron、SHA 監視、差分時のみ PR 自動作成) | リポジトリ外 (上流) | public |
+| `data/idols.db` (SQLite) | 派生マスタ | リポジトリ commit + コンテナイメージ焼込、read-only | リポジトリ + コンテナ内 | public read |
+| `data/idols.json` (JSON snapshot) | 派生マスタ (副) | 同上 (diff レビュー用 / wasmJs クライアント直読用) | リポジトリ + コンテナ内 | public read |
+| `data/.imasparql-sync-state.json` | 同期メタ | 同期ジョブが latest SHA を記録 | リポジトリ内 | 公開 (機密性なし) |
+| `data/users.db` (SQLite) | ユーザーデータ | Backend 内蔵 + Litestream で R2 へ WAL replicate + 起動時 restore | Cloud Run の `/data` + R2 private bucket | **private (PII 含む)** |
 
-## フロー図 (TODO: A2 で Mermaid 化)
+## 全体フロー図
 
+```mermaid
+flowchart TB
+    subgraph Upstream["上流"]
+        IMSparql[("imas/imasparql\n(RDF endpoint)")]
+    end
+
+    subgraph CI["GitHub Actions (日次 cron)"]
+        SyncJob["sync-imasparql workflow"]
+        SHACheck{"SHA 一致?"}
+        Fetch["./gradlew :backend:cli:fetchIdolColorsFromImasparql"]
+        PR["chore/sync-imasparql-&lt;SHA&gt; PR"]
+        Issue["失敗時 Issue 自動起票"]
+    end
+
+    subgraph Repo["リポジトリ"]
+        IdolsDb[("data/idols.db\nidols.json\n.imasparql-sync-state.json")]
+    end
+
+    subgraph CloudRun["Cloud Run (Backend)"]
+        Container["コンテナイメージ"]
+        Server["Ktor Server"]
+        UsersDb[("/data/users.db\n(SQLite + WAL)")]
+        Litestream["Litestream daemon"]
+    end
+
+    subgraph R2["Cloudflare R2 (private)"]
+        WAL[("users.db WAL\n継続レプリカ")]
+    end
+
+    subgraph Client["クライアント (4 target)"]
+        ClientApp["Compose Multiplatform App"]
+    end
+
+    IMSparql --SPARQL query--> SyncJob
+    SyncJob --> SHACheck
+    SHACheck -->|不一致| Fetch
+    SHACheck -->|一致| Skip([no-op])
+    Fetch --> IdolsDb
+    Fetch --失敗--> Issue
+    IdolsDb --PR レビュー後 merge--> PR
+    IdolsDb --コンテナビルド時--> Container
+    Container --デプロイ--> Server
+    Server --起動時 restore--> UsersDb
+    R2 --restore--> UsersDb
+    UsersDb --WAL replicate--> Litestream
+    Litestream --> WAL
+    Server --/api/idols/*--> ClientApp
+    Server --/api/me/* (Bearer)--> ClientApp
 ```
-imas/imasparql (RDF)
-  └─[日次 cron, SHA 監視, ADR 0007]─→ data/idols.db (SQLite)
-                                       └─[コンテナイメージ焼込]─→ Backend
-                                                                   ├─ /api/idols/* ─→ Client
-                                                                   └─ /api/me/*    ─→ Client
-                                                                          ↑
-                                                                          ├─ GIS ID Token (Bearer)
-                                                                          └─ users.db (uid のみ)
-                                                                                ↕ Litestream
-                                                                              R2 (private)
-```
+
+> 凡例: 実線 = データの流れ、円柱 = 永続層、丸角 = workflow / プロセス。`data/users.db`
+> は **コンテナイメージに焼き込まない** (`.dockerignore` で除外、ADR 0008 / 0020)。
+
+## im@sparql 同期フロー (`docs/harness/plan.md` §3.3 詳細)
+
+1. **SHA チェック** — GitHub Actions が `gh api repos/imas/imasparql/commits/master` で latest SHA を取得し、`data/.imasparql-sync-state.json` の `upstream_sha` と比較
+2. **一致 → no-op** で正常終了 (API 呼び出し 1 回のみのコスト、Free tier 圧迫しない)
+3. **不一致 → 取得** — `./gradlew :backend:cli:fetchIdolColorsFromImasparql` を実行し、`data/idols.db` と `data/idols.json` を更新
+4. **レコード数 ±X% の異常検知** — 前回比で大幅な減少 / 増加があれば fail (上流の不具合を捕捉)
+5. **PR 自動作成** — `chore/sync-imasparql-<short-sha>` ブランチで PR を起票、`<!-- evidence:imasparql-sync -->` メタデータを description に挿入、人間レビュー必須 (auto-merge 禁止、R-15)
+6. **異常時** — im@sparql サーバが 5xx を返す等のケースで GitHub Issue を自動起票、次回 cron でリトライ
+7. **ローカル検証** — 開発者がローカルで Fuseki Docker (ADR 0014) を起動して `:backend:cli:fetchIdolColorsFromImasparql` をテスト可能
+
+詳細手順は `docs/runbooks/sync-imasparql.md` (C6 で本格化)。
+
+## Litestream replicate / restore フロー (ADR 0008 / 0022)
+
+### Replicate (Backend 稼働中)
+
+1. Ktor Server が `/data/users.db` への書き込み (担当追加 / 削除 / プロファイル更新)
+2. SQLite が WAL ファイル (`users.db-wal`) を更新
+3. Litestream daemon が WAL の変化を検知し、R2 へ HTTP PUT (S3 互換 API)
+4. R2 は private bucket、Cloud Run の service account に紐づく R2 access token のみ allow (ADR 0021)
+
+### Restore (Backend 起動時)
+
+1. Cloud Run が新コンテナを起動
+2. エントリポイント (`scripts/startup.sh` 等) が Litestream `restore` を実行
+3. R2 上の最新 WAL から `/data/users.db` を再構築
+4. Litestream daemon を background で起動
+5. Ktor Server が起動、`/api/me/*` の処理を開始
+
+> **重要**: Cloud Run は ephemeral (コンテナ再起動で `/data` が初期化される) のため、
+> 起動時 restore が **必須**。restore 失敗時は server を起動しない (起動順序の保証は
+> ADR 0008 と `.claude/rules/cloud-run-deploy.md` で規約化、A2-2 で本格化)。
 
 ## クライアント側のキャッシュ戦略
 
-- アイドル情報: Repository 層で memory cache (TTL なし、起動時に一括取得)
-- ユーザー情報 (GIS userinfo): memory cache TTL 15 分 (`.claude/rules/pii.md` 準拠)
+| データ | キャッシュ | TTL | 理由 |
+|---|---|---|---|
+| アイドル一覧 / 個別 / 検索結果 | Repository 層で memory cache (全件) | なし (起動時取得後は永続) | read-only マスタ、データソースは日次 sync 時点で確定 |
+| ブランド一覧 / カラー一覧 | 同上 | なし | 同上 |
+| GIS userinfo (display name / email / picture) | Backend 側 memory cache (クライアントは経由のみ) | 15 分 | PII 最小化と取得コストのバランス (`pii.md`) |
+| ID Token (GIS) | クライアント側 secure storage | GIS が発行する exp 値 (通常 1 時間) | exp 失効時はクライアントが再取得 |
+| 担当・推し一覧 | クライアント側 memory cache (画面表示中のみ) | 画面遷移で破棄 | 自分のデータの即時反映を優先、stale 化を避ける |
+
+クライアント実装は C3 (feature-first 再編) で `core/domain` の Repository に集約。
+
+## Backend 側のキャッシュ戦略
+
+| データ | キャッシュ | TTL | 備考 |
+|---|---|---|---|
+| `/api/idols/*` レスポンス | Cloud Run の HTTP `Cache-Control: public, max-age=86400` | 24 時間 | 日次 sync 後のデプロイで自然失効 |
+| JWKS (Google 公開鍵) | Backend memory cache | Google が指定する Cache-Control (通常 6 時間) | `Authorization` ヘッダ検証で都度参照、JWKS 取得失敗時は 503 |
+| GIS userinfo | Backend memory cache (key: uid) | 15 分 | PII 取扱い、Skill 出力前 redaction (`pii.md`) |
+
+CDN レベルキャッシュ (Cloudflare CDN 等) は **採用していない** (Cloud Run の上に CDN を被せていない、`docs/harness/plan.md` §3.4)。将来 traffic が増えた場合は Cloudflare CDN + Cloud Run の組合せを ADR で検討する。
+
+## エラーパスとリトライ
+
+| 失敗箇所 | 検知 | 対応 |
+|---|---|---|
+| im@sparql 5xx / timeout | sync workflow | Issue 起票 + 次回 cron でリトライ |
+| `idols.db` レコード数異常 (±X% 超) | sync workflow | PR 作成せず fail、人間が原因確認 |
+| Litestream replicate 失敗 | Backend ヘルスチェック | アラート (Slack / 簡易 Webhook、C7 で整備) |
+| Backend 起動時 R2 restore 失敗 | 起動 script | Backend を起動しない、Cloud Run が retry |
+| GIS JWKS 取得失敗 | API ハンドラ | 503 + retry-after ヘッダ、クライアントは再試行 |
+| ID Token 期限切れ | API ハンドラ | 401 + クライアントは GIS で再取得 |
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- `backend/cli/` は Gradle module が存在するのみで実装薄 (im@sparql fetch は C6 で本格化)
+- `core/network/imasparql/` は SPARQL クライアントの骨格あり、本格化は C6
+- `data/idols.db` は repo に commit 済 (read-only マスタとして稼働中)
+- `data/users.db` は **存在しない** (Backend 未稼働、C5 で生成)
+- Litestream は導入未済 (C5 で `docker-compose` または `Dockerfile` に追加)
+- 上記フロー図は **C5-C7 完了後の最終形** を記述
 
 ## 関連
 
-- `docs/harness/plan.md` §3.3 (同期戦略) / §3.4 (ホスティング)
-- ADR 0007 / 0008 / 0010
-- `docs/runbooks/sync-imasparql.md` / `docs/runbooks/r2-litestream.md` (C5 / C6 で本格化)
+- `overview.md` / `layers.md` / `infrastructure.md` / `sequences.md`
+- ADR 0007 (im@sparql upstream-driven 同期) / 0008 (Backend SQLite + Litestream + R2) / 0010 (idols.db repo 内 commit) / 0014 (ローカル Fuseki Docker) / 0022 (Cloudflare R2)
+- `docs/runbooks/sync-imasparql.md` (C6 で本格化) / `docs/runbooks/r2-litestream.md` (C5 で本格化)
+- `.claude/rules/{sync-job,sparql,sqlite-data-file,r2-litestream,db-protection}.md`
+- `../api/colormaster-api.yaml` (API スキーマの SoT)

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -71,19 +71,24 @@ flowchart TB
     SHACheck -->|一致| Skip([no-op])
     Fetch --> IdolsDb
     Fetch --失敗--> Issue
-    IdolsDb --PR レビュー後 merge--> PR
+    Fetch --起票--> PR
+    PR --human review + merge--> IdolsDb
     IdolsDb --コンテナビルド時--> Container
     Container --デプロイ--> Server
-    Server --起動時 restore--> UsersDb
-    R2 --restore--> UsersDb
-    UsersDb --WAL replicate--> Litestream
-    Litestream --> WAL
+    WAL --restore (起動時)--> Litestream
+    Litestream --rebuild (起動時)--> UsersDb
+    UsersDb --WAL replicate (継続)--> Litestream
+    Litestream --PUT chunks--> WAL
+    Server --read/write--> UsersDb
     Server --/api/idols/*--> ClientApp
     Server --/api/me/* (Bearer)--> ClientApp
 ```
 
 > 凡例: 実線 = データの流れ、円柱 = 永続層、丸角 = workflow / プロセス。`data/users.db`
 > は **コンテナイメージに焼き込まない** (`.dockerignore` で除外、ADR 0008 / 0020)。
+> **restore の主体は Litestream daemon** (Startup script から起動)、Server は restore
+> 完了後にのみ start する (詳細は本ページ「Restore (Backend 起動時)」+ `sequences.md`
+> ユースケース 5)。
 
 ## im@sparql 同期フロー (`docs/harness/plan.md` §3.3 詳細)
 

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,36 +1,156 @@
 ---
 id: arch-domain-model
-title: ドメインモデル (アイドル / ブランド / カラー)
+title: ドメインモデル (アイドル / ブランド / カラー / 担当・推し)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3
+related_plan: docs/harness/plan.md §3.2
+related_adrs:
+  - ADR-0007
+  - ADR-0010
+  - ADR-0020
 ---
 
 # ドメインモデル
 
-> **5 行以内 summary**: ColorMaster のドメインモデル概観 (アイドル / ブランド / イメージカラー /
-> 担当・推し)。詳細は A2 + C3 で `core/domain/` の Kotlin 実装に整合する形で
-> Mermaid `erDiagram` 化する。用語の正規化は `docs/glossary.md` に集約。
+> **5 行以内 summary**: ColorMaster のドメインモデル概観 (Idol / Brand / ColorPalette /
+> FavoriteIdol)。アイドル情報は `data/idols.db` (read-only マスタ、im@sparql 由来)、
+> 担当・推しは `users.db` (uid のみ保存) に分かれて永続化される。詳細な値オブジェクト・
+> 集約境界・実装パスは C3 (`core/domain/` 新設) で本格定義。本ファイルは概観のみ。
 
-## 主要エンティティ (骨格)
+## エンティティ関係 (erDiagram)
 
-| エンティティ | 説明 | 関連属性 |
+```mermaid
+erDiagram
+    Brand ||--o{ Idol : "has"
+    Idol ||--|| ColorPalette : "has"
+    User ||--o{ FavoriteIdol : "owns"
+    Idol ||--o{ FavoriteIdol : "referenced by"
+
+    Brand {
+        BrandId id PK
+        string name
+        string nameEn
+    }
+
+    Idol {
+        IdolId id PK
+        BrandId brandId FK
+        string name
+        string nameRuby
+        ColorPalette color
+    }
+
+    ColorPalette {
+        Hex primary PK
+        string name
+        Hex onPrimary
+    }
+
+    User {
+        Uid uid PK "Google sub claim"
+    }
+
+    FavoriteIdol {
+        Uid uid PK,FK
+        IdolId idolId PK,FK
+        Timestamp addedAt
+        FavoriteKind kind "担当 or 推し"
+    }
+```
+
+> 補足: `User` テーブルは PII 最小化のため **`uid` 列のみ** (ADR 0020)。display name /
+> email / picture は GIS userinfo endpoint から都度取得し、Backend memory cache TTL 15 分
+> を経由してクライアントに返す (`docs/api/auth.md` 参照)。
+
+## エンティティ詳細 (骨格、A2-5 + C3 で本格化)
+
+### Idol (アイドル)
+
+| 属性 | 型 | 説明 | 値域・例 |
+|---|---|---|---|
+| `id` | `IdolId` (value class、内部は `String`) | アイドル一意 ID | im@sparql の RDF 識別子 (`imas:Idol_天海春香` 等) を slug 化 |
+| `brandId` | `BrandId` (value class) | 所属ブランド | `765AS` / `CG` / `ML` / `SC` / `SS` / `SP` |
+| `name` | `String` | アイドル名 (表示用) | 「天海春香」 |
+| `nameRuby` | `String` | フリガナ (ソート / 検索用) | 「あまみはるか」 |
+| `color` | `ColorPalette` | イメージカラー (集約所有) | 後述 |
+
+### Brand (ブランド)
+
+| 属性 | 型 | 説明 |
 |---|---|---|
-| `Idol` | アイドル | id, name, brand, color (`ColorPalette`) |
-| `Brand` | ブランド (765AS / CG / ML / SS / SC 等) | id, name, idols (一対多) |
-| `ColorPalette` | アイドルのイメージカラー (16 進カラー + 関連メタ) | hex, name |
-| `FavoriteIdol` | ユーザーの担当・推しアイドル (`users.db` 経由) | uid, idolId, addedAt |
+| `id` | `BrandId` | ブランド ID。enum 風だが将来追加に備え value class |
+| `name` | `String` | 日本語表記 (「アイドルマスター」「シャイニーカラーズ」等) |
+| `nameEn` | `String` | 英語表記 (「The IDOLM@STER」等) |
 
-## A2 + C3 での本格化内容
+### ColorPalette (イメージカラー)
 
-- `erDiagram` で関係を可視化
-- 値オブジェクト (`Hex`, `BrandId` 等) の定義
-- DDD 風の集約境界 (Idol / FavoriteIdol を別 aggregate にするか)
-- `core/data/Model*.kt` / `core/domain/UseCase*.kt` と対応
+| 属性 | 型 | 説明 |
+|---|---|---|
+| `primary` | `Hex` (value class、`#RRGGBB`) | アイドルのイメージカラー本体 |
+| `name` | `String` | カラー名称 (「桃色」「カナリヤ色」等、im@sparql 上に存在する場合のみ) |
+| `onPrimary` | `Hex` | `primary` に重ねる文字色 (WCAG コントラスト計算済、`Hex.calcOnColor()` で導出) |
+
+### FavoriteIdol (担当・推し)
+
+| 属性 | 型 | 説明 |
+|---|---|---|
+| `uid` | `Uid` (value class、内部は `String` で 21 桁数字) | 所有ユーザーの Google sub claim |
+| `idolId` | `IdolId` | 担当・推しのアイドル ID |
+| `addedAt` | `Instant` | 追加時刻 (`Clock.System.now()`) |
+| `kind` | `FavoriteKind` (sealed class: `Tantou` / `Oshi`) | 「担当」(プロデュース) と「推し」を区別 |
+
+## 値オブジェクト (Phase C で本格化)
+
+| 名前 | 制約 | 関連 rule |
+|---|---|---|
+| `Hex` | `#RRGGBB` 6 桁、`Hex.calcOnColor()` で onColor 導出 | `design-tokens.md` |
+| `IdolId` | im@sparql RDF 識別子 slug、空文字禁止 | `sparql.md` / `naming.md` |
+| `BrandId` | enum 風だが value class、未知の文字列は受け取らない | `naming.md` |
+| `Uid` | 21 桁数字 (Google sub claim 仕様)、`@Spec` でテスト | `pii.md` / `backend-auth.md` |
+| `FavoriteKind` | sealed class、`Tantou` / `Oshi` の 2 実装 | `ui-state.md` |
+
+## 集約境界 (DDD 風、暫定方針)
+
+- **Idol 集約**: `Idol` (root) + `ColorPalette` (内部値) — `ColorPalette` 単体での参照はせず、`Idol.color` 経由
+- **Brand 集約**: `Brand` (root) のみ。`Brand.idols` の一対多は **遅延読み込み** (リレーション)、Brand 自身は idols リストを持たない
+- **User 集約**: `User` (root) + `FavoriteIdol` (内部リスト) — Backend `/api/me/favorites` で取得・追加・削除
+- **越境**: `FavoriteIdol.idolId` は `Idol` への参照 (集約間は ID 経由、エンティティ参照しない)
+
+C3 (`core/domain/` 新設時) に DDD 風命名 (`IdolRepository.findById(id: IdolId): Idol`) と sealed class 構成を確定。本ファイルでは方向性のみ示す。
+
+## データソースとの対応
+
+| エンティティ | データソース | 永続化方式 | 詳細 |
+|---|---|---|---|
+| Idol / Brand / ColorPalette | `data/idols.db` (SQLite) | コンテナイメージ焼込、read-only | `data-flow.md` / ADR 0010 |
+| FavoriteIdol | `data/users.db` (SQLite) | Backend 内蔵 + Litestream → R2 | `data-flow.md` / ADR 0008 |
+| User (uid のみ) | `data/users.db` | 同上 | ADR 0020 (PII 最小化) |
+| User の display name / email / picture | GIS userinfo endpoint | DB 保存せず、Backend memory cache TTL 15 分 | `../api/auth.md` |
+
+## クエリパターン (将来の実装、C3 + C5)
+
+- アイドル一覧: `GET /api/idols?brand=<id>&color=<hex>&page=<n>`
+- アイドル個別: `GET /api/idols/{id}`
+- キーワード検索: `GET /api/idols/search?q=<query>` (name / nameRuby / brand / colorName を全文検索)
+- 担当・推し一覧: `GET /api/me/favorites?kind=<tantou|oshi>`
+- 担当・推し追加: `POST /api/me/favorites` (body: `{idolId, kind}`)
+- 担当・推し削除: `DELETE /api/me/favorites/{idolId}`
+
+詳細は `../api/{idols,me}.md` を参照。
+
+## 現状 (B0 段階、2026-05-17 時点)
+
+- 既存実装: `core/model/` 配下に `IdolColor` 等の旧データクラス (Phase C 前のもの)
+- `core/data/` 配下にも旧 Repository 実装あり (Firebase Firestore 経由のものを含む)
+- 本ファイルが記述するモデルは **C3 (`core/domain/` 新設) 時点の最終形**。Firebase 撤去 (C5) と feature-first 再編 (C3) で旧モデルを順次置換
+
+A2-5 (本 PR) では決定済の設計のみ記録、実装側との整合は EPIC-001 (C3) / EPIC-003 (C5) の Plan で順次取る。
 
 ## 関連
 
-- `docs/architecture/overview.md`
-- `docs/glossary.md` (用語定義)
-- `docs/codebase-map.md` (実装パス)
-- `core/data/` (将来の実装)
+- `overview.md` / `layers.md` / `data-flow.md`
+- `docs/glossary.md` (用語定義、A2-4 で本格化: アイドル / ブランド / 担当 / 推し / im@sparql / SPARQL prefix)
+- ADR 0007 (im@sparql upstream-driven 同期) / 0010 (アイドル情報マスタ repo 内 SQLite) / 0020 (PII 最小化)
+- `.claude/rules/{naming,sparql,design-tokens,pii}.md`
+- `../api/colormaster-api.yaml` (DTO 側の SoT)
+- `core/data/` / `core/model/` (将来の実装)

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -3,49 +3,161 @@ id: arch-infrastructure
 title: インフラ構成 (Cloud Run + Cloudflare Pages + R2 + GIS)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3.4 / §3.5
+related_plan: docs/harness/plan.md §3.4 / §3.5 / §3.8
 related_adrs:
   - ADR-0008
   - ADR-0009
   - ADR-0011
+  - ADR-0021
   - ADR-0022
 ---
 
 # インフラ構成
 
-> **5 行以内 summary**: ColorMaster の本番インフラはハイブリッド構成 — Backend は
-> Cloud Run (Google Cloud)、静的配信は Cloudflare Pages、Litestream バックアップ先は
-> Cloudflare R2、認証は GIS (Google Identity Services)。Terraform は不使用 (デプロイは
-> GitHub Actions + gcloud CLI + wrangler)。本格化は A2 + C7 デプロイ Plan。
+> **5 行以内 summary**: ColorMaster の本番インフラはハイブリッド構成 — Backend は GCP の
+> Cloud Run、静的配信は Cloudflare Pages、Litestream バックアップ先は Cloudflare R2、
+> 認証は GIS。Terraform は不採用、デプロイは GitHub Actions + `gcloud` CLI + `wrangler`
+> で管理。本格化は A2-5 で骨格 + C7 (リリース Plan) で詳細化。
 
 ## 構成要素
 
-| 要素 | 用途 | デプロイ手段 | 関連 ADR |
-|---|---|---|---|
-| **Cloud Run** | Ktor Backend のホスティング | GitHub Actions + gcloud CLI + Artifact Registry | ADR 0009 |
-| **Cloudflare Pages** | wasmJs 静的配信 | wrangler / Pages CLI | ADR 0022 |
-| **Cloudflare R2** | Litestream バックアップ先 (`users.db` の WAL) | wrangler / Cloudflare MCP | ADR 0008 / 0022 |
-| **GIS** (Google Identity Services) | 認証統一プロバイダ | GCP コンソール (Client ID 発行) | ADR 0011 |
-| **Secret Manager** | 本番 secrets (R2 token / GIS Client Secret) | gcloud CLI、Cloud Run service account から参照 | ADR 0021 |
-| **Artifact Registry** | Backend コンテナイメージ保管 | GitHub Actions + gcloud CLI | ADR 0009 |
+| 要素 | 用途 | プロバイダ | デプロイ手段 | 関連 ADR |
+|---|---|---|---|---|
+| **Cloud Run** | Ktor Backend のホスティング (Free tier 内運用) | Google Cloud | GitHub Actions + `gcloud run deploy` | ADR 0009 |
+| **Artifact Registry** | Backend コンテナイメージ保管 | Google Cloud | GitHub Actions + `docker push` | ADR 0009 |
+| **Google Cloud Secret Manager** | 本番 secrets (R2 token / GIS Client Secret 等) | Google Cloud | `gcloud secrets create`、Cloud Run service account から参照 | ADR 0021 |
+| **Cloudflare Pages** | wasmJs 静的バンドル配信 (unlimited bandwidth) | Cloudflare | `wrangler pages deploy` | ADR 0022 |
+| **Cloudflare R2** | Litestream バックアップ先 (S3 互換、egress 無料) | Cloudflare | `wrangler r2` または Cloudflare MCP | ADR 0008 / 0022 |
+| **GIS** (Google Identity Services) | 認証統一プロバイダ | Google | GCP コンソールで Client ID 発行 | ADR 0011 |
+| **GitHub Actions** | CI/CD ジョブ / im@sparql 同期 / トラフィック router | GitHub | repo `.github/workflows/` で管理 | ADR 0017 (Claude API は呼ばない) |
+| **GitHub Secrets** | CI 用 secrets (R2 token / GCP service account key 等) | GitHub | repo 設定で管理 | ADR 0021 |
 
-## 採用見送り
+## 構成図
 
-- **Cloudflare Containers**: Workers Paid plan $5/月必須でコスト劣後 (ADR 0009)
-- **Terraform**: 構成が小さく学習コスト・運用コストの方が大きい。GitHub Actions スクリプト + CLI で管理 (`docs/harness/plan.md` §3.5)
+```mermaid
+graph LR
+    subgraph Dev["開発者ローカル"]
+        Local["Claude Code\n+ gh CLI\n+ gcloud / wrangler"]
+    end
+
+    subgraph GH["GitHub"]
+        Repo["repo: colormaster"]
+        Actions["GitHub Actions\n(deploy / sync-imasparql)"]
+        Secrets["GitHub Secrets\n(R2 token, GCP SA key)"]
+    end
+
+    subgraph GCP["Google Cloud"]
+        AR["Artifact Registry\nbackend イメージ"]
+        CR["Cloud Run\nKtor server"]
+        SM["Secret Manager\nR2 token / GIS secret"]
+    end
+
+    subgraph CF["Cloudflare"]
+        Pages["Pages\nwasmJs バンドル"]
+        R2["R2 (private)\nusers.db WAL"]
+    end
+
+    subgraph Auth["Google Identity"]
+        GIS["GIS\nID Token 発行 + JWKS"]
+    end
+
+    Local --git push--> Repo
+    Repo --workflow--> Actions
+    Actions --read--> Secrets
+    Actions --docker push--> AR
+    Actions --gcloud run deploy--> CR
+    Actions --wrangler deploy--> Pages
+    AR --pull--> CR
+    CR --read at runtime--> SM
+    CR --WAL replicate--> R2
+    R2 --restore at startup--> CR
+    CR --JWKS verify--> GIS
+    Pages -.serve to client.- ClientUser([ユーザーブラウザ])
+    CR -.HTTPS /api/*.- ClientUser
+    GIS -.ID Token.- ClientUser
+```
 
 ## デプロイフロー (C7 で本格化)
 
-1. master push → GitHub Actions が `./gradlew check` を実行
-2. Backend イメージビルド → Artifact Registry へ push
-3. `gcloud run deploy` で Cloud Run 更新
-4. wasmJs ビルド → Cloudflare Pages へ wrangler 経由でデプロイ
-5. デプロイ完了通知
+### 通常リリース (master push)
+
+1. `master` に push → GitHub Actions `release.yml` が発火
+2. `./gradlew check` を全 module で実行 (Konsist / Roborazzi / kotlin-test、ADR 0023)
+3. Backend Docker イメージビルド (`./gradlew :backend:server:dockerBuild`)
+4. `docker push` で Artifact Registry に push (`asia-northeast1-docker.pkg.dev/<project>/backend/server:<sha>`)
+5. `gcloud run deploy` で Cloud Run service を更新 (revision 切替、トラフィック 100% 即時)
+6. wasmJs バンドルビルド (`./gradlew :wasmJsBrowserDistribution`)
+7. `wrangler pages deploy` で Cloudflare Pages にアップロード (preview → production への昇格は人間 approve)
+8. デプロイ完了通知 (Slack / 簡易 Webhook、C7 で整備)
+
+### im@sparql 同期 (日次 cron)
+
+1. GitHub Actions `sync-imasparql.yml` が cron で発火
+2. upstream SHA を取得して比較 (`data-flow.md` 参照)
+3. 差分時は `chore/sync-imasparql-<sha>` ブランチで PR 起票
+4. 人間または AI レビューで内容確認 (auto-merge 禁止、R-15)
+5. master merge → 通常リリースフローに follow-through
+
+### 緊急ロールバック
+
+- Cloud Run の `gcloud run services update-traffic --to-revisions <prev>=100` で前 revision に即時切替
+- Cloudflare Pages の `wrangler pages rollback` (将来サポート時) または前 deploy の URL から再 promote
+- `users.db` 自体のロールバックは Litestream の point-in-time restore で対応 (R2 の WAL 履歴から指定時刻に復元、`docs/runbooks/r2-litestream.md` で手順整備、C5)
+
+## Secret Manager の経路
+
+```mermaid
+sequenceDiagram
+    participant Actions as GitHub Actions
+    participant SM as Secret Manager
+    participant CR as Cloud Run
+    participant R2 as Cloudflare R2
+
+    Note over Actions,R2: 初期セットアップ (手動 / 90 日ごと)
+    Actions->>SM: gcloud secrets create r2-token --data-file=...
+    Note over Actions: GitHub Secrets には CI 用 GCP SA key のみ保存
+
+    Note over CR,R2: ランタイム (Backend 起動時)
+    CR->>SM: SecretManagerClient.access("r2-token")
+    SM-->>CR: token (in-memory only)
+    CR->>R2: PUT WAL (Litestream)
+    R2-->>CR: 200 OK
+```
+
+- Cloud Run service account が `roles/secretmanager.secretAccessor` を持つ
+- secret 値はコンテナの環境変数 / ファイルに **書き出さない** (memory only)
+- TTL 90 日でローテーション (`docs/runbooks/secrets-rotation.md`)
+- 漏洩疑い時は即時 `gcloud secrets versions destroy` + 新 version 作成 (ADR 0021)
+
+## 採用見送りの代替案
+
+| 候補 | 採用見送り理由 |
+|---|---|
+| **Cloudflare Containers** | Workers Paid plan $5/月必須で完全無料運用が不可、Cloud Run の Free tier に劣後 (ADR 0009) |
+| **Koyeb** (Backend) | Free tier の制約が Cloud Run より厳しい (ADR 0009 で代替候補として記録) |
+| **Fly.io** | 2024 年に無料枠廃止 |
+| **Render / Railway** | sleep / 実質有料 |
+| **Firebase Hosting** | 10GB bandwidth 上限、Firebase 全廃方針と整合しない |
+| **Vercel** (Hobby) | 商用利用不可 |
+| **Terraform / Pulumi** | 管理対象が小さく、学習・保守コストが旨味を上回る (`docs/harness/plan.md` §3.5) |
+
+## モニタリング (C7 で本格化)
+
+| 観点 | ツール | 備考 |
+|---|---|---|
+| Cloud Run リクエスト数 / レイテンシ | Cloud Run 標準ダッシュボード | Free tier 圧迫検知も |
+| Cloud Run 5xx エラー率 | Cloud Logging + alerting policy | 簡易、有償 oncall は未導入 |
+| Litestream 健全性 | Backend `/health` endpoint で WAL lag を含める | C5 で実装 |
+| Cloudflare Pages リクエスト数 | Cloudflare ダッシュボード | 無料枠内なら通知不要 |
+| R2 ストレージ使用量 | Cloudflare ダッシュボード | 月次レビュー |
+| GIS JWKS 取得失敗 | Cloud Logging | structured log で `event=jwks_fetch_fail` を発火 (`logging.md` 規約、A2-2 で本格化) |
+
+詳細は `docs/runbooks/release.md` / `docs/runbooks/monitoring.md` (将来作成、C7) を参照。
 
 ## 関連
 
-- `docs/harness/plan.md` §3.4 / §3.5
-- ADR 0008 / 0009 / 0011 / 0022
-- `docs/runbooks/release.md` (C7 で本格化)
-- `docs/runbooks/secrets-rotation.md`
-- `docs/runbooks/r2-litestream.md`
+- `overview.md` / `data-flow.md` / `sequences.md`
+- ADR 0008 (Backend SQLite + Litestream + R2) / 0009 (Cloud Run) / 0011 (GIS 統一) / 0021 (Secrets 管理) / 0022 (Cloudflare Pages + R2)
+- `docs/runbooks/{release,secrets-rotation,r2-litestream}.md` (C5-C7 で本格化)
+- `.claude/rules/{cloud-run-deploy,r2-litestream,cloudflare-pages,secrets,backend-auth}.md`
+- `docs/harness/plan.md` §3.4 (ホスティング) / §3.5 (Terraform 不採用) / §3.8 (PII / Secrets)

--- a/docs/architecture/layers.md
+++ b/docs/architecture/layers.md
@@ -3,42 +3,129 @@ id: arch-layers
 title: 層別責務
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3
+related_plan: docs/harness/plan.md §3.1 / §3.6
 related_adrs:
   - ADR-0002
   - ADR-0003
+  - ADR-0005
+  - ADR-0011
+  - ADR-0012
 ---
 
 # 層別責務
 
-> **5 行以内 summary**: ColorMaster の層構造 (feature → core/domain → core/data → core/network)
-> と各層の責務、越境ルール、依存方向を記述する。Phase C で feature-first モジュール再編
-> (EPIC-001) が完了した時点で本ファイルが本格的に意味を持つ。本格化は A2 + C3。
+> **5 行以内 summary**: ColorMaster の層構造 (`feature/<画面>` → `core/domain` → `core/data` →
+> `core/network` → `backend/server`) と各層の責務、依存方向、越境ルール、撤去予定の
+> 旧モジュールを記述する。EPIC-001 (C3) で feature-first 再編が完了した時点で本ファイルが
+> 完全実装と整合する。本格化は A2-5 + C3 (実装着手に応じて追記)。
 
-## 層 (A2 + C3 で本格化)
+## 層の責務マトリクス
 
-| 層 | 責務 | 依存可能な層 | 関連 rules |
-|---|---|---|---|
-| `feature/<画面>` | 画面固有の ViewModel / Composable / UiState / Route | core/domain, core/data | viewmodel.md, composable.md, navigation.md, ui-state.md |
-| `core/domain` | ドメインモデル / ユースケース | core/data, core/network | repository.md (interface) |
-| `core/data` | Repository 実装 / DB 抽象化 | core/network, core/database | repository.md (impl), error-handling.md |
-| `core/network` | Ktor Client / API DTO | (なし) | network-client.md, error-handling.md |
-| `backend` | Ktor Server / `/api/me/*` / 認証検証 | im@sparql, GIS, R2 | backend-auth.md |
+| 層 | パス | 主責務 | 出力 | 依存可能な層 | 関連 rule |
+|---|---|---|---|---|---|
+| **feature/<画面>** | `feature/<name>/` (C3 移行後) | 画面固有の `ViewModel` / `UiState` / `UiAction` / `Screen` Composable / `Route` / `di` | UiState / UiAction / Screen | core/domain, core/data, core/model | `viewmodel.md` / `composable.md` / `navigation.md` / `ui-state.md` |
+| **core/domain** | `core/domain/` (C3 で新設) | ドメインモデル / UseCase / Repository インタフェース | UseCase 関数 / Repository interface | core/model | `repository.md` (interface 部) |
+| **core/data** | `core/data/` | Repository 実装 / DB 抽象化 / マッパー | Repository impl / 永続層 | core/network, core/database | `repository.md` (impl) / `error-handling.md` |
+| **core/network** | `core/network/{imasparql, colormaster-api}/` | Ktor Client / API DTO / シリアライゼーション | HTTP request / DTO | (外部のみ) | `network-client.md` / `error-handling.md` |
+| **core/model** | `core/model/` | 全層共有の値オブジェクト / sealed class | データクラス | (なし、葉) | `naming.md` |
+| **core/common** | `core/common/` | ロガー / coroutine helper / Result wrapper | utility 関数 | (なし、葉) | `error-handling.md` / `logging.md` |
+| **backend/server** | `backend/server/` | Ktor Server / `/api/*` ハンドラ / JWKS 検証 / SQLite アクセス | HTTP response | (外部: GIS, R2, idols.db, users.db) | `backend-auth.md` |
+| **backend/cli** | `backend/cli/` | im@sparql からのアイドル情報取得 / `data/idols.db` 生成 | SQLite ファイル | (外部: imas/imasparql) | `sync-job.md` / `sparql.md` |
+
+## 依存方向 (上 → 下、逆向き禁止)
+
+```mermaid
+graph LR
+    Feature["feature/<画面>"]
+    Domain["core/domain"]
+    Data["core/data"]
+    Network["core/network"]
+    Model["core/model"]
+    Common["core/common"]
+    Backend["backend/server"]
+    External["外部 (GIS / R2 / idols.db / users.db / im@sparql)"]
+
+    Feature --> Domain
+    Feature --> Model
+    Domain --> Data
+    Domain --> Model
+    Data --> Network
+    Data --> Common
+    Network --> Model
+    Network -.HTTP.-> Backend
+    Backend --> External
+```
+
+- 実線は **コンパイル時依存**、点線はランタイムの HTTP 通信
+- `core/network` から `core/data` への逆参照は **禁止** (Konsist で機械検証、A2-2 で導入)
+- `feature/*` から `core/network` への直接参照も **禁止** (必ず Repository / UseCase 経由)
+- `core/model` / `core/common` は葉、他層への依存ゼロ (循環参照防止)
 
 ## 越境ルール
 
-- **上から下への一方向依存**: feature → core/domain → core/data → core/network。逆向き禁止
-- **`core/network/` から DB 直接アクセス禁止**: 必ず Repository 経由
-- **`feature/` から `core/network/` 直接参照禁止**: 必ず Repository / UseCase 経由
-- **A2 で Konsist 規約として機械化**
+1. **`feature/*` → `core/network/*` 直接参照禁止**
+   - 必ず Repository (`core/data`) または UseCase (`core/domain`) 経由
+   - 理由: ネットワーク失敗時のリトライ / キャッシュ / モック差し替えを Repository に集約
+2. **`core/network/*` から DB 直接アクセス禁止**
+   - DTO ⇄ ドメインモデルのマッピングは `core/data/Mapper*.kt` で行う
+   - 理由: API レスポンスとドメインモデルの分離 (Single Source は backend、クライアント側はビュー寄り)
+3. **`feature/*` 間の直接依存禁止**
+   - 共有ロジックは `core/domain` または `core/common` に昇格
+   - 画面間遷移は Navigation 3 の `Route.kt` で表現
+4. **`core/domain` から `core/network` 直接依存禁止**
+   - Repository interface は `core/domain` で宣言、impl は `core/data` で `core/network` を使う
+   - 理由: ドメイン層を純粋に保ち、テストでネットワーク不要にする
+5. **`backend/server` の各 API ハンドラは `requireUid()` 呼出必須** (`/api/me/*` のみ)
+   - Konsist で機械検証 (A2-2 + A6 で導入、`.claude/rules/backend-auth.md`)
+6. **Composable から ViewModel 以外の Stateful オブジェクトを参照しない**
+   - 画面状態は `StateFlow<UiState>` 経由のみ
+   - `.claude/rules/{composable,ui-state}.md` 参照
 
-## 撤去予定の層
+## 機械検証 (Konsist、A2-2 + A6 で導入)
 
-- `core/network/auth/` (Firebase Auth 連携) → C5 で撤去、GIS に統一
-- `core/network/firestore/` (Firestore 連携) → C5 で撤去、Backend SQLite に統一
+| 規約 | 検証手段 |
+|---|---|
+| feature → core/network 直接参照禁止 | Konsist `KoFileExtension.imports` で `core.network.*` を `feature.*` から検出 |
+| feature 間の直接依存禁止 | Konsist で `feature.A.*` が `feature.B.*` を import していないことを検証 |
+| `/api/me/*` ハンドラの `requireUid()` 必須 | Konsist で `backend.server.routing.me.*` の関数本体に `requireUid()` 呼出を要求 |
+| `core/model` / `core/common` の葉性 | Konsist で他 `core.*` への依存ゼロを検証 |
+| ViewModel から Composable の Context 系参照禁止 | Konsist で `androidx.compose.ui.*` の参照を ViewModel から検出 |
+
+`docs/architecture/overview.md` の通り、機械検証の導入は A2-2 (rules 本格化) + A6 (Konsist 設定本格化)。本ファイルでは規約を明示するのみ。
+
+## 撤去予定モジュール (Phase C)
+
+| 撤去対象 | 撤去理由 | 撤去時期 | 関連 ADR |
+|---|---|---|---|
+| `core/network/auth/` | Firebase Auth 撤去 (GIS に統一) | C5 | ADR 0011 |
+| `core/network/firestore/` | Firestore 撤去 (Backend SQLite に統一) | C5 | ADR 0008 / 0011 |
+| `js/app/` / `js/material/` | wasmJs 移行のため | C9 | ADR 0012 |
+| `kotlin-js-store/` | wasmJs 移行時に再生成 | C9 | ADR 0012 |
+| `firebase.json` / `.firebaserc` | Cloudflare Pages 移行 | C7 | ADR 0022 |
+| `core/features/*` | `feature/*` への再編 (feature-first) | C3 | ADR 0003 |
+
+詳細な撤去手順は `.claude/rules/removed-modules.md` (A2-2 で本格化) + 各 Phase の Plan / Epic を参照。
+
+## 新設モジュール (Phase C)
+
+| 新設対象 | 用途 | 新設時期 | 関連 ADR |
+|---|---|---|---|
+| `core/domain/` | UseCase + Repository interface 集約 | C3 | ADR 0002 / 0003 |
+| `core/network/colormaster-api/` | Backend `/api/*` 専用クライアント (旧 `core/network/auth` `core/network/firestore` を統合) | C5 | ADR 0011 |
+| `feature/<画面>/` (各画面) | `core/features/*` から移行 | C3 | ADR 0003 |
+| `backend/server/` 内 `/api/me/*` 系ハンドラ | ユーザーデータ API 本実装 | C5 | ADR 0008 / 0011 |
+
+## 現状の差分 (B0 段階、2026-05-17 時点)
+
+- 現存: `core/{common, model, data, test}` / `core/network/{firestore, auth, imasparql}` / `core/features/{home, search, myidols, preview}` / `android/` / `backend/{server, cli}`
+- 不在: `feature/*` ディレクトリ (C3 で新設) / `core/domain/` (C3 で新設) / `core/network/colormaster-api/` (C5 で新設)
+- Firebase 系依存 (`dev.gitlive:firebase-*`) は **現存**、C5 で削除
+
+本ファイルが記述する層構造は **Phase C 完了後の最終形**。EPIC-A2 の docs 本格化フェーズでは未来の構造を Single Source として明文化し、Phase C 実装で本ファイルを差分更新する想定。
 
 ## 関連
 
-- `docs/architecture/overview.md`
-- ADR 0002 / 0003 / 0011
-- `.claude/rules/{viewmodel,composable,navigation,repository,network-client}.md`
+- `overview.md` (アーキ全体俯瞰)
+- ADR 0002 (Compose Multiplatform + 共通 ViewModel + Navigation 3) / 0003 (feature-first) / 0005 (Decompose 撤去) / 0011 (GIS 統一) / 0012 (js/app 撤去)
+- `.claude/rules/{viewmodel,composable,navigation,repository,network-client,backend-auth,removed-modules,naming}.md`
+- `docs/codebase-map.md` (主要パス → 責務、A2-4 で本格化)

--- a/docs/architecture/layers.md
+++ b/docs/architecture/layers.md
@@ -23,16 +23,16 @@ related_adrs:
 
 | 層 | パス | 主責務 | 出力 | 依存可能な層 | 関連 rule |
 |---|---|---|---|---|---|
-| **feature/<画面>** | `feature/<name>/` (C3 移行後) | 画面固有の `ViewModel` / `UiState` / `UiAction` / `Screen` Composable / `Route` / `di` | UiState / UiAction / Screen | core/domain, core/data, core/model | `viewmodel.md` / `composable.md` / `navigation.md` / `ui-state.md` |
+| **feature/<画面>** | `feature/<name>/` (C3 移行後) | 画面固有の `ViewModel` / `UiState` / `UiAction` / `Screen` Composable / `Route` / `di` | UiState / UiAction / Screen | core/domain, core/model | `viewmodel.md` / `composable.md` / `navigation.md` / `ui-state.md` |
 | **core/domain** | `core/domain/` (C3 で新設) | ドメインモデル / UseCase / Repository インタフェース | UseCase 関数 / Repository interface | core/model | `repository.md` (interface 部) |
-| **core/data** | `core/data/` | Repository 実装 / DB 抽象化 / マッパー | Repository impl / 永続層 | core/network, core/database | `repository.md` (impl) / `error-handling.md` |
-| **core/network** | `core/network/{imasparql, colormaster-api}/` | Ktor Client / API DTO / シリアライゼーション | HTTP request / DTO | (外部のみ) | `network-client.md` / `error-handling.md` |
+| **core/data** | `core/data/` | Repository 実装 (core/domain の interface を実装) / DB 抽象化 / マッパー | Repository impl / 永続層 | core/domain, core/network, core/common, core/model | `repository.md` (impl) / `error-handling.md` |
+| **core/network** | `core/network/{imasparql, colormaster-api}/` | Ktor Client / API DTO / シリアライゼーション | HTTP request / DTO | core/model | `network-client.md` / `error-handling.md` |
 | **core/model** | `core/model/` | 全層共有の値オブジェクト / sealed class | データクラス | (なし、葉) | `naming.md` |
 | **core/common** | `core/common/` | ロガー / coroutine helper / Result wrapper | utility 関数 | (なし、葉) | `error-handling.md` / `logging.md` |
 | **backend/server** | `backend/server/` | Ktor Server / `/api/*` ハンドラ / JWKS 検証 / SQLite アクセス | HTTP response | (外部: GIS, R2, idols.db, users.db) | `backend-auth.md` |
 | **backend/cli** | `backend/cli/` | im@sparql からのアイドル情報取得 / `data/idols.db` 生成 | SQLite ファイル | (外部: imas/imasparql) | `sync-job.md` / `sparql.md` |
 
-## 依存方向 (上 → 下、逆向き禁止)
+## 依存方向 (DIP 適用、逆向き禁止)
 
 ```mermaid
 graph LR
@@ -47,33 +47,35 @@ graph LR
 
     Feature --> Domain
     Feature --> Model
-    Domain --> Data
-    Domain --> Model
+    Data --> Domain
     Data --> Network
     Data --> Common
+    Data --> Model
+    Domain --> Model
     Network --> Model
     Network -.HTTP.-> Backend
     Backend --> External
 ```
 
 - 実線は **コンパイル時依存**、点線はランタイムの HTTP 通信
-- `core/network` から `core/data` への逆参照は **禁止** (Konsist で機械検証、A2-2 で導入)
-- `feature/*` から `core/network` への直接参照も **禁止** (必ず Repository / UseCase 経由)
+- **DIP (依存性逆転)**: Repository interface は `core/domain` で宣言、impl は `core/data` が `core/domain` に依存 (impl が interface に依存)。Koin DI で `feature` に impl を注入する (`feature` の compile-time 依存は `core/domain` のみ)
+- `core/network` から `core/data` / `core/domain` への参照は **禁止** (Konsist で機械検証、A2-2 で導入)
+- `feature/*` から `core/network` / `core/data` への直接参照は **禁止** (必ず `core/domain` の Repository interface 経由 + DI 注入)
 - `core/model` / `core/common` は葉、他層への依存ゼロ (循環参照防止)
 
 ## 越境ルール
 
-1. **`feature/*` → `core/network/*` 直接参照禁止**
-   - 必ず Repository (`core/data`) または UseCase (`core/domain`) 経由
-   - 理由: ネットワーク失敗時のリトライ / キャッシュ / モック差し替えを Repository に集約
+1. **`feature/*` → `core/network/*` および `core/data/*` 直接参照禁止**
+   - 必ず `core/domain` の Repository interface または UseCase 経由 (impl は DI で注入)
+   - 理由: ネットワーク失敗時のリトライ / キャッシュ / モック差し替えを Repository に集約し、feature 層を interface のみに依存させる (DIP)
 2. **`core/network/*` から DB 直接アクセス禁止**
    - DTO ⇄ ドメインモデルのマッピングは `core/data/Mapper*.kt` で行う
    - 理由: API レスポンスとドメインモデルの分離 (Single Source は backend、クライアント側はビュー寄り)
 3. **`feature/*` 間の直接依存禁止**
    - 共有ロジックは `core/domain` または `core/common` に昇格
    - 画面間遷移は Navigation 3 の `Route.kt` で表現
-4. **`core/domain` から `core/network` 直接依存禁止**
-   - Repository interface は `core/domain` で宣言、impl は `core/data` で `core/network` を使う
+4. **`core/domain` から `core/network` / `core/data` 直接依存禁止**
+   - Repository interface は `core/domain` で宣言、impl は `core/data` で `core/network` を使う (DIP: 実装が抽象に依存、抽象は実装を知らない)
    - 理由: ドメイン層を純粋に保ち、テストでネットワーク不要にする
 5. **`backend/server` の各 API ハンドラは `requireUid()` 呼出必須** (`/api/me/*` のみ)
    - Konsist で機械検証 (A2-2 + A6 で導入、`.claude/rules/backend-auth.md`)
@@ -85,7 +87,8 @@ graph LR
 
 | 規約 | 検証手段 |
 |---|---|
-| feature → core/network 直接参照禁止 | Konsist `KoFileExtension.imports` で `core.network.*` を `feature.*` から検出 |
+| feature → core/network / core/data 直接参照禁止 | Konsist `KoFileExtension.imports` で `core.network.*` / `core.data.*` を `feature.*` から検出 |
+| core/domain → core/data / core/network 直接参照禁止 (DIP) | Konsist で `core.domain.*` の import に `core.data.*` / `core.network.*` を含まないことを検証 |
 | feature 間の直接依存禁止 | Konsist で `feature.A.*` が `feature.B.*` を import していないことを検証 |
 | `/api/me/*` ハンドラの `requireUid()` 必須 | Konsist で `backend.server.routing.me.*` の関数本体に `requireUid()` 呼出を要求 |
 | `core/model` / `core/common` の葉性 | Konsist で他 `core.*` への依存ゼロを検証 |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -85,16 +85,24 @@ graph TD
     Wasm --> Feature
     Desktop --> Feature
     Feature --> CDomain
-    CDomain --> CData
+    Feature --> CModel
+    CData --> CDomain
     CData --> CNetwork
-    CNetwork --> BServer
+    CData --> CCommon
+    CData --> CModel
+    CDomain --> CModel
+    CNetwork --> CModel
+    CNetwork -.HTTP.-> BServer
     BServer --> GIS
     BServer --> R2
     BCli --> IMSparql
     Wasm -.静的配信.-> CFPages
 ```
 
-> 凡例: 実線 = 依存方向 (上から下)、点線 = ホスティング配信。`feature/*` は EPIC-001 (C3) で `core/features/*` から移行予定 (現状は `core/features/*` に残存)。
+> 凡例: 実線 = コンパイル時依存、点線 = ランタイム通信 / 配信。**DIP**: Repository
+> interface は `core/domain` で宣言、impl は `core/data` が `core/domain` に依存
+> (`CData --> CDomain`)。`feature/*` は EPIC-001 (C3) で `core/features/*` から移行予定。
+> 詳細な層間越境ルールは `layers.md` を参照。
 
 ## target / platform マトリクス
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,60 +3,156 @@ id: arch-overview
 title: アーキテクチャ概要
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3
+related_plan: docs/harness/plan.md §3.1 / §3.4
 related_adrs:
   - ADR-0002
   - ADR-0003
+  - ADR-0005
+  - ADR-0008
+  - ADR-0009
+  - ADR-0011
+  - ADR-0022
 ---
 
 # アーキテクチャ概要
 
 > **5 行以内 summary**: ColorMaster は Compose Multiplatform + 共通 ViewModel +
-> Navigation 3 を採用した KMP プロジェクト。Android / iOS / wasmJs / JVM の 4 ターゲット
-> を持ち、Backend は Ktor を Cloud Run にデプロイする。詳細は他 6 ファイル
-> (layers / data-flow / domain-model / state-machines / sequences / infrastructure) を参照。
+> Navigation 3 を採用した KMP プロジェクトで、Android / iOS / wasmJs / JVM (Desktop)
+> の 4 target と Cloud Run 上の Ktor Backend をハイブリッドホスティングで運用する。
+> 本ファイルは全体俯瞰と各サブ docs (`layers` / `data-flow` / `domain-model` /
+> `state-machines` / `sequences` / `infrastructure`) への索引を担う。
 
-## 構成 (A2 で本格化)
+## 採用スタック (Single Source: `docs/harness/plan.md` §3.1)
 
-A2 で各ファイル (`layers.md` / `data-flow.md` / `domain-model.md` / `state-machines.md` / `sequences.md` / `infrastructure.md`) を本格化する。本ファイルは索引と全体像のみ。
+| 領域 | 採用 | 関連 ADR |
+|---|---|---|
+| アーキテクチャパターン | Compose Multiplatform + 共通 ViewModel + Navigation 3 | ADR 0002 |
+| モジュール構造 | feature-first (`feature/<name>/{ViewModel, UiState, UiAction, Screen, di}.kt`) | ADR 0003 |
+| 状態管理 | `StateFlow<UiState>` + `onAction(UiAction)` + `Channel<UiEffect>` の軽量 UDF | ADR 0002 |
+| Navigation | Navigation 3 (Compose Multiplatform 1.10+ で全 target サポート) | ADR 0002 / 0005 |
+| DI | Koin 4.0.4 | — |
+| i18n | compose-multiplatform-resources (`composeResources/values-<locale>/strings.xml`) | ADR 0006 |
+| Backend | Ktor (Kotlin/JVM) | ADR 0009 |
+| 認証 | Google Identity Services (GIS) 全 target 統一、Firebase Auth 撤去 | ADR 0011 |
+| データ永続化 (Backend) | Cloud Run 内蔵 SQLite (`users.db`) + Litestream → R2 | ADR 0008 |
+| アイドル情報マスタ | `data/idols.db` (リポジトリ commit、コンテナ焼込、read-only) | ADR 0010 |
+| 静的配信 | Cloudflare Pages (wasmJs) | ADR 0022 |
+| バックアップ先 | Cloudflare R2 (private、egress 無料) | ADR 0022 |
 
-### モジュール俯瞰 (TODO: A2 で Mermaid 図化)
+撤去スタック: Decompose (ADR 0005)、Firebase 全廃 (ADR 0011)、`js/app` (ADR 0012)。
 
+## モジュール俯瞰
+
+```mermaid
+graph TD
+    subgraph Client["クライアント (KMP 4 target)"]
+        Android["android (Android App entry)"]
+        iOS["iosApp (iOS entry、C8 で本格化)"]
+        Wasm["wasmJs entry (C9 で本格化)"]
+        Desktop["JVM Desktop (テスト / Roborazzi 主実行)"]
+    end
+
+    subgraph Feature["feature/* (C3 で再編、現状は core/features/*)"]
+        FHome["feature/home"]
+        FSearch["feature/search"]
+        FMyIdols["feature/myidols"]
+        FPreview["feature/preview"]
+    end
+
+    subgraph Core["core/*"]
+        CCommon["core/common"]
+        CModel["core/model"]
+        CDomain["core/domain (C3 で新設)"]
+        CData["core/data"]
+        CNetwork["core/network/{imasparql, colormaster-api}"]
+        CTest["core/test"]
+    end
+
+    subgraph Backend["backend/ (Ktor on Cloud Run)"]
+        BServer["backend/server"]
+        BCli["backend/cli (im@sparql 取得)"]
+    end
+
+    subgraph External["外部依存"]
+        GIS["GIS (Google Identity Services)"]
+        IMSparql["imas/imasparql (RDF)"]
+        R2["Cloudflare R2"]
+        CFPages["Cloudflare Pages"]
+    end
+
+    Android --> Feature
+    iOS --> Feature
+    Wasm --> Feature
+    Desktop --> Feature
+    Feature --> CDomain
+    CDomain --> CData
+    CData --> CNetwork
+    CNetwork --> BServer
+    BServer --> GIS
+    BServer --> R2
+    BCli --> IMSparql
+    Wasm -.静的配信.-> CFPages
 ```
-android (Android App)
-  ↓
-feature/* (画面別モジュール、C3 で新設)
-  ↓
-core/data, core/domain, core/network
-  ↓
-backend (Ktor on Cloud Run)
-  ↓
-im@sparql (外部) / GIS (Google Identity Services) / R2 (Litestream)
-```
 
-### Backend と外部依存
+> 凡例: 実線 = 依存方向 (上から下)、点線 = ホスティング配信。`feature/*` は EPIC-001 (C3) で `core/features/*` から移行予定 (現状は `core/features/*` に残存)。
 
-- **Backend** (`backend/`): Ktor、Cloud Run デプロイ、内蔵 SQLite + Litestream (`users.db`) / アイドル情報 SQLite (`idols.db`、コンテナイメージ焼込)
-- **GIS**: 認証統一 (Firebase Auth から移行、ADR 0011)
-- **im@sparql**: アイドル情報の上流ソース、upstream-driven sync (ADR 0007)
-- **R2**: Litestream バックアップ先 (ADR 0022)
-- **Cloudflare Pages**: 静的配信 (wasmJs 完成後、ADR 0022)
+## target / platform マトリクス
 
-## 詳細 (他ファイル)
+| target | source set | UI | 認証 | 配信 | 主用途 |
+|---|---|---|---|---|---|
+| Android | `androidMain` | Compose | GIS Android SDK | Google Play (将来) | モバイル本番 |
+| iOS | `iosMain` | Compose for iOS (1.8 Stable) | GIS iOS SDK | App Store (将来、C8) | モバイル本番 |
+| wasmJs | `wasmJsMain` | Compose for Web | GIS JavaScript Library | Cloudflare Pages | Web 本番 |
+| JVM Desktop | `jvmMain` | Compose Desktop | (テスト用のみ) | (配布なし) | Roborazzi screenshot 実行ランタイム |
 
-| ファイル | 内容 |
-|---|---|
-| `layers.md` | 層別責務 (feature → core → repository → network) |
-| `data-flow.md` | データフロー (im@sparql → backend → client) |
-| `domain-model.md` | ドメインモデル (アイドル / ブランド / カラー) |
-| `state-machines.md` | UiState 状態遷移 |
-| `sequences.md` | 主要ユースケースのシーケンス |
-| `infrastructure.md` | ホスティング / IaC 構成 (Cloud Run + Cloudflare Pages + R2 + GIS) |
+- `commonMain` に **全 target 共有のロジック・UiState・Composable** を配置 (Compose Multiplatform 統一)
+- `wasmJsMain` の actual 実装は GIS フロー等の薄い層に限定 (Roborazzi 未対応のため Konsist + 単体テストで担保、ADR 0023)
+- iOS は C8 で本格起動、wasmJs は C9 で本格化 (`docs/harness/plan.md` §6.3 / EPIC-A2 では touch しない)
+
+## 外部依存とその役割
+
+| 依存 | 役割 | ADR | 関連 docs |
+|---|---|---|---|
+| imas/imasparql | アイドル情報の上流マスタ (RDF / SPARQL) | ADR 0007 | `data-flow.md` |
+| GIS (Google Identity Services) | 認証統一プロバイダ、ID Token 発行 | ADR 0011 | `../api/auth.md` |
+| Cloud Run | Ktor Backend のホスティング (Free tier) | ADR 0009 | `infrastructure.md` |
+| Cloudflare Pages | wasmJs バンドル静的配信 (unlimited bandwidth) | ADR 0022 | `infrastructure.md` |
+| Cloudflare R2 | Litestream バックアップ先 (S3 互換 / egress 無料) | ADR 0008 / 0022 | `data-flow.md` / `infrastructure.md` |
+| Google Cloud Secret Manager | 本番 secrets (R2 token / GIS Client Secret) | ADR 0021 | `infrastructure.md` |
+| Artifact Registry | Backend コンテナイメージ保管 | ADR 0009 | `infrastructure.md` |
+
+## アーキテクチャ上の重要な前提
+
+- **クライアント / Backend 間の通信は全て `/api/*` 経由** (GIS ID Token Bearer 認証、`docs/api/colormaster-api.yaml` が SoT)
+- **`core/network/` から DB 直接アクセス禁止**、必ず Repository 経由 (`layers.md` 越境ルール)
+- **クライアントは GIS 経由で ID Token を取得**、Backend で JWKS 検証して `uid` 抽出 (`auth.md`)
+- **アイドル情報はクライアント側でキャッシュ可** (read-only)、ユーザーデータはキャッシュせず常に Backend 取得
+- **Cloud Run の ephemeral 性は Litestream で吸収** (起動時 R2 から restore、ADR 0008)
+
+## 構成要素別 docs 索引 (lazy-load)
+
+| ファイル | 内容 | 主読者 |
+|---|---|---|
+| `layers.md` | 層別責務 (feature → core/domain → core/data → core/network → backend) と依存方向、撤去予定モジュール | Kotlin 実装担当 AI / 人間レビュアー |
+| `data-flow.md` | im@sparql → idols.db → Backend → Client のデータフロー、Litestream replicate/restore | Backend 実装担当 |
+| `domain-model.md` | ドメインモデル (Idol / Brand / ColorPalette / FavoriteIdol) の概観 | feature/* 実装担当 |
+| `state-machines.md` | UiState 状態遷移の共通語彙と画面別 TODO | UI 実装担当 |
+| `sequences.md` | 主要 4 ユースケース (ログイン / 検索 / 担当追加 / 同期) のシーケンス図 | エンドツーエンド設計レビュー |
+| `infrastructure.md` | Cloud Run + Cloudflare Pages + R2 + GIS の構成図とデプロイフロー | DevOps / Cloud Run 設定担当 |
+| `../api/README.md` | API 全体規約 (バージョニング / 認証 / エラー / Cache-Control) | Backend / クライアント連携担当 |
+| `../api/colormaster-api.yaml` | OpenAPI 3.1 (全リクエスト/レスポンス JSON スキーマの SoT) | 機械検証 / コード生成 |
+
+## 本ファイルの本格化スコープ (現状: skeleton)
+
+- **現状**: ADR 0001-0027 + plan.md §3 で決定済の設計を概観として記録。Mermaid 図はモジュール俯瞰のみで、層別の詳細は `layers.md` 等へ委譲
+- **A2-5 (本 PR) で追加**: モジュール俯瞰 Mermaid、採用スタック表、target マトリクス、外部依存表、各 docs への索引
+- **Phase C で更新**: 実装着手に伴い、`core/features/*` → `feature/*` への移行完了 / Firebase 撤去完了等の状態変化を反映。本ファイルは概観として `status: living` に昇格
 
 ## 関連
 
-- `docs/harness/plan.md` §3 (設計指針)
-- ADR 0002 (Compose Multiplatform + 共通 ViewModel + Navigation 3)
-- ADR 0003 (モジュール構造 feature-first)
-- ADR 0009 / 0011 / 0022 (Backend / 認証 / 静的配信)
-- `docs/codebase-map.md`
+- `docs/harness/plan.md` §3.1 (アプリケーション設計) / §3.4 (ホスティング) / §3.6 (撤去対象)
+- ADR 0002 (Compose Multiplatform + 共通 ViewModel + Navigation 3) / 0003 (feature-first) / 0005 (Decompose 撤去)
+- ADR 0008 (Backend SQLite + Litestream + R2) / 0009 (Cloud Run) / 0011 (GIS 統一) / 0022 (Cloudflare Pages + R2)
+- `docs/codebase-map.md` (主要パス → 責務、A2-4 で本格化)
+- `docs/glossary.md` (ドメイン用語、A2-4 で本格化)
+- `.claude/rules/{viewmodel,composable,navigation,ui-state,repository,network-client,backend-auth}.md`

--- a/docs/architecture/sequences.md
+++ b/docs/architecture/sequences.md
@@ -3,34 +3,215 @@ id: arch-sequences
 title: 主要ユースケースのシーケンス
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3
+related_plan: docs/harness/plan.md §3.2 / §3.3 / §3.4
+related_adrs:
+  - ADR-0007
+  - ADR-0008
+  - ADR-0011
+  - ADR-0014
 ---
 
 # 主要ユースケースのシーケンス
 
-> **5 行以内 summary**: ColorMaster の主要ユースケース (ログイン / アイドル検索 / 担当追加 /
-> 同期実行) のシーケンス図を集約する。Phase C 進行に応じて各 EPIC の詳細設計
-> (`docs/specifications/detail/`) で個別に詳細化、本ファイルは概観として残す。
-> 本格化は A2 + C3-C6。
+> **5 行以内 summary**: ColorMaster の主要 4 ユースケース (ログイン / アイドル検索 /
+> 担当追加 / 同期実行) と Cloud Run 起動 (Litestream restore) のシーケンスを Mermaid
+> `sequenceDiagram` で集約する。Phase C 進行に応じて各 EPIC の詳細設計
+> (`docs/specifications/detail/`) で更新、本ファイルは概観として残す。本格化は A2-5 + C3-C7。
 
-## 主要ユースケース (骨格、A2 + C3-C6 で本格化)
+## ユースケース 1: ログイン (GIS)
 
-| ユースケース | 主参加者 | 関連 EPIC | 詳細 |
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant Client as Client (Android/iOS/wasmJs)
+    participant GIS as GIS
+    participant Backend as Cloud Run (Ktor)
+    participant JWKS as Google JWKS
+
+    User->>Client: サインインボタンタップ
+    Client->>GIS: requestIdToken()
+    GIS-->>User: 同意画面 (Google アカウント選択)
+    User->>GIS: 同意
+    GIS-->>Client: ID Token (JWT, exp 1 時間)
+    Client->>Client: secure storage に保存
+    Client->>Backend: GET /api/me/profile\nAuthorization: Bearer <ID Token>
+    Backend->>JWKS: fetch /oauth2/v3/certs (cache 6 時間)
+    JWKS-->>Backend: 公開鍵セット
+    Backend->>Backend: JWT 署名 + iss/aud/exp 検証
+    Backend->>Backend: sub claim → uid 抽出
+    Backend->>GIS: GET /oauth2/v3/userinfo (memory cache 15 分)
+    GIS-->>Backend: {name, email, picture}
+    Backend-->>Client: 200 {uid, name, picture}
+    Client-->>User: ホーム画面 (uid 表示)
+```
+
+> 補足: `email` は **クライアントには返さない** (PII 最小化、ADR 0020)。`name` と `picture`
+> は表示用に返却するが、Backend memory cache TTL 15 分のみで永続化しない。
+
+## ユースケース 2: アイドル検索
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant Screen as SearchScreen
+    participant VM as SearchViewModel
+    participant Repo as IdolRepository
+    participant Net as ApiClient
+    participant Backend as Cloud Run
+    participant IdolsDb as idols.db
+
+    User->>Screen: 検索クエリ入力 "はるか"
+    Screen->>VM: onAction(OnQueryChanged("はるか"))
+    VM->>VM: state = Loading
+    VM->>Repo: search(query="はるか")
+    Repo->>Repo: memory cache 確認 (miss)
+    Repo->>Net: GET /api/idols/search?q=はるか
+    Net->>Backend: HTTPS request (Cache-Control: public, max-age=86400)
+    Backend->>IdolsDb: SELECT * FROM idols WHERE name LIKE ?
+    IdolsDb-->>Backend: 3 rows
+    Backend-->>Net: 200 {idols: [...]}
+    Net-->>Repo: List<IdolDto>
+    Repo->>Repo: DTO → Idol マッピング + cache 格納
+    Repo-->>VM: List<Idol>
+    VM->>VM: state = Loaded(idols)
+    Screen-->>User: 検索結果リスト表示
+```
+
+> 認証不要 (`/api/idols/*` は公開マスタ)。Cloud Run の `Cache-Control: public, max-age=86400`
+> で CDN レイヤがあれば自動キャッシュ、クライアント側も Repository memory cache。
+
+## ユースケース 3: 担当追加
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant Screen as IdolDetailScreen
+    participant VM as IdolDetailViewModel
+    participant Repo as MeRepository
+    participant Net as ApiClient
+    participant Backend as Cloud Run
+    participant UsersDb as users.db
+    participant LS as Litestream
+    participant R2 as Cloudflare R2
+
+    User->>Screen: 「担当に追加」ボタンタップ
+    Screen->>VM: onAction(OnAddFavorite(idolId, kind=Tantou))
+    VM->>VM: 楽観更新 (UI 即座に追加表示)
+    VM->>Repo: addFavorite(idolId, Tantou)
+    Repo->>Net: POST /api/me/favorites\nAuthorization: Bearer <ID Token>\nbody: {idolId, kind: "tantou"}
+    Net->>Backend: HTTPS request
+    Backend->>Backend: requireUid() (ID Token 検証 + uid 抽出)
+    Backend->>UsersDb: INSERT INTO favorites VALUES (uid, idolId, now, 'tantou')
+    UsersDb->>UsersDb: WAL 更新
+    UsersDb-->>Backend: OK
+    Backend-->>Net: 201 Created
+    Net-->>Repo: Success
+    Repo-->>VM: Success
+    Note over LS,R2: 非同期 (background)
+    UsersDb->>LS: WAL 変更通知
+    LS->>R2: PUT WAL chunk
+    R2-->>LS: 200 OK
+    VM-->>Screen: 確定 (楽観更新が成功確定)
+    Screen-->>User: トースト「担当に追加しました」
+```
+
+> 失敗時は楽観更新をロールバック (UI から削除) + エラー表示。Backend の `INSERT` が失敗した
+> 場合 Litestream は発火しない (原子性は SQLite が保証)。
+
+## ユースケース 4: im@sparql 同期 (GitHub Actions cron)
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions cron
+    participant GH as GitHub API
+    participant State as data/.imasparql-sync-state.json
+    participant Sparql as imas/imasparql endpoint
+    participant Cli as backend/cli
+    participant Repo as repo workspace
+    participant PR as PR
+
+    Cron->>GH: gh api repos/imas/imasparql/commits/master
+    GH-->>Cron: {sha: "abc123..."}
+    Cron->>State: read upstream_sha
+    State-->>Cron: "def456..."
+    alt SHA 一致
+        Cron->>Cron: no-op (exit 0)
+    else SHA 不一致
+        Cron->>Cli: ./gradlew :backend:cli:fetchIdolColorsFromImasparql
+        Cli->>Sparql: SPARQL query (Fuseki or production endpoint)
+        Sparql-->>Cli: RDF triples
+        Cli->>Cli: マッピング (RDF → Idol / Brand / ColorPalette)
+        Cli->>Repo: write data/idols.db, idols.json
+        Cli->>Cli: レコード数 ±X% チェック
+        alt 異常 (大幅減 / 増)
+            Cli-->>Cron: fail (exit 非ゼロ)
+            Cron->>GH: gh issue create (異常検知)
+        else 正常
+            Cli->>State: write upstream_sha = "abc123..."
+            Cron->>PR: gh pr create --head chore/sync-imasparql-abc1234
+            PR-->>Cron: PR #N (human/AI review 必須)
+        end
+    end
+```
+
+> 詳細は `data-flow.md` および `docs/runbooks/sync-imasparql.md` (C6 で本格化) を参照。
+
+## ユースケース 5: Cloud Run 起動 (Litestream restore)
+
+```mermaid
+sequenceDiagram
+    participant CR as Cloud Run
+    participant Img as コンテナイメージ
+    participant Startup as scripts/startup.sh
+    participant LS as Litestream
+    participant R2 as Cloudflare R2
+    participant Db as /data/users.db
+    participant Server as Ktor Server
+
+    Note over CR: 新リクエスト到来 (cold start)
+    CR->>Img: pull (Artifact Registry から)
+    Img->>Startup: container entrypoint
+    Startup->>LS: litestream restore -o /data/users.db r2://bucket/users.db
+    LS->>R2: GET WAL chunks
+    R2-->>LS: WAL data
+    LS->>Db: 再構築
+    LS-->>Startup: restore 完了
+    alt restore 成功
+        Startup->>LS: litestream replicate (daemon 起動、background)
+        Startup->>Server: Ktor server start
+        Server-->>CR: listen on :8080
+        CR-->>Server: HTTP traffic 開始
+    else restore 失敗
+        Startup-->>CR: exit 非ゼロ
+        CR->>CR: retry (max 3 回) → 失敗時 revision rollback 検討
+    end
+```
+
+> 起動順序の保証は ADR 0008 と `.claude/rules/cloud-run-deploy.md` で規約化 (A2-2 で本格化)。
+> restore 失敗時の server 不起動は **必須** (空 DB で API を提供しない、PII 喪失リスク回避)。
+
+## エラーパスの代表例
+
+| ユースケース | 失敗箇所 | 応答 | クライアント挙動 |
 |---|---|---|---|
-| ログイン (GIS) | Client → GIS → Backend (`/api/me`) | C5 | TODO Mermaid `sequenceDiagram` |
-| アイドル検索 | Client → Backend (`/api/idols/search`) → idols.db | C3 | TODO |
-| 担当追加 | Client → Backend (`/api/me/favorites`) → users.db → Litestream → R2 | C5 | TODO |
-| im@sparql 同期 | GitHub Actions cron → imas/imasparql → idols.db diff PR | C6 | TODO |
-| Cloud Run 起動 (Litestream restore) | Cloud Run startup → R2 → users.db restore → Ktor start | C5 / C7 | TODO |
+| ログイン | JWKS 取得失敗 | 503 + Retry-After | クライアント側 exponential retry (3 回) |
+| ログイン | ID Token 期限切れ | 401 | GIS で再取得 |
+| 検索 | idols.db クエリ失敗 (broken DB) | 500 | エラー画面表示、運用通知 |
+| 担当追加 | uid 不一致 (他人の uid に書こうとした) | 403 | ローカル状態を破棄、ログアウト誘導 |
+| 同期 | im@sparql 5xx | sync workflow fail | Issue 起票、次回 cron で retry |
+| Cloud Run 起動 | R2 unreachable | restore fail | Cloud Run retry → revision rollback |
 
-## A2 + C3-C6 での本格化内容
+## A2-5 + Phase C で本格化する内容
 
-- 各ユースケースを Mermaid `sequenceDiagram` で記述
-- エラーケース / リトライ / タイムアウトの分岐を明示
-- 関連 Spec basic / detail へのリンク
+- 各ユースケースのエラーケース / リトライ / タイムアウトの分岐を Mermaid に明示
+- 関連 Spec basic / detail へのリンク (REQ → SPEC → 実装のトレース)
+- パフォーマンス目標 (検索 < 500ms、ログイン < 2s 等) の追記
+- ユーザー削除フロー (`/api/me` DELETE + R2 WAL 期限切れ) の追加
 
 ## 関連
 
-- `docs/architecture/{overview,data-flow,layers}.md`
-- `docs/specifications/{basic,detail}/` (各機能の Spec、Phase C で個別作成)
-- `docs/runbooks/{sync-imasparql,release,r2-litestream}.md`
+- `overview.md` / `layers.md` / `data-flow.md` / `infrastructure.md` / `state-machines.md`
+- ADR 0007 (im@sparql upstream-driven 同期) / 0008 (Backend SQLite + Litestream + R2) / 0011 (GIS 統一) / 0014 (ローカル Fuseki)
+- `docs/specifications/{basic,detail}/SPEC-*.md` (各機能の Spec、Phase C で個別作成)
+- `docs/runbooks/{sync-imasparql,release,r2-litestream}.md` (C5-C7 で本格化)
+- `../api/{auth,idols,me}.md` (API 詳細)

--- a/docs/architecture/state-machines.md
+++ b/docs/architecture/state-machines.md
@@ -3,41 +3,125 @@ id: arch-state-machines
 title: 状態遷移 (UiState 状態機械)
 status: skeleton
 last_updated: 2026-05-17
-related_plan: docs/harness/plan.md §3
+related_plan: docs/harness/plan.md §3.1
+related_adrs:
+  - ADR-0002
 ---
 
 # 状態遷移 (UiState)
 
-> **5 行以内 summary**: ColorMaster の各画面の UiState 状態遷移 (Loading / Loaded /
-> Empty / Error / Partially Loaded) の規約と画面別の状態機械概観。本格化は A2 + C3
-> (feature-first モジュール再編後)、各 feature の詳細設計 (`docs/specifications/detail/`)
-> でも個別に Mermaid `stateDiagram-v2` で記述する。
+> **5 行以内 summary**: ColorMaster は `StateFlow<UiState>` + `onAction(UiAction)` +
+> `Channel<UiEffect>` の軽量 UDF (Unidirectional Data Flow) を採用する。本ファイルは
+> 共通の状態語彙 (Loading / Loaded / Empty / Error / PartiallyLoaded) と画面別の
+> 状態機械概観を集約する。詳細な画面別実装は C3 + 各 EPIC の `docs/specifications/detail/`
+> で個別に Mermaid `stateDiagram-v2` で記述。
 
 ## 共通の状態語彙
 
-| 状態 | 意味 | UI 表示例 |
-|---|---|---|
-| `Loading` | 初回ロード中 | スピナー全画面 |
-| `Loaded` | データ取得成功 | コンテンツ表示 |
-| `Empty` | 取得成功だが結果が空 | 「該当なし」メッセージ |
-| `Error` | 取得失敗 | エラーメッセージ + リトライボタン |
-| `PartiallyLoaded` | 一部成功 / 一部失敗 (アイドル N 件中 M 件取得失敗等) | 取得分を表示 + 失敗分の警告 |
+| 状態 | 意味 | UI 表示例 | 遷移先 |
+|---|---|---|---|
+| `Loading` | 初回ロード中 (またはリトライ中) | スピナー / スケルトン | → `Loaded` / `Empty` / `Error` |
+| `Loaded(data)` | データ取得成功 | コンテンツ表示 | → `Loading` (refresh) / `Loaded(data')` (更新) |
+| `Empty` | 取得成功だが結果が空 | 「該当なし」メッセージ | → `Loading` (検索条件変更) |
+| `Error(reason)` | 取得失敗 | エラーメッセージ + リトライボタン | → `Loading` (retry) |
+| `PartiallyLoaded(data, failures)` | 一部成功 / 一部失敗 | 取得分を表示 + 失敗分の警告 | → `Loading` (full retry) / `Loaded` (partial fill) |
+
+## UDF 構造
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Loading: init
+    Loading --> Loaded: onSuccess(data)
+    Loading --> Empty: onSuccess(empty)
+    Loading --> Error: onFailure(reason)
+    Loading --> PartiallyLoaded: onPartial(data, failures)
+    Loaded --> Loading: onRefresh
+    Empty --> Loading: onParamChanged
+    Error --> Loading: onRetry
+    PartiallyLoaded --> Loading: onFullRetry
+    PartiallyLoaded --> Loaded: onPartialFill(data)
+    Loaded --> [*]: onLeave
+```
+
+> 凡例: `[*]` = 画面に進入 / 離脱、矢印ラベル = `UiAction` または ViewModel 内部イベント。
+> ViewModel が `_state.update { ... }` で `StateFlow<UiState>` を遷移させ、Composable は
+> `collectAsStateWithLifecycle()` で観測する。
+
+## UiAction → 状態遷移の対応
+
+| UiAction | 受信時の状態 | 遷移先 | 副作用 (UiEffect) |
+|---|---|---|---|
+| `OnInit` | (初期) | `Loading` | Repository へ取得依頼 |
+| `OnRefresh` | `Loaded` / `PartiallyLoaded` | `Loading` | 同上 |
+| `OnRetry` | `Error` | `Loading` | 同上 |
+| `OnParamChanged(p)` | 任意 | `Loading` | 同上 (新 param で) |
+| `OnSelectItem(id)` | `Loaded` | (遷移なし) | `UiEffect.Navigate(Route.Detail(id))` |
+| `OnAddFavorite(idolId)` | `Loaded` | (遷移なし、楽観更新後リトライ) | Backend `POST /api/me/favorites` |
+| `OnSignIn` | 全状態 (Auth 上位) | (Auth 状態変化) | GIS フロー起動 |
+
+## 画面別の状態機械 (骨格、A2-5 + C3 で本格化)
+
+各画面の Mermaid `stateDiagram-v2` は EPIC-001 (C3) 着手時に `docs/specifications/detail/`
+で個別に詳細化する。本ファイルでは概観のみを表で持つ。
+
+| 画面 | パス (将来) | 主要状態 | 関連 SPEC | 関連 EPIC |
+|---|---|---|---|---|
+| Home | `feature/home/` | `Loading` → `Loaded(idolGrid)` / `Empty` / `Error` | SPEC-IDOL-001 (C3) | EPIC-001 |
+| Search | `feature/search/` | `Loading(query)` → `Loaded(results)` / `Empty` / `Error` + `Idle` (検索前) | SPEC-IDOL-002 (C3) | EPIC-001 |
+| Preview | `feature/preview/` | `Loaded(idol)` / `Error` (id 不存在) | SPEC-IDOL-003 (C3) | EPIC-001 |
+| MyIdols (担当・推し) | `feature/myidols/` | `Loading` → `Loaded(favorites)` / `Empty` / `Error` + `Unauthenticated` | SPEC-USER-001 (C5) | EPIC-003 |
+| Auth (上位) | `feature/auth/` | `Unauthenticated` ⇄ `Authenticating` ⇄ `Authenticated(uid)` / `AuthError` | SPEC-AUTH-001 (C5) | EPIC-003 |
+
+## 共通状態 (横断、Auth / Network)
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Unauthenticated
+    Unauthenticated --> Authenticating: OnSignIn
+    Authenticating --> Authenticated: GIS Token 取得成功
+    Authenticating --> AuthError: GIS 失敗 / cancel
+    AuthError --> Authenticating: OnRetry
+    Authenticated --> Unauthenticated: OnSignOut / Token 期限切れ
+    Authenticated --> [*]
+```
+
+> Auth 状態はアプリ全体の上位状態として `core/domain/auth/` (C5 で新設) に集約。各画面は
+> `Authenticated(uid)` を前提条件として動作し、`Unauthenticated` 検知時は Auth 画面に
+> リダイレクト。Navigation 3 の上位グラフで分岐。
 
 ## 規約
 
-- **UiState は sealed class** (`.claude/rules/ui-state.md`)
+- **UiState は sealed class** で表現 (`.claude/rules/ui-state.md` で本格化、A2-2)
+  - 状態を網羅可能にし、`when` 式での compile-time exhaustive check を効かせる
 - **UiAction (intent) も sealed class** で受信
 - **状態遷移は ViewModel が一元管理**、Composable は State を hoist して受け取る
-- 詳細実装規約は `.claude/rules/{ui-state,viewmodel,composable}.md` (A2 で本格化)
+- **`UiEffect` は `Channel` (Flow ではなく)** で一回性副作用 (画面遷移 / Toast) を表現
+- **state hoisting**: Composable は `state: UiState` と `onAction: (UiAction) -> Unit` を引数で受ける
+- **Composable は ViewModel への参照を持たない** (Stateful Composable で集約、Stateless Composable は state のみ受ける)
+- 詳細実装規約は `.claude/rules/{ui-state,viewmodel,composable}.md` (A2-2 で本格化)
 
-## A2 + C3 での本格化内容
+## 機械検証 (Konsist、A2-2 + A6 で導入)
 
-- 各画面 (Home / Search / Preview / MyIdols) の状態遷移を Mermaid 化
-- 共通状態 (Auth / Network) の上位状態機械
-- 状態遷移 + UiAction の対応表
+| 規約 | 検証手段 |
+|---|---|
+| `UiState` は sealed class | Konsist で `*UiState.kt` の sealed 修飾子を検証 |
+| `UiAction` は sealed class | 同上 |
+| Stateless Composable は ViewModel を受け取らない | Konsist で `@Composable fun` の引数型に ViewModel を含まないことを検証 |
+| ViewModel の `_state` は private | Konsist で `MutableStateFlow` の可視性を検証 |
+
+## A2-5 + C3 + EPIC 詳細設計での本格化内容
+
+- 各画面 (Home / Search / Preview / MyIdols / Auth) の状態遷移を Mermaid `stateDiagram-v2` で記述
+- 各画面の `UiAction` → 状態遷移の対応表を完備
+- 共通状態 (Auth / Network 可達性 / オフライン) の上位状態機械
+- 状態遷移とエラーリカバリパターン (Exponential backoff / circuit breaker 等は採用しない方針) の明示
 
 ## 関連
 
-- `docs/architecture/overview.md`
-- `.claude/rules/{ui-state,viewmodel,composable}.md`
+- `overview.md` / `layers.md` / `sequences.md`
+- ADR 0002 (Compose Multiplatform + 共通 ViewModel + Navigation 3)
+- `.claude/rules/{ui-state,viewmodel,composable,navigation}.md`
 - `docs/design/inventory/states/` (状態別 UI パターン、A10 で本格化)
+- `docs/specifications/detail/SPEC-*.md` (各画面の状態遷移詳細、C3-C5 で個別作成)

--- a/docs/epics/EPIC-A2-rules-docs-extension/progress.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/progress.md
@@ -25,13 +25,20 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-1 Phase 8 (roadmap-tracker 手動代替) 実施 → PR #122 (`harness/roadmap-mirror-a2-1`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md 更新 | PR #122 |
 | 2026-05-17 | A2-1 Phase 9 (worktree cleanup) 実施 → `feature/A2-rules-docs-extension` worktree remove + branch -d | — |
 | 2026-05-17 | A2-4 着手 (worktree `feature/A2-4-docs-core` で `implementation-workflow` Phase 1 から、A2-2 / A2-5 と並走) | A2-4 PR #123 |
+| 2026-05-17 | A2-5 着手 (worktree `feature/A2-5-docs-arch-api` で `implementation-workflow` Phase 1 から、A2-2 / A2-4 と並走) | A2-5 PR #126 |
+| 2026-05-17 | A2-5: docs/architecture 7 + docs/api 5 = 12 ファイルを 5KB+ に拡充 (合計 +2,005 行)、PR #126 ドラフト起票 (commit `4fc26a2`) | A2-5 PR #126 |
+| 2026-05-17 | A2-5 code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) 並列 review 完了 → architecture Critical 4 件検出 (DIP 違反方向 / `core/database` 未定義 / restore 主体誤り / Mermaid 非対称) | A2-5 PR #126 |
+| 2026-05-17 | A2-5 fix loop 実施 (commit `de2b1f8`、Critical 4 件解消) → Coordinator が Ready 判定 | A2-5 PR #126 |
+| 2026-05-17 | A2-4 PR #123 merge 完了 → master 取得 → A2-5 PR #126 を rebase (`progress.md` / `roadmap.md` 衝突を A2-4 完了反映と A2-5 着手記録の統合で解決) | A2-5 PR #126 |
 
 ## マイルストーン
 
 | 日付 | マイルストーン | 達成 / 未達 |
 |---|---|---|
 | 2026-05-17 | A2-1 PR ドラフト起票 | ✅ 達成 (PR #121) |
-| 2026-05-17 | A2-1 マージ → A2-2 / A2-4 並走着手の前提整備 | ✅ 達成 (PR #121 merge commit `feb41b5`、PR #122 で roadmap mirror) |
+| 2026-05-17 | A2-1 マージ → A2-2 / A2-4 / A2-5 並走着手の前提整備 | ✅ 達成 (PR #121 merge commit `feb41b5`、PR #122 で roadmap mirror) |
+| 2026-05-17 | A2-4 マージ (docs/ コア + runbooks 拡充) | ✅ 達成 (PR #123) |
+| 2026-05-17 | A2-5 PR ドラフト起票 | ✅ 達成 (PR #126) |
 | (未定) | A2-2 / A2-3 マージ (rules 全本格化完了) | 未達 |
-| (未定) | A2-4 / A2-5 マージ (docs 全面拡充完了) | 未達 (A2-4 ドラフト起票中、PR #123) |
+| (未定) | A2-5 マージ (docs/architecture + api 拡充) | (本 PR Ready 昇格 + merge 予定) |
 | (未定) | EPIC-A2 status → completed | 未達 |

--- a/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
@@ -21,7 +21,7 @@ source_epic: EPIC-A2
 | **A2-2** | rules 実装・コード系本格化 | proposed | `.claude/rules/{plan,epic,adr,roadmap,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,pii,secrets,db-protection,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream,rules-index}.md` | — |
 | **A2-3** | rules プロセス・ハーネス・UI系本格化 | proposed | `.claude/rules/{pr-template,branch-naming,merge-readiness,pr-draft-policy,spec-living-sync,harness-meta-criteria,retrospective-format,pr-poller,skill-authoring,harness-evolution,implementation-workflow,code-reviewer-aspects,design-tokens,ui-snapshot,ui-inventory,behavior-preservation,docs-structure,template-language,rules-index}.md` | — |
 | **A2-4** | docs/ コア + runbooks 拡充 | proposed | `docs/{README,glossary,codebase-map}.md`, `docs/security/README.md`, `docs/requirements/{README,template}.md`, `docs/specifications/{README,basic/template,detail/template}.md`, `docs/runbooks/{local-development,testing,i18n,mcp-setup}.md` | — |
-| **A2-5** | docs/architecture + api 拡充 | proposed | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md`, `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` | — |
+| **A2-5** | docs/architecture + api 拡充 | in-progress | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md`, `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` | (本 PR で更新) |
 
 ## 完了根拠
 
@@ -64,6 +64,7 @@ A2-1 完了後、A2-2/A2-3 (rules 系) と A2-4/A2-5 (docs 系) は **並走可*
 | 2026-05-17 | EPIC-A2 起票 + A2 を 5 PR に分割 | B0 (96 files / +5408 行) のレビュー負荷が上限近く、A2 全体は B0 を超える規模が想定されるため。A1 レトロ Try「巨大 PR の aspect 並列 review における入力分割」と整合 |
 | 2026-05-17 | A2-1 着手 (現 worktree `feature/A2-rules-docs-extension` を reuse) | A1 レトロ 15 提案のうち消化可能項目を最優先で消化、後続 PR の規約・索引基盤を整える |
 | 2026-05-17 | A2-1 status を in-progress → completed (PR #121 マージ、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、後続 A2-2 / A2-4 並走着手の前提が整う。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
+| 2026-05-17 | A2-5 着手 (worktree `feature/A2-5-docs-arch-api`) | A2-1 マージ後、A2-2 / A2-4 と並行で docs/architecture + api サブツリーを 12 ファイル 5KB+ に拡充 (touch ファイル重複ゼロ) |
 
 ## 次の推奨着手 (並行実装観点)
 


### PR DESCRIPTION
## 概要

EPIC-A2 配下 5 番目の PR。`docs/architecture/{overview, layers, data-flow, domain-model, state-machines, sequences, infrastructure}.md` (7) + `docs/api/{README, colormaster-api.yaml, auth, idols, me}.md` (5) の **12 ファイル** を B0 skeleton (1.3-2.5KB) から **本格化 (5KB+、合計 +2,005 行)**。ADR 0001-0027 と `docs/harness/plan.md` §3-§4 で決定済の設計を Single Source として執筆 (Option A: ADR/plan 駆動)、実装が薄い部分は「現状: B0 段階」「本格実装: Phase C」と honest に明示する方針。

## 関連

- Epic: EPIC-A2 (`.claude/rules/*` 全ファイル本格化 + docs 全面拡充)
- ADR: ADR-0002 / 0003 / 0005 / 0007 / 0008 / 0009 / 0010 / 0011 / 0014 / 0020 / 0021 / 0022 / 0027
- 元 learnings: (該当なし、A1 レトロは A2-1 で消化済)
- 元 evolution-proposals: (該当なし)

## PR の種別

- [ ] A1 レトロ 等の即時消化フォロー PR
- [x] **rules / Skill 本格化** (B0 雛形 → 本文充実) — `docs/` 側だが性質は同一
- [ ] ハーネス改修 PR (`harness-meta` 起票)
- [ ] 外部研究駆動の改修 PR (`harness-evolution` 起票)
- [ ] レトロ集約 PR
- [ ] その他

## 変更内容

| 区分 | パス | 変更内容 |
|---|---|---|
| docs | `docs/architecture/overview.md` | 採用スタック表 / モジュール俯瞰 Mermaid `graph TD` / target 言語マトリクス / 外部依存表 / 各サブ docs 索引拡充 |
| docs | `docs/architecture/layers.md` | 層別責務マトリクス / 依存方向 Mermaid `graph LR` / 越境ルール / Konsist 機械検証規約 / 撤去予定モジュール表 / 新設モジュール表 / 現状差分 |
| docs | `docs/architecture/domain-model.md` | Mermaid `erDiagram` (Idol / Brand / ColorPalette / FavoriteIdol) / エンティティ詳細表 / 値オブジェクト表 / 集約境界の暫定方針 / クエリパターン |
| docs | `docs/architecture/data-flow.md` | 全体 Mermaid `flowchart TB` (im@sparql → CI → repo → Cloud Run → Client) / 同期フロー 7 ステップ / Litestream replicate/restore フロー / キャッシュ戦略表 / エラーパス表 |
| docs | `docs/architecture/infrastructure.md` | Mermaid `graph LR` 構成図 / デプロイフロー (通常 / 同期 / ロールバック) / Secret Manager 経路 Mermaid `sequenceDiagram` / 採用見送り表 / モニタリング表 |
| docs | `docs/architecture/state-machines.md` | 共通状態語彙表 / UDF Mermaid `stateDiagram-v2` / UiAction 遷移対応表 / 画面別状態機械骨格 / Auth 上位状態機械 / Konsist 機械検証規約 |
| docs | `docs/architecture/sequences.md` | 主要 5 ユースケースの Mermaid `sequenceDiagram` (ログイン / 検索 / 担当追加 / im@sparql 同期 / Cloud Run 起動 Litestream restore) / エラーパス代表例 |
| docs | `docs/api/README.md` | ベース URL / エンドポイント分類 / 認証方式 / バージョニング規約 / 標準応答ヘッダ / 標準エラー応答 / ステータスコード規約 / エラーコード語彙 / CORS / `/health` schema / ロギング規約 |
| docs | `docs/api/colormaster-api.yaml` | paths を 11 endpoint に拡張 (`/health`, `/api/idols`, `/api/idols/{id}`, `/api/idols/search`, `/api/brands`, `/api/colors`, `/api/me/profile`, `/api/me/favorites` GET/POST, `/api/me/favorites/{idolId}` DELETE, `/api/me` DELETE)。`components/schemas` で Idol / IdolList / Brand / ColorPalette / Profile / Favorite / FavoriteList / FavoriteCreateRequest / Health / Error を定義 |
| docs | `docs/api/auth.md` | GIS 認証フロー 5 ステップ + Mermaid `sequenceDiagram` / JWKS 検証規約 / `requireUid()` 規約 / エラーケース表 / PII 取扱 / クライアント secure storage 表 / Firebase 撤去計画 / mock 開発モード |
| docs | `docs/api/idols.md` | 5 endpoint 仕様 / クエリパラメータ規約 / レスポンス形式 / キャッシュ戦略 / データソースライフサイクル / レスポンス例 / エラーケース表 / Konsist 機械検証規約 / Repository 利用パターン |
| docs | `docs/api/me.md` | 5 endpoint 仕様 / 認可規約 / `users.db` DB スキーマ / 初回サインイン Mermaid `sequenceDiagram` / ユーザー削除フロー Mermaid `sequenceDiagram` / エラーケース表 / キャッシュ戦略 / レスポンス例 / Konsist 機械検証規約 / PII 取扱 |
| docs | `docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` | A2-5 行を `proposed` → `in-progress`、着手順変更履歴に追記 |
| docs | `docs/epics/EPIC-A2-rules-docs-extension/progress.md` | A2-1 マージ / A2-5 着手 / 12 ファイル拡充のマイルストーン追記 |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 0 | 0 | 0 | 0 |
| `[skill]` | 0 | 0 | 0 | 0 |
| `[template]` | 0 | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

(本 PR は EPIC-A2 配下の docs 本格化 PR、harness-meta / learning ベースの改修提案を持たない)

## 受け入れ基準 (AC)

- [x] AC-01: docs/architecture 7 + docs/api 5 = 12 ファイルが冒頭 5 行 summary + 本文 5KB+ (`wc -c` で全件 6.6KB - 12.1KB を確認、合計 +2,005 行)
- [x] AC-02: frontmatter の `related_adrs` / `expected_modules` は block 形式必須 (`.claude/rules/docs-structure.md`、全 12 ファイル準拠)
- [x] AC-03: Mermaid 図は全 7 architecture docs + sequences 5 ユースケースで描画 (`graph TD/LR` / `flowchart TB` / `erDiagram` / `stateDiagram-v2` / `sequenceDiagram`)
- [x] AC-04: ADR 0001-0027 / `docs/harness/plan.md` §3-§4 / `.claude/rules/*` の既存記述と矛盾しない (Option A: ADR/plan 駆動執筆)
- [x] AC-05: EPIC-A2 `roadmap.md` の A2-5 行と `progress.md` を更新済
- [x] AC-06: コード断片は `colormaster-api.yaml` (OpenAPI) と短い参考 JSON レスポンス例 / Mermaid に限定、`docs/{requirements, specifications}/**` のコード断片禁止 (§4.6.1) には抵触しない (本 PR はそのサブツリーを touch しない)
- [x] AC-07: PII 取扱を auth.md / me.md / README.md / data-flow.md / api/README.md で明示 (`.claude/rules/pii.md` 準拠)

## テスト

- [x] markdownlint-cli2 グリーン (A6 未導入のため目視確認のみ、frontmatter / 5 行 summary / lazy-load 構造を全 12 ファイルで確認済)
- [x] Gradle カスタムタスクの docs 検証グリーン (A6 未導入のため目視確認のみ、`related_adrs` の block 形式を全 12 ファイルで確認済)
- [x] OpenAPI 3.1 spec の `info.version` を `0.0.0-skeleton` 維持 (C5 で `0.1.0-alpha` に bump 予定)

## レビュー観点

- `Option A (ADR/plan 駆動執筆)` の方針が妥当か (実装が薄い領域を「現状: B0 / 本格化: Phase C」と honest に明示する形)
- Mermaid 図が GitHub Markdown レンダラーで意図通り表示されるか
- `colormaster-api.yaml` の paths / schemas が現実装 (Backend 未実装、Firebase 撤去未済) と乖離しすぎていないか — 本 PR は将来形 (C5 完了後の最終形) を SoT として記述する方針
- `/api/me/*` のセキュリティモデル (`requireUid()` 規約 / uid フィルタ必須 / `Cache-Control: private, no-store`) が ADR 0011 / 0020 と整合しているか
- ADR 起票基準を新たに満たす変更があるか — 本 PR では既存 ADR の参照のみ、新規 ADR 起票不要と判断
- 撤回コスト: 本 PR は docs のみ touch、`core/**` / `feature/**` / `backend/**` を変更しないため、撤回は git revert で完結

## チェックリスト

- [x] Conventional Commits 規約準拠 (subject 72 字以内、body は 72 字でラップ、Co-Authored-By 必須)
- [x] EPIC-A2 配下 PR (本 PR が 5 番目、A2-1 PR #121 merged 済)
- [x] `docs/architecture` / `docs/api` 以外のサブツリー (rules / runbooks / requirements / specifications) は触らない (EPIC-A2 内の touch 分離原則、A2-2 / A2-4 と並走可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)