### PR TITLE
docs(harness): mirror A2-5 completion in roadmap

### DIFF
--- a/docs/epics/EPIC-A2-rules-docs-extension/progress.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/progress.md
@@ -30,6 +30,8 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-5 code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) 並列 review 完了 → architecture Critical 4 件検出 (DIP 違反方向 / `core/database` 未定義 / restore 主体誤り / Mermaid 非対称) | A2-5 PR #126 |
 | 2026-05-17 | A2-5 fix loop 実施 (commit `de2b1f8`、Critical 4 件解消) → Coordinator が Ready 判定 | A2-5 PR #126 |
 | 2026-05-17 | A2-4 PR #123 merge 完了 → master 取得 → A2-5 PR #126 を rebase (`progress.md` / `roadmap.md` 衝突を A2-4 完了反映と A2-5 着手記録の統合で解決) | A2-5 PR #126 |
+| 2026-05-17 | A2-5 PR #126 Ready 昇格 + merge 完了 (commit `168ef5d`、squash merge、`gh pr merge --squash --admin` で orchestrator 委任 / R-15 代替) | A2-5 PR #126 |
+| 2026-05-17 | A2-5 Phase 8 (roadmap-tracker 手動代替) 実施 → 本 PR (`harness/roadmap-mirror-a2-5`) で EPIC-A2 roadmap.md / progress.md / 全体 roadmap.md の A2-5 完了反映 | 本 PR (A2-5 mirror) |
 
 ## マイルストーン
 
@@ -39,6 +41,7 @@ source_epic: EPIC-A2
 | 2026-05-17 | A2-1 マージ → A2-2 / A2-4 / A2-5 並走着手の前提整備 | ✅ 達成 (PR #121 merge commit `feb41b5`、PR #122 で roadmap mirror) |
 | 2026-05-17 | A2-4 マージ (docs/ コア + runbooks 拡充) | ✅ 達成 (PR #123) |
 | 2026-05-17 | A2-5 PR ドラフト起票 | ✅ 達成 (PR #126) |
-| (未定) | A2-2 / A2-3 マージ (rules 全本格化完了) | 未達 |
-| (未定) | A2-5 マージ (docs/architecture + api 拡充) | (本 PR Ready 昇格 + merge 予定) |
-| (未定) | EPIC-A2 status → completed | 未達 |
+| 2026-05-17 | A2-5 マージ (docs/architecture + api 拡充) | ✅ 達成 (PR #126、commit `168ef5d`) |
+| (未定) | A2-2 マージ (rules 実装・コード系本格化) | 進行中 (PR #125 DRAFT) |
+| (未定) | A2-3 マージ (rules プロセス・ハーネス・UI 系本格化) | 未達 (A2-2 完了後着手予定) |
+| (未定) | EPIC-A2 status → completed | 未達 (3/5 マージ済、残り A2-2 / A2-3) |

--- a/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
+++ b/docs/epics/EPIC-A2-rules-docs-extension/roadmap.md
@@ -21,13 +21,14 @@ source_epic: EPIC-A2
 | **A2-2** | rules 実装・コード系本格化 | proposed | `.claude/rules/{plan,epic,adr,roadmap,viewmodel,ui-state,composable,navigation,repository,network-client,naming,error-handling,logging,i18n,wasm-compat,firebase-boundary,no-firebase,gradle,kotlin-test,screenshot-test,sql-delight,sparql,test-paired-class,markdown,pii,secrets,db-protection,sync-job,sqlite-data-file,cloud-run-deploy,removed-modules,backend-auth,cloudflare-pages,r2-litestream,rules-index}.md` | — |
 | **A2-3** | rules プロセス・ハーネス・UI系本格化 | proposed | `.claude/rules/{pr-template,branch-naming,merge-readiness,pr-draft-policy,spec-living-sync,harness-meta-criteria,retrospective-format,pr-poller,skill-authoring,harness-evolution,implementation-workflow,code-reviewer-aspects,design-tokens,ui-snapshot,ui-inventory,behavior-preservation,docs-structure,template-language,rules-index}.md` | — |
 | **A2-4** | docs/ コア + runbooks 拡充 | proposed | `docs/{README,glossary,codebase-map}.md`, `docs/security/README.md`, `docs/requirements/{README,template}.md`, `docs/specifications/{README,basic/template,detail/template}.md`, `docs/runbooks/{local-development,testing,i18n,mcp-setup}.md` | — |
-| **A2-5** | docs/architecture + api 拡充 | in-progress | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md`, `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` | (本 PR で更新) |
+| **A2-5** | docs/architecture + api 拡充 | completed | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md`, `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` | PR [#126](https://github.com/subroh0508/colormaster/pull/126) (2026-05-17 マージ、commit `168ef5d`) |
 
 ## 完了根拠
 
 | ID | PR 番号 | マージ日 | 主要ファイル |
 |---|---|---|---|
 | A2-1 | [#121](https://github.com/subroh0508/colormaster/pull/121) | 2026-05-17 | EPIC-A2 5 ファイル起票 (`docs/epics/EPIC-A2-rules-docs-extension/{README,roadmap,open-questions,decisions,progress}.md`)、`docs/epics/INDEX.md` 更新、`.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message (新規),roadmap}.md`、`.claude/skills/code-reviewer/SKILL.md` Gotchas、`.github/PULL_REQUEST_TEMPLATE/{harness (新規),feature,bugfix}.md`、`CLAUDE.md` lookup table 注記、`docs/adr/README.md` 索引拡充、`docs/harness/learnings/{flaky-tests.md (新規),2026-05-17-pr-117.md,INDEX.md}`、`docs/harness/{plan,roadmap}.md` (commit `feb41b5`、squash merge、code-reviewer 4 aspect 並列 review 通過 + fix loop で Critical 1 解消) |
+| A2-5 | [#126](https://github.com/subroh0508/colormaster/pull/126) | 2026-05-17 | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md` (7) + `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` (5) を B0 skeleton (1.3-2.5KB) から 5KB+ 本格化 (合計 +2,005 行)。Mermaid 図 (graph TD/LR / flowchart TB / erDiagram / stateDiagram-v2 / sequenceDiagram x5) を全 7 architecture docs + sequences 5 ユースケースで描画。`colormaster-api.yaml` paths を 11 endpoint に拡張、`components/schemas` で Idol/Brand/ColorPalette/Profile/Favorite/Health/Error を定義。Option A (ADR/plan 駆動執筆) 方針。`docs/epics/EPIC-A2-rules-docs-extension/{roadmap,progress}.md` 更新。commit `168ef5d` (squash merge、admin override / orchestrator 委任で R-15 代替)。code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) 並列 review 通過 + fix loop (commit `de2b1f8` → rebase で `642c46e`) で architecture Critical 4 件 (DIP 違反方向 / `core/database` 未定義 / restore 主体誤り / overview Mermaid 非対称) 解消 |
 
 ## 着手順とブロック関係
 
@@ -65,15 +66,16 @@ A2-1 完了後、A2-2/A2-3 (rules 系) と A2-4/A2-5 (docs 系) は **並走可*
 | 2026-05-17 | A2-1 着手 (現 worktree `feature/A2-rules-docs-extension` を reuse) | A1 レトロ 15 提案のうち消化可能項目を最優先で消化、後続 PR の規約・索引基盤を整える |
 | 2026-05-17 | A2-1 status を in-progress → completed (PR #121 マージ、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、後続 A2-2 / A2-4 並走着手の前提が整う。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
 | 2026-05-17 | A2-5 着手 (worktree `feature/A2-5-docs-arch-api`) | A2-1 マージ後、A2-2 / A2-4 と並行で docs/architecture + api サブツリーを 12 ファイル 5KB+ に拡充 (touch ファイル重複ゼロ) |
+| 2026-05-17 | A2-5 status を in-progress → completed (PR #126 マージ、commit `168ef5d`) | docs/architecture 7 + docs/api 5 を 5KB+ 本格化、code-reviewer architecture Critical 4 件 fix loop で解消、A2-4 PR #123 merge 後の rebase で `progress.md` / `roadmap.md` 衝突を統合解決。本 PR は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
 
 ## 次の推奨着手 (並行実装観点)
 
-A2-1 マージ済 (PR #121、commit `feb41b5`)。次のステップ:
+A2-1 / A2-4 / A2-5 マージ済 (PR #121 / #123 / #126)。残りステップ:
 
-1. **A2-4 (docs/ コア + runbooks 拡充)** — `docs/` のみ touch、`.claude/rules/` に依存しない。別 worktree で並走着手可
-2. **A2-2 (rules 実装・コード系本格化)** — A2-4 と並走可 (touch ファイル重複ゼロ)。別 worktree で並走着手可
-3. A2-3 (rules プロセス系) 着手は A2-2 完了後 (`.claude/rules/rules-index.md` の連続編集回避のため)
-4. A2-5 (docs/architecture + api) 着手は A2-4 完了後または並走 (`docs/` 内のサブツリーが異なれば衝突なし)
+1. **A2-2 (rules 実装・コード系本格化)** — PR #125 DRAFT 進行中 (`feature/A2-2-rules-impl`)。Ready 昇格 + code-reviewer → merge
+2. **A2-3 (rules プロセス・ハーネス・UI 系本格化)** — A2-2 完了後着手 (`.claude/rules/rules-index.md` の連続編集回避のため)
+3. EPIC-A2 完了は A2-2 / A2-3 マージ後 (4/5 → 5/5 で `completed` 昇格、別 mirror PR で記録)
+4. A3 (専用 Skill 群実装) 着手は EPIC-A2 完了後 (ADR + 本格化された rules を参照する Skill 群実装のため)
 
 ## 関連
 

--- a/docs/harness/roadmap.md
+++ b/docs/harness/roadmap.md
@@ -19,7 +19,7 @@ source_plan: docs/harness/plan.md
 |---|---|---|---|---|
 | **B0** | ブートストラップ PR | completed | `.claude/**`, `docs/**`, `.github/**`, `scripts/**` | PR #117 (2026-05-17 マージ、commit `0256be9`) |
 | **A1** | ADR 0001-0027 一括起草 | completed | `docs/adr/**` | PR [#119](https://github.com/subroh0508/colormaster/pull/119) (2026-05-17 マージ、commit `7f155b5`) |
-| **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 | in-progress | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | (EPIC-A2 で 5 PR に分割、A2-1 着手中) |
+| **A2** | `.claude/rules/*` 全ファイル本格化 + docs 全面拡充 | in-progress | `.claude/rules/**`, `docs/{architecture,api,security,requirements,specifications,runbooks}/**` | (EPIC-A2 で 5 PR に分割、A2-1 / A2-5 マージ済、残り A2-2 / A2-3 / A2-4 進行中) |
 | **A3** | 専用 Skill 群実装 PR | proposed | `.claude/skills/**` | — |
 | **A4** | ローカルポーリング機構の本格化 | proposed | `.claude/skills/pr-poller/**`, `.claude/rules/harness-meta-criteria.md` | — |
 | **A5** | 不要モジュール撤去 | proposed | `js/**`, `kotlin-js-store/**`, `public/**`, `core/network/{auth,firestore}/**`, `firebase.json`, `.firebaserc`, `web-build-and-deploy.yml` | — |
@@ -46,6 +46,7 @@ source_plan: docs/harness/plan.md
 | B0 | [#117](https://github.com/subroh0508/colormaster/pull/117) | 2026-05-17 | `.claude/{rules,skills,mcp.json,settings.json}/**`, `docs/{adr,api,architecture,design,epics,harness,requirements,runbooks,security,specifications,README.md,glossary.md,codebase-map.md,traceability.md}`, `DESIGN.md`, `.github/{pull_request_template.md,PULL_REQUEST_TEMPLATE/**}`, `scripts/install-git-hooks.sh`, `CLAUDE.md`, `AGENTS.md` |
 | A1 | [#119](https://github.com/subroh0508/colormaster/pull/119) | 2026-05-17 | `docs/adr/ADR-0001-*.md` 〜 `ADR-0027-*.md` (27 件)、`docs/adr/README.md`、`docs/plans/{PLAN-001-adr-bootstrap.md,INDEX.md}`、`docs/harness/roadmap.md` |
 | A2-1 (EPIC-A2 配下) | [#121](https://github.com/subroh0508/colormaster/pull/121) | 2026-05-17 | EPIC-A2 5 ファイル起票 (`docs/epics/EPIC-A2-rules-docs-extension/{README,roadmap,open-questions,decisions,progress}.md`)、`.claude/rules/{rules-index,template-language,mcp-usage,db-protection,commit-message,roadmap}.md`、`.claude/skills/code-reviewer/SKILL.md` Gotchas、`.github/PULL_REQUEST_TEMPLATE/{harness,feature,bugfix}.md`、`CLAUDE.md`、`docs/adr/README.md`、`docs/harness/learnings/{flaky-tests,2026-05-17-pr-117,INDEX}.md`、`docs/harness/{plan,roadmap}.md` (commit `feb41b5`) |
+| A2-5 (EPIC-A2 配下) | [#126](https://github.com/subroh0508/colormaster/pull/126) | 2026-05-17 | `docs/architecture/{overview,layers,data-flow,domain-model,state-machines,sequences,infrastructure}.md` (7) + `docs/api/{README,colormaster-api.yaml,auth,idols,me}.md` (5) を B0 skeleton (1.3-2.5KB) から 5KB+ 本格化 (合計 +2,005 行)、Mermaid 図 (graph TD/LR / flowchart TB / erDiagram / stateDiagram-v2 / sequenceDiagram x5) を全 7 architecture docs + sequences 5 ユースケースで描画、`colormaster-api.yaml` paths を 11 endpoint に拡張、`docs/epics/EPIC-A2-rules-docs-extension/{roadmap,progress}.md` 更新 (commit `168ef5d`) |
 
 (B0 は `implementation-workflow` を経由せず手動マージしたため `roadmap-tracker` の Phase 8 自動起動は発火せず、`pr-retrospective` の learning PR (`harness/learnings-batch-2026-W20`) で手動更新)
 
@@ -104,6 +105,7 @@ gantt
 | 2026-05-17 | A1 status を in-progress → completed | PR #119 (commit `7f155b5`) で ADR 0001-0027 一括起票が merge 完了、PR #120 で `roadmap-tracker` Phase 8 自動同期の手動代替を実施 |
 | 2026-05-17 | A2 status を proposed → in-progress + EPIC-A2 を 5 PR に分割 (A2-1〜A2-5) | B0 (96 files / +5408 行) のレビュー負荷上限に近く、A2 全体は B0 を超える規模が想定されるため。A1 レトロ Try「巨大 PR の aspect 並列 review における入力分割」と整合 |
 | 2026-05-17 | A2-1 (EPIC-A2 配下、初の EPIC PR) マージ完了 (PR #121、commit `feb41b5`) | A1 レトロ 15 提案中 11 件を消化、EPIC-A2 起票、rules / docs / template 索引基盤を整備。後続 A2-2 / A2-4 並走着手の前提が整う。本 PR (`harness/roadmap-mirror-a2-1`) は `roadmap-tracker` Phase 8 自動同期の手動代替 |
+| 2026-05-17 | A2-5 (EPIC-A2 配下、3 番目の merge) マージ完了 (PR #126、commit `168ef5d`) | docs/architecture 7 + docs/api 5 = 12 ファイルを B0 skeleton から 5KB+ 本格化 (+2,005 行)、ADR/plan 駆動の Option A 執筆方針で確定。code-reviewer architecture Critical 4 件を fix loop で解消、A2-4 PR #123 merge 後の rebase で衝突統合。orchestrator 委任で R-15 代替し admin override squash merge。本 mirror PR (`harness/roadmap-mirror-a2-5`) は `roadmap-tracker` Phase 8 自動同期の手動代替 (A3 で Skill 本格化まで継続) |
 
 ## 次の推奨着手 (並行実装観点)
 


### PR DESCRIPTION
## 概要

`roadmap-tracker` Skill (A3 で本格化予定) の Phase 8 自動同期の **手動代替**。A2-5 PR #126 (commit `168ef5d`) の merge 完了を `docs/epics/EPIC-A2-rules-docs-extension/{roadmap, progress}.md` と `docs/harness/roadmap.md` (全体) に反映する。

## 関連

- Epic: EPIC-A2 (`.claude/rules/*` 全ファイル本格化 + docs 全面拡充)
- 対象 PR: [#126](https://github.com/subroh0508/colormaster/pull/126) (A2-5: docs/architecture + api 拡充、squash merge commit `168ef5d`)
- ADR: ADR-0017 (ローカル Claude Code ポーリング駆動) / ADR-0027 (docs 構造)
- 元 mirror PR の前例: [#120](https://github.com/subroh0508/colormaster/pull/120) (A1) / [#122](https://github.com/subroh0508/colormaster/pull/122) (A2-1)

## PR の種別

- [x] **ロードマップ手動同期** (`harness/roadmap-mirror-*` ブランチ、`roadmap-tracker` Phase 8 自動代替)

## 変更内容

| 区分 | パス | 変更内容 |
|---|---|---|
| docs | `docs/epics/EPIC-A2-rules-docs-extension/roadmap.md` | A2-5 行 status を `in-progress → completed`、完了根拠列に PR #126 + commit `168ef5d` 記録、完了根拠表に A2-5 行追加 (docs/architecture 7 + docs/api 5 = 12 ファイル 5KB+ 本格化 / Mermaid 図全 7 + sequences 5 / OpenAPI paths 11 endpoint / code-reviewer architecture Critical 4 件 fix loop で解消の経緯を記録)、着手順変更履歴に A2-5 completed を追加、「次の推奨着手」セクションを A2-2 / A2-3 残存状態に更新 |
| docs | `docs/epics/EPIC-A2-rules-docs-extension/progress.md` | A2-5 PR #126 Ready 昇格 + merge + Phase 8 (本 mirror PR) を進捗ログに追加、マイルストーン「A2-5 マージ」を ✅ 達成 に更新 (3/5 マージ済、残り A2-2 進行中 + A2-3 未着手) |
| docs | `docs/harness/roadmap.md` (全体) | A2 行説明を「A2-1 / A2-5 マージ済、残り A2-2 / A2-3 / A2-4 進行中」に更新 (A2-4 完了反映は別 mirror PR #127 に委譲、衝突回避)、完了根拠表に A2-5 (EPIC-A2 配下) を追加、着手順変更履歴に A2-5 マージ完了を追加 |

## ハーネス改善提案件数

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 0 | 0 | 0 | 0 |
| `[skill]` | 0 | 0 | 0 | 0 |
| `[template]` | 0 | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

(本 PR は roadmap 手動同期、harness-meta / learning ベースの改修提案を持たない)

## 受け入れ基準 (AC)

- [x] AC-01: EPIC-A2 roadmap.md の A2-5 行が `completed` に遷移、完了根拠列に PR #126 と commit `168ef5d` が記録
- [x] AC-02: EPIC-A2 roadmap.md 完了根拠表に A2-5 行が追加 (主要ファイル列に docs/architecture 7 + docs/api 5 = 12 ファイル詳細を記載)
- [x] AC-03: EPIC-A2 roadmap.md 着手順変更履歴に A2-5 completed が append-only で追加 (R-34)
- [x] AC-04: EPIC-A2 progress.md にマイルストーン更新 + 進捗ログ追加 (A2-5 Ready 昇格 + merge + 本 mirror PR の 3 行)
- [x] AC-05: 全体 docs/harness/roadmap.md の A2 行説明 + 完了根拠表 + 着手順変更履歴に A2-5 を反映
- [x] AC-06: A2-4 mirror PR #127 と衝突回避: A2 行説明で「残り A2-2 / A2-3 / A2-4 進行中」と明示し、A2-4 完了反映は別 PR に委譲 (R-34 片方向ミラー)
- [x] AC-07: frontmatter は変更なし (block 形式維持、`.claude/rules/docs-structure.md` 準拠)

## テスト

- [x] markdownlint-cli2 グリーン (A6 未導入のため目視確認、表の `|` 数 / `---` 区切り行 / 列見出し統一を確認)
- [x] frontmatter `related_*` block 形式維持 (本 PR は frontmatter を変更しない)
- [x] PII redaction (`.claude/rules/pii.md`): 本 PR は roadmap 更新のみで PII を含まない、`@example.com` 外メアド / 21 桁数字 sub claim / `googleusercontent.com` URL のいずれも混入なし

## レビュー観点

- A2-4 mirror PR #127 と編集箇所が一部重なる (`docs/epics/EPIC-A2-rules-docs-extension/{roadmap, progress}.md` / `docs/harness/roadmap.md`)。merge 順序によって rebase で衝突解消が必要 (本 PR が後発なら #127 merge 後に rebase、先発なら #127 側で対応)
- A2-4 完了反映を本 PR で行わない判断 (衝突回避のため A2-4 mirror に委譲) が妥当か
- 「(A2-5 は ... 手動代替)」の merge note 段落の追加は本 PR では classifier ブロックにより未反映。orchestrator 側で手動追記するか、後続 PR で補完するかの判断

## 撤回コスト

- `git revert` で完結 (本 PR は roadmap.md / progress.md の text 編集のみ)。実装コードへの影響なし。

## チェックリスト

- [x] Conventional Commits 規約準拠 (`docs(harness): mirror A2-5 completion in roadmap`、subject 50 字以内、body 72 字でラップ)
- [x] EPIC-A2 配下 PR (A2-5 PR #126 merge の Phase 8 手動代替)
- [x] `docs/epics/EPIC-A2-rules-docs-extension/{roadmap, progress}.md` + `docs/harness/roadmap.md` 以外のサブツリーは触らない (touch ファイル分離原則)
- [x] R-15 (auto-merge 禁止) について: 本 PR は orchestrator (人間) からの merge 委任で代替する想定。ただし Claude Code 自走実行モードの classifier が `gh pr merge --squash --admin` を hard boundary 違反として denied する場合は、本 PR を OPEN 状態で留め置き、orchestrator 側から手動 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)