### PR TITLE
feat(harness): A2-3 rules プロセス・ハーネス・UI系本格化

### DIFF
--- a/.claude/rules/behavior-preservation.md
+++ b/.claude/rules/behavior-preservation.md
@@ -1,30 +1,32 @@
 ---
 id: rules-behavior-preservation
 title: リファクタ時の振る舞い維持原則
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "feature/**/*.kt"
   - "core/**/*.kt"
   - "composeApp/**/*.kt"
   - "docs/design/inventory/**"
-related_plan: docs/harness/plan.md §3.9 / ADR 0023
 related_adrs:
   - ADR-0023
+related_plan: docs/harness/plan.md §3.9 / §6.2 A9 / A10 / §6.3 Phase C / R-22
 ---
 
 # behavior-preservation.md — リファクタ時の振る舞い維持原則
 
 > Phase C で大規模リファクタ (EPIC-001 〜 EPIC-006) を行う際に、ユーザーから見える振る舞い
 > (UI / API レスポンス / 状態遷移) を変えないことを保証する規約。
-> `code-reviewer` の visual-regression と spec-conformance の二本柱で検証する。
+> `code-reviewer` の visual-regression と spec-conformance の二本柱で検証する (ADR 0023)。
 
 ## 二本柱
 
-| 検証軸 | 担当 aspect | 担保するもの |
-|---|---|---|
-| **Visual regression** | `code-reviewer` visual-regression aspect (A10 完了後 enable) | UI 見た目の不変性 (Roborazzi baseline diff) |
-| **Spec conformance** | `code-reviewer` spec-conformance aspect | 機能仕様の不変性 (`@Spec` + Acceptance criteria が全て pass) |
+| 検証軸 | 担当 aspect | 担保するもの | enable 時期 |
+|---|---|---|---|
+| **Visual regression** | `code-reviewer` visual-regression aspect | UI 見た目の不変性 (Roborazzi baseline diff) | A10 完了後 |
+| **Spec conformance** | `code-reviewer` spec-conformance aspect | 機能仕様の不変性 (`@Spec` + Acceptance criteria が全て pass) | A7 完了後 (現状は手動代替) |
+
+詳細は `.claude/rules/code-reviewer-aspects.md` 参照。
 
 ## リファクタの定義 (Phase C)
 
@@ -34,32 +36,94 @@ related_adrs:
 - UI レイアウトの変更 (色 / 余白 / フォントサイズ含む)
 - 状態遷移の追加・削除
 - エラーメッセージの変更
+- アニメーション速度 / イージング曲線の変更
 
-これらが必要なときは `feat` / `fix` で別 Plan / Epic を立てる。
+これらが必要なときは `feat` / `fix` で別 Plan / Epic を立てる (`branch-naming.md` / `pr-template.md` と整合)。
 
 ## Phase C リファクタの順序
 
 1. **A10 で凍結**: DESIGN.md + UI Inventory + Roborazzi baseline で現状を記録
 2. **Phase C で構造変更**: リファクタ Plan / Epic を実装
 3. **検証**: `./gradlew check` + `./gradlew verifyRoborazziDebug` + `code-reviewer` の visual-regression / spec-conformance aspect が全て green
-4. **PR description に "Behavior Preservation 証拠" を必須化** (§4.8.3 refactor type)
+4. **PR description に "Behavior Preservation 証拠" を必須化** (`pr-template.md` refactor.md セクション参照)
+
+## Behavior Preservation 証拠の必須セクション (refactor PR)
+
+PR description に以下を必ず含める (`pr-template.md` refactor.md 規約):
+
+```markdown
+## Behavior Preservation 証拠
+
+### Visual regression (Roborazzi)
+
+- [x] `./gradlew verifyRoborazziDebug` 完走 (4 パターン × N 画面)
+- [x] baseline diff = 0 (意図的更新なし)
+- [x] (意図的更新あり) PR description「visual regression 意図的更新」セクションに更新内容と理由を記載
+
+### Spec conformance
+
+- [x] 既存 `@Spec` annotation 全件 pass
+- [x] SPEC 本体 (`docs/specifications/{basic,detail}/*.md`) に変更なし
+- [x] (spec-living-sync 発動なし) PR description「仕様変更箇所」セクション = N/A
+
+### 手動検証 (refactor PR で実施)
+
+- [x] 主要画面 (Home / Search / Preview / MyIdols) で目視動作確認 (mobile / desktop × Light / Dark)
+- [x] 状態遷移 (Empty → Loading → Loaded / PartiallyLoaded / Error) 全パターン目視確認
+- [x] アクセシビリティ (TalkBack / VoiceOver) 主要画面で動作確認
+```
+
+## リファクタ前後の検証チェックリスト
+
+- [ ] 触る予定のコードに対応する Inventory ファイル (`docs/design/inventory/`) が存在
+- [ ] 既存 `@Spec` annotation 一覧を grep で取得、リファクタ後も同じ SPEC-ID を pass
+- [ ] Roborazzi baseline 4 パターン × N 画面が PR 起票前に存在
+- [ ] `code-reviewer` visual-regression aspect の binary checklist 5 項目を確認 (`code-reviewer-aspects.md`)
+- [ ] `code-reviewer` spec-conformance aspect の binary checklist 7 項目を確認
+- [ ] PR description Behavior Preservation 証拠セクション 3 ブロック全て記入
+- [ ] `pr-template.md` refactor.md テンプレ選択 (`gh pr create --template refactor.md`)
+- [ ] `branch-naming.md` `refactor/<slug>` または `feature/EPIC-NNN-*-pr-NN` (Epic 配下) ブランチ命名
 
 ## 例外的に baseline 更新を許可するケース
 
-- A10 凍結時点でバグがあった UI の修正 (PR description に修正理由を明記、別 Plan で実施)
-- アクセシビリティ改善 (contentDescription 追加等、visual diff 無し)
-- パフォーマンス改善 (アニメーション最適化等、目視で同じに見える)
+| ケース | 説明 | 対応 |
+|---|---|---|
+| **A10 凍結時点でバグがあった UI の修正** | 凍結後に判明したバグの修正 | PR description に修正理由を明記、別 Plan で実施 (`fix/<slug>`) |
+| **アクセシビリティ改善** | contentDescription 追加等、visual diff 無し | visual-regression は false-positive を出すため `changeThreshold` 緩和 + 意図的更新明示 |
+| **パフォーマンス改善** | アニメーション最適化等、目視で同じに見える | 同上、Roborazzi `changeThreshold` 緩和 + 意図的更新明示 |
+| **フォントレンダリング差** | OS バージョン更新等で発生する微差 | `changeThreshold = 0.01` 範囲内で許容、超過時は意図的更新明示 |
 
-これらは visual-regression が false-positive を出すため、PR description で意図的更新と明示 + human approve 必須。
+これらは visual-regression が false-positive を出すため、PR description で意図的更新と明示 + human approve 必須 (`merge-readiness.md` 3 条件と整合)。
+
+## A10 完了前のリファクタ制約
+
+- **A10 完了前のリファクタは behavior preservation 検証ができない** (Roborazzi baseline 不在のため)、Phase C 着手前提条件として A10 完了が必須 (R-22)
+- A10 完了前に行うリファクタは:
+  - **本質的に不可逆な構造変更を避ける** (例: モジュール削除、API スキーマ変更)
+  - **可逆な内部リファクタのみ** (例: private 関数の分割、命名変更)
+  - **spec conformance は A7 完了後** に厳格化 (現状は手動代替で `@Spec` 整合確認)
+
+## 機械検証 (A6 + A7 + A10 で段階導入)
+
+- **A6**: Konsist で `refactor.md` テンプレ選択 PR の touch ファイル種別を検証 (Kotlin source / config / docs 比率の妥当性)
+- **A7**: `code-reviewer` spec-conformance aspect で `@Spec` 整合を機械化
+- **A10**: `code-reviewer` visual-regression aspect で Roborazzi baseline diff の `changeThreshold` 内完走を機械化
+- **A10**: PR description「Behavior Preservation 証拠」セクション 3 ブロック全記入を GitHub Actions で check (Gradle カスタムタスク連携)
 
 ## Gotchas
 
-- **A10 完了前のリファクタは behavior preservation 検証ができない**ため、Phase C 着手前提条件として A10 完了が必須 (R-22)
-- spec-conformance も A10 と並行して `docs/specifications/basic/SPEC-NNN-*.md` の逆生成 (A9) が必要
-- リファクタで「ついでに API レスポンスを変える」を絶対許可しない (PR を分割する)
+- **A10 完了前のリファクタは behavior preservation 検証ができない**、Phase C 着手前提条件として A10 完了が必須 (R-22)
+- **spec-conformance も A10 と並行して `docs/specifications/basic/SPEC-NNN-*.md` の逆生成 (A9) が必要**: A9 完了後に SPEC docs が揃い、spec-conformance aspect の厳格化が成立
+- **リファクタで「ついでに API レスポンスを変える」を絶対許可しない**: PR を分割 (`refactor/<slug>` + `feat/<slug>`)、 commit message も分離
+- **Behavior Preservation 証拠セクション 3 ブロック全記入**: 「N/A」明示も許容 (空欄禁止)、CI 必須化は A10 完了後
+- **アクセシビリティ改善は visual diff なし** だが PR description に明示 (false-positive 抑制と監査可能性の両立)
+- **`changeThreshold` 緩和は core 画面で 0.02 まで、補助コンポーネントで 0.05 まで**: 過剰緩和は visual regression 検出力を失う
+- **A10 完了前の可逆リファクタ**: モジュール削除 / API スキーマ変更 / DB マイグレーション等の不可逆操作を避け、内部命名変更 / private 関数分割等に限定
 
 ## 関連
 
-- ADR 0023 (UI 凍結三本柱)
-- `docs/harness/plan.md` §3.9 / §6.2 A9 / A10 / §6.3 Phase C
-- `.claude/rules/{ui-snapshot,ui-inventory,design-tokens,code-reviewer-aspects}.md`
+- ADR 0023 (UI 凍結三本柱: DESIGN.md + UI Inventory + Roborazzi baseline)
+- `docs/harness/plan.md` §3.9 / §6.2 A9 / A10 / §6.3 Phase C / R-22
+- `.claude/rules/{ui-snapshot,ui-inventory,design-tokens,code-reviewer-aspects,pr-template,branch-naming,spec-living-sync,coverage-100,spec-traceability}.md`
+- `.claude/skills/{ui-snapshot,code-reviewer}/SKILL.md`
+- `docs/design/inventory/` (UI Inventory 配置先)

--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -74,7 +74,7 @@ related_plan: docs/harness/plan.md §4.7 / §5.4.2
 | ハーネス改修 / レトロ起票 / mirror | `harness/<purpose>` | `harness.md` | `feat` / `docs` (scope `harness`) |
 | 雑務 | `chore/<purpose>` | `feature.md` を流用 (chore 専用テンプレなし) | `chore` |
 
-## 自動検証 (A6 で導入予定)
+## 機械検証 (A6 で導入予定)
 
 - **Git hook (`scripts/install-git-hooks.sh` 拡張)**: `pre-push` で現在ブランチが正規表現 `^(feature|fix|refactor|docs|chore|harness|epic|renovate|master|main)/.+$` (または `master` / `main` 自体) に合致するかチェック
 - **GitHub Actions**: PR open 時に `head_ref` を検証、`branch-naming.md` の prefix allow リストに合致しない場合は warning コメント (A6 / detekt 導入と同時)

--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -1,0 +1,98 @@
+---
+id: rules-branch-naming
+title: ブランチ命名規約 (feature / epic / harness / chore / fix / docs)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".claude/skills/implementation-workflow/**"
+  - "scripts/install-git-hooks.sh"
+related_adrs:
+  - ADR-0017
+  - ADR-0018
+related_plan: docs/harness/plan.md §4.7 / §5.4.2
+---
+
+# branch-naming.md — ブランチ命名規約
+
+> 本リポジトリで作成する全ブランチは `<種別>/<ID or purpose>-<slug>` 形式で命名する。
+> `implementation-workflow` Phase 0 (`git worktree add` + `-b`) でこの規約に従い
+> worktree path も自動導出する (`branch-slug` への変換ルール参照)。
+
+## 種別 prefix 一覧
+
+| prefix | 用途 | ID / purpose | スラグ例 |
+|---|---|---|---|
+| `feature/` | 単一機能 Plan (`type: feature-request`) / Epic 配下 PR | `PLAN-NNN-<slug>` / `EPIC-NNN-<slug>-pr-NN` | `feature/PLAN-007-add-search` / `feature/A2-3-rules-process` |
+| `epic/` | Epic 配下 PR (旧形式、`feature/EPIC-NNN-*` への移行を推奨) | `EPIC-NNN-<slug>-pr-NN` | `epic/EPIC-001-feature-restructure-pr-01` |
+| `fix/` | バグ修正 Plan (`type: bug-fix`) | `PLAN-NNN-<slug>` または `<slug>` | `fix/PLAN-012-search-flaky` |
+| `refactor/` | リファクタ Plan (`type: refactor`) | `PLAN-NNN-<slug>` | `refactor/PLAN-020-extract-repo` |
+| `docs/` | docs 単独 Plan (`type: docs`) | `PLAN-NNN-<slug>` | `docs/PLAN-005-adr-bootstrap` |
+| `harness/` | ハーネス改修・レトロ起票・ロードマップ mirror | `<purpose>` (自由形) | `harness/learnings-batch-2026-W20` / `harness/roadmap-mirror-a2-4` |
+| `chore/` | 軽微な雑務 (`.gitignore` 更新、設定ファイル等) | `<purpose>` (自由形) | `chore/install-git-hooks` |
+| `dependency/` | Renovate 系 (将来検討、現状は `renovate/*` が Renovate 側で自動付与) | — | `renovate/koin-major` (Renovate 自動) |
+
+## ID と slug の構築規約
+
+- **ID 部**: `PLAN-NNN` / `EPIC-NNN` / フェーズ ID (`A2-3`) を **大文字 + ハイフン** で記述、ゼロパディングを保持
+- **slug 部**: kebab-case (小文字 + ハイフン)、動詞は省略可、要件のキーワードを含める
+- **長さ**: ブランチ名全体で **60 文字以内推奨、80 文字 hard limit** (GitHub UI 表示の閾値)
+- **禁止文字**: 半角スペース / `_` / 大文字英字 (ID 部除く) / `\` / `:` / `?` / `*` / `[` / `]` / 日本語
+
+例:
+
+| ✅ OK | ❌ NG |
+|---|---|
+| `feature/PLAN-007-add-search-by-brand` | `feature/PLAN-007-Add Search By Brand` (空白 / 大文字) |
+| `epic/EPIC-001-feature-restructure-pr-03` | `epic/epic-001-feature-restructure-pr-3` (ID 小文字 / ゼロパディングなし) |
+| `harness/roadmap-mirror-a2-4` | `harness/roadmap_mirror_a2_4` (アンスコ) |
+| `feature/A2-3-rules-process` | `feature/A2.3-rules-process` (ドット) |
+
+## worktree path 規約 (slug 導出)
+
+- worktree path: `../<repo-name>-worktrees/<branch-slug>`
+- `<branch-slug>` はブランチ名のスラッシュをハイフンに置換した文字列
+
+| ブランチ名 | worktree path |
+|---|---|
+| `feature/PLAN-007-add-search` | `../colormaster-worktrees/feature-PLAN-007-add-search` |
+| `epic/EPIC-001-feature-restructure-pr-01` | `../colormaster-worktrees/epic-EPIC-001-feature-restructure-pr-01` |
+| `harness/roadmap-mirror-a2-4` | `../colormaster-worktrees/harness-roadmap-mirror-a2-4` |
+| `feature/A2-3-rules-process` | `../colormaster-worktrees/feature-A2-3-rules-process` |
+
+詳細は `.claude/rules/implementation-workflow.md` Phase 0 参照。
+
+## Plan / Epic ⇄ ブランチ ⇄ PR の対応
+
+| Plan / Epic 種別 | ブランチ prefix | PR テンプレ | commit type |
+|---|---|---|---|
+| Plan `type: feature-request` | `feature/PLAN-NNN-*` | `feature.md` | `feat` |
+| Plan `type: bug-fix` | `fix/PLAN-NNN-*` | `bugfix.md` | `fix` |
+| Plan `type: refactor` | `refactor/PLAN-NNN-*` | `refactor.md` | `refactor` |
+| Plan `type: dependency-upgrade` | Renovate 自動 (`renovate/*`) | `dependency-upgrade.md` | `chore` / `build` |
+| Plan `type: docs` | `docs/PLAN-NNN-*` | `docs.md` | `docs` |
+| Epic 配下 PR | `feature/EPIC-NNN-*-pr-NN` または `feature/<phase-id>-<slug>` | Epic 性質に応じて (`feature.md` / `harness.md` 等) | Epic 性質に応じて |
+| ハーネス改修 / レトロ起票 / mirror | `harness/<purpose>` | `harness.md` | `feat` / `docs` (scope `harness`) |
+| 雑務 | `chore/<purpose>` | `feature.md` を流用 (chore 専用テンプレなし) | `chore` |
+
+## 自動検証 (A6 で導入予定)
+
+- **Git hook (`scripts/install-git-hooks.sh` 拡張)**: `pre-push` で現在ブランチが正規表現 `^(feature|fix|refactor|docs|chore|harness|epic|renovate|master|main)/.+$` (または `master` / `main` 自体) に合致するかチェック
+- **GitHub Actions**: PR open 時に `head_ref` を検証、`branch-naming.md` の prefix allow リストに合致しない場合は warning コメント (A6 / detekt 導入と同時)
+- **JetBrains MCP**: rename refactoring で生成されるブランチ名候補に上記 prefix を提案 (将来検討)
+
+## Gotchas
+
+- **`master` / `main` 直 push 禁止**: 全変更は PR 経由 (R-15 と整合、GitHub branch protection 併用予定 A6)
+- **長すぎるブランチ名**: 80 文字超過時は slug 部を短縮、PR description に full slug を記載
+- **ブランチ命名と Conventional Commits type の整合**: `feature/` ↔ `feat`、`fix/` ↔ `fix`、`refactor/` ↔ `refactor`、`docs/` ↔ `docs`、`chore/` ↔ `chore`、`harness/` は `feat(harness)` / `docs(harness)` のいずれかを subject に明示
+- **Renovate ブランチは Renovate 側で自動命名** (`renovate/<package>-<version>`)、本 rule の prefix allow リストに含める
+- **EPIC 配下 PR のブランチは `feature/EPIC-NNN-*-pr-NN` または `feature/<phase-id>-<slug>`** (実例: EPIC-A2 配下は `feature/A2-1-*` / `feature/A2-2-*` / ... を採用)
+- **mirror PR (`roadmap-tracker` Phase 8 自動同期の手動代替) は `harness/roadmap-mirror-<phase-id>`** を慣例 (A2-2 / A2-4 / A2-5 mirror の実績)
+
+## 関連
+
+- ADR 0017 (ローカル Claude Code ポーリング駆動、ブランチ運用の位置付け)
+- ADR 0018 (`implementation-workflow` 10 フェーズ設計)
+- `docs/harness/plan.md` §4.7 / §5.4.2
+- `.claude/rules/{implementation-workflow,commit-message,plan,epic,pr-template}.md`
+- `scripts/install-git-hooks.sh` (Git hook 実装、A6 で `pre-push` 拡張予定)

--- a/.claude/rules/code-reviewer-aspects.md
+++ b/.claude/rules/code-reviewer-aspects.md
@@ -1,90 +1,215 @@
 ---
 id: rules-code-reviewer-aspects
 title: code-reviewer 8 aspect の binary eval checklist と Coordinator 形式
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - ".claude/skills/code-reviewer/**"
-related_plan: docs/harness/plan.md §5.3 / §5.4.3 / ADR 0019
+related_adrs:
+  - ADR-0017
+  - ADR-0019
+related_plan: docs/harness/plan.md §5.3 / §5.4.3 / R-13 / R-37
 ---
 
 # code-reviewer-aspects.md — 8 aspect 規約
 
-> `code-reviewer` Skill の 8 aspect (spec-conformance / test-quality / architecture / security /
-> performance / code-quality / visual-regression / design-tokens) のチェック項目と
-> Coordinator のレビューコメント形式を規定。詳細実装は A3 で本格化。
+> `code-reviewer` Skill の 8 aspect (`spec-conformance` / `test-quality` / `architecture` /
+> `security` / `performance` / `code-quality` / `visual-regression` / `design-tokens`) の
+> binary yes/no eval checklist と Coordinator のレビューコメント形式を規定。
+> 各 aspect は **独立した system prompt** で動作 (R-13、Generator バイアス回避)。
 
 ## 8 aspect 概要
 
 | aspect | 状態 | system prompt の独立観点 |
 |---|---|---|
-| `spec-conformance` | B0 雛形 / A3 本格化 | `@Spec` annotation の存在、SPEC-ID 整合性、frontmatter `related_specs` 有効性、設計書 ⇄ 実装の対応 |
-| `test-quality` | 同上 | 差分カバレッジ 100%、Spec coverage 差分 100%、mutation score 妥当性、tautological テスト検出 |
-| `architecture` | 同上 | レイヤー依存方向 (feature → core → repository)、モジュール越境、命名規約、循環依存検出 |
-| `security` | 同上 | PII redaction、secrets 取り扱い、認証境界 (`requireUid()` 強制)、Konsist 規約準拠 |
-| `performance` | 同上 | N+1 クエリ、無駄な再描画 (`derivedStateOf`, `remember` 漏れ)、coroutine スコープ、不要な hot reload |
-| `code-quality` | 同上 | error-handling (Result 型ラップ徹底)、命名規約、可読性、defensive 過剰禁止 |
+| `spec-conformance` | active (A3 前は手動代替) | `@Spec` annotation の存在、SPEC-ID 整合性、frontmatter `related_specs` 有効性、設計書 ⇄ 実装の対応 |
+| `test-quality` | active (A3 前は手動代替) | 差分カバレッジ 100%、Spec coverage 差分 100%、mutation score 妥当性、tautological テスト検出 |
+| `architecture` | active (A3 前は手動代替) | レイヤー依存方向 (feature → core → repository)、モジュール越境、命名規約、循環依存検出 |
+| `security` | active (A3 前は手動代替) | PII redaction、secrets 取り扱い、認証境界 (`requireUid()` 強制)、Konsist 規約準拠 |
+| `performance` | active (A3 前は手動代替) | N+1 クエリ、無駄な再描画 (`derivedStateOf`, `remember` 漏れ)、coroutine スコープ、不要な hot reload |
+| `code-quality` | active (A3 前は手動代替) | error-handling (Result 型ラップ徹底)、命名規約、可読性、defensive 過剰禁止 |
 | `visual-regression` | **A10 完了後 enable** | Roborazzi baseline diff (4 パターン: mobile/desktop × Light/Dark)、許容 threshold 内 |
 | `design-tokens` | **A10 完了後 enable** | DESIGN.md に存在しない hex / sp / dp の混入なし、Primitive/Semantic/Component 3 階層整合 |
 
-## 各 aspect の binary yes/no eval checklist (最低 5 項目)
+## 各 aspect の binary yes/no eval checklist (各 ≥5 項目、R-13)
 
-各 aspect は **binary yes/no eval checklist を最低 5 項目** 持つ (R-13)。
-詳細は A3 で各 aspect 個別ファイルとして拡充予定 (`.claude/rules/code-reviewer-aspects/<aspect>.md` の分割案)。
-B0 時点では本ファイルにまとめ、A3 で分割する。
+PR #121 レトロ Try「binary checklist 4 aspect × 7-8 項目 = 29 項目を A3 本格化時に確定」を反映。
+本 rule で各 aspect の **最低 5 項目、推奨 7-8 項目** を確定。
 
-### 例: spec-conformance
+### spec-conformance (7 項目)
 
-- [ ] 新規追加・変更 Kotlin 行に対応する `@Spec("SPEC-NNN-N")` annotation がテスト側に存在
+- [ ] 新規追加・変更 Kotlin 行に対応する `@Spec("SPEC-NNN-N")` annotation がテスト側に存在 (A7 完了前は warning)
 - [ ] `@Spec` で参照される SPEC-ID が `docs/specifications/{basic,detail}/` に実在
 - [ ] PR description frontmatter `related_specs` の SPEC-ID が実在
 - [ ] 基本設計 ⇄ 詳細設計の `related_basic` / `related_detail` ペアが整合
-- [ ] 設計書本文にコード断片が混入していない (フェンス付き `kotlin/sh/sql` 等)
+- [ ] 設計書本文にコード断片が混入していない (フェンス付き `kotlin/sh/sql` 等、`docs-structure.md` §4.6)
+- [ ] frontmatter 配列が block 形式 (flow 形式 `[A, B]` が混入していない、`docs-structure.md` frontmatter 規約)
+- [ ] spec-living-sync 発動時は PR description「仕様変更箇所」セクションに記載 (`spec-living-sync.md`)
+
+### test-quality (7 項目)
+
+- [ ] 差分 Line / Branch coverage が 100% (Kover 出力、A7 完了前は N/A 明記で skip 妥当)
+- [ ] 差分 Spec coverage が 100% (Konsist `@Spec` カバー率、A7 完了前は N/A)
+- [ ] mutation score が前回値以上 (PITest、A7 完了前は N/A)
+- [ ] tautological / trivial テストが含まれていない (`assertEquals(x, x)` 等)
+- [ ] テスト fixture のメールアドレスが `@example.com` ドメイン (`.claude/rules/pii.md`)
+- [ ] Kotest DescribeSpec の `describe` / `it` 階層が `.claude/rules/kotlin-test.md` 規約に準拠
+- [ ] `runTest` / `Dispatchers.setMain` が coroutine テストで適切に使用されている
+
+### architecture (7 項目)
+
+- [ ] レイヤー依存方向が `feature → core → repository → network` に従う (逆方向依存ゼロ)
+- [ ] モジュール越境 (`feature/A` から `feature/B` の internal 参照等) がない
+- [ ] 命名規約 (`.claude/rules/naming.md`) 準拠 (Composable は `*Screen` / `*Section`、ViewModel は `*ViewModel`、UiState は `*UiState`)
+- [ ] 循環依存ゼロ (Konsist 検出、A6 で機械化)
+- [ ] SoT (`docs/harness/plan.md` / ADR / `.claude/rules/*`) との矛盾なし (A1 レトロ Problem #1 / PR #121 plan.md L1125 と同様の latent contradiction 検出)
+- [ ] 新規 ADR 起票基準 (`adr.md` §起票基準) を 2 項目以上満たすアーキ変更時は ADR が起票されている
+- [ ] `rules-index.md` の status 表記が rule 実体と一致 (PR #117 「既存」誤宣言 13+ 件と同様の drift 検出)
+
+### security (7 項目)
+
+- [ ] PII (メール / display name / GIS avatar URL / IP / sub claim) が code / docs / PR description / commit message に混入していない (`.claude/rules/pii.md` redaction)
+- [ ] secrets (API key / token / password / AWS access key / GitHub PAT / JWT) が混入していない (`.claude/rules/secrets.md` redaction)
+- [ ] `users.db` / `service-account*.json` / `.env*` / `.claude/oauth-tokens*` が `.gitignore` 対象であり、commit に含まれていない (`.claude/rules/db-protection.md`)
+- [ ] 認証境界 (`requireUid()`) が backend API endpoint で強制されている (`.claude/rules/backend-auth.md`)
+- [ ] Konsist の Firebase 検出が 0 件 (`.claude/rules/{no-firebase,firebase-boundary}.md`)
+- [ ] Dockerfile に `COPY data/users.db` パターンがない (`.claude/rules/db-protection.md`)
+- [ ] `.dockerignore` が 5 必須項目 (`data/users.db*` / `.env*` / `*-credentials.json` / `service-account*.json` / `.claude/oauth-tokens*`) を含む (A6 で機械化、Dockerfile 配置時)
+
+### performance (5 項目)
+
+- [ ] N+1 クエリパターンがない (SQL / SPARQL、`.claude/rules/{sql-delight,sparql}.md`)
+- [ ] Compose の無駄な再描画がない (`remember` 漏れ / `derivedStateOf` 未使用 / `mutableStateOf` の hoisting)
+- [ ] coroutine スコープが適切 (`viewModelScope` / `lifecycleScope`、leaking なし)
+- [ ] 不要な hot reload (Compose Desktop) が発生していない (`@Stable` / `@Immutable` 適切付与)
+- [ ] 大量データ処理時に `Flow` / `Channel` の backpressure が適切に処理されている
+
+### code-quality (7 項目)
+
+- [ ] `Result<T>` / `runCatching` の error-handling が徹底 (`.claude/rules/error-handling.md`)
+- [ ] 命名規約 (`.claude/rules/naming.md`) 準拠
+- [ ] 可読性 (1 関数 50 行以内推奨、cyclomatic complexity 10 以下)
+- [ ] defensive 過剰禁止 (フレームワーク保証範囲内の null チェック / バリデーション禁止、`docs/harness/plan.md` §システム指示原則)
+- [ ] コメントは WHY のみ (WHAT を説明するコメント禁止、CLAUDE.md システム指示準拠)
+- [ ] Markdown フェンス言語指定必須 (MD040、A6 で markdownlint-cli2 機械化)
+- [ ] 日本語見出し / template-language 規約準拠 (ADR 0027 / `.claude/rules/{template-language,markdown}.md`)
+
+### visual-regression (5 項目、A10 完了後 enable)
+
+- [ ] 4 パターン baseline (mobile/desktop × Light/Dark) が `docs/design/inventory/screenshots/` に存在
+- [ ] Roborazzi diff が `changeThreshold` 内 (誤検出抑制、`.claude/rules/ui-snapshot.md`)
+- [ ] 意図的更新時は PR description に「visual regression 意図的更新」明記
+- [ ] wasmJs 固有 actual は対象外 (`.claude/rules/wasm-compat.md` R-24)
+- [ ] アニメーション停止 + 代表 brand color 固定の Preview パラメータ使用
+
+### design-tokens (5 項目、A10 完了後 enable)
+
+- [ ] Kotlin / Compose code に hex (`#XXXXXX` / `0xFFXXXXXX`) のハードコードなし (Konsist 検出)
+- [ ] `sp` / `dp` の固定値がデザイントークン経由
+- [ ] `Color.Red` 等の Material 直接参照なし (テーマ非対応回避)
+- [ ] DESIGN.md の Primitive 値以外を実コードから参照していない
+- [ ] テストコード (`*Test.kt` / `*Spec.kt`) と Roborazzi baseline 用 Preview パラメータは例外
 
 ## Coordinator の役割
 
 - 各 aspect の binary yes/no eval 結果を集約
 - 重複指摘を排除し、重要度別 (Critical / Improvement) に整理
-- 日本語の構造化レビューコメントを PR に post (§5.5 例)
-- Merge readiness を判定: **Critical = 0 で Ready**
+- 日本語の構造化レビューコメントを PR に post (下記フォーマット)
+- Merge readiness を判定: **Critical = 0 で Ready** (`merge-readiness.md` 3 条件と整合)
+- PR コメント post 前に `.claude/rules/pii.md` / `.claude/rules/secrets.md` redaction を必ず通す (R-26)
 
-## Coordinator のレビューコメント形式 (§5.5 例)
+## Coordinator のレビューコメント形式
 
 ```markdown
 ## 🔍 AI コードレビュー
 
 > 生成: code-reviewer Skill (vX.Y.Z) at YYYY-MM-DDTHH:MM:SSZ
 > 並列実行した aspect: spec-conformance, test-quality, architecture, security, performance, code-quality
+> Skip aspect: visual-regression / design-tokens (A10 完了後 enable)
 
 ### サマリ
+
 | 観点 | 結果 | 重大な指摘 | 改善提案 |
 |---|---|---|---|
 | 仕様適合性 (spec-conformance) | ✅ 合格 | 0 | 0 |
-| ...
+| テスト品質 (test-quality) | ✅ 合格 | 0 | 2 |
+| アーキテクチャ (architecture) | ❌ 不合格 | 1 | 3 |
+| セキュリティ (security) | ✅ 合格 | 0 | 1 |
+| パフォーマンス (performance) | — | — | — (skip) |
+| コード品質 (code-quality) | ✅ 合格 | 0 | 2 |
 
-### マージ可否: ✅ 可 | ❌ まだ不可
+### マージ可否: ❌ まだ不可
+
 ### 重大な指摘 (merge ブロック)
-1. **[aspect]** `path:line` — 説明
+
+1. **[architecture]** `core/data/Repository.kt:42` — 説明
    - 修正案: ...
 
 ### 改善提案 (non-blocking)
-- ...
+
+- **[test-quality]** `feature/home/HomeViewModelSpec.kt:15` — 説明
 
 ### Eval チェックリスト (binary yes/no)
-- [x] 仕様適合性: 全 Acceptance criteria に @Spec タグ付きテストが存在
-- [ ] ...
+
+#### spec-conformance (7/7 ✅)
+- [x] 新規追加・変更 Kotlin 行に対応する `@Spec` annotation がテスト側に存在
+- [x] `@Spec` で参照される SPEC-ID が実在
+- [x] PR description frontmatter `related_specs` が実在
+- [x] 基本設計 ⇄ 詳細設計の `related_*` ペア整合
+- [x] 設計書本文にコード断片混入なし
+- [x] frontmatter 配列が block 形式
+- [x] spec-living-sync 発動時の記載
+
+#### architecture (6/7 ❌、1 件 Critical)
+- [x] レイヤー依存方向に従う
+- [ ] **モジュール越境ゼロ** — `feature/home` から `feature/search/internal` を import (Critical)
+- [x] 命名規約準拠
+- [x] 循環依存ゼロ
+- [x] SoT 矛盾なし
+- [x] ADR 起票基準充足
+- [x] rules-index status 整合
+
+(...他 aspect 略)
+
+### 人間レビュアー向け文言
+
+> AI レビューの指摘で十分でしょうか? `architecture` aspect の Critical 1 件を解消した上で、
+> 追加で確認すべき観点があればコメントください。`Critical = 0` 充足後に Ready 昇格します。
 ```
+
+## fix loop 上限 (`implementation-workflow.md` R-14 と整合)
+
+- code-reviewer Critical 修正の fix loop 上限: **3 回**
+- 超過時は Plan / Epic decisions.md に `status: blocked` を記録し人間に通知
+- fix loop 中の中間 commit は squash merge で集約されるため粒度を気にしすぎない (`pr-draft-policy.md` 参照)
+
+## 機械検証 (A6 + A10 で段階導入)
+
+- **A6**: Konsist で `@Spec` annotation の SPEC-ID 実在検証、Kotlin source の Firebase 検出 0 件、命名規約準拠、レイヤー依存方向検証
+- **A6**: Gradle カスタムタスクで Markdown frontmatter 必須キー / 5 行 summary / 日本語見出し検証
+- **A10**: `visual-regression` / `design-tokens` aspect の Coordinator 並列起動対象追加、Roborazzi diff の `changeThreshold` 確定、`.claude/rules/design-tokens.md` 検出パターン Konsist 化
+
+## A10 完了後 enable 手順 (4 ステップ)
+
+1. **DESIGN.md + UI Inventory + Roborazzi baseline の生成完了確認** (A10 完了マイルストーン)
+2. **`code-reviewer/SKILL.md` の aspect status を更新**: `visual-regression` / `design-tokens` を `A10 完了後 enable` → `active`
+3. **Coordinator 並列起動対象に追加**: `code-reviewer` Skill の system prompt + サブエージェント起動コマンド更新
+4. **binary checklist 各 5 項目の確定**: 本 rule §visual-regression / §design-tokens の項目を Coordinator が parse して機械検証
 
 ## Gotchas
 
-- **各 aspect は独立した system prompt** で動作 (Generator バイアス回避、R-13)。
-- **Claude API への直接呼び出しは禁止**、ローカル Claude Code のサブエージェントで並列実行 (R-37)。
-- **Critical = 0 のみ Ready 昇格**、Improvement は non-blocking。
-- **人間レビュアーには「code-reviewer の指摘で十分か?」を考えさせる文言** を PR コメントに含める (R-15)。
+- **各 aspect は独立した system prompt** で動作 (Generator バイアス回避、R-13)
+- **Claude API への直接呼び出しは禁止**、ローカル Claude Code のサブエージェントで並列実行 (R-37 / ADR 0017)
+- **Critical = 0 のみ Ready 昇格**、Improvement は non-blocking
+- **人間レビュアーには「code-reviewer の指摘で十分か?」を考えさせる文言** を PR コメントに含める (R-15、上記フォーマット参照)
+- **PR コメント post 前に PII / secrets redaction を必ず通す** (R-26、`.claude/rules/pii.md` / `secrets.md`)
+- **harness PR の既定 4 aspect** (`spec-conformance` / `architecture` / `security` / `code-quality`) で十分、他 4 aspect は skip 妥当な場合が多い (A2-1 / A2-2 / A2-4 / A2-5 実績)
+- **mirror PR は spec-conformance / architecture / security の 3 aspect で十分** (`merge-readiness.md` Gotchas)
 
 ## 関連
 
-- `docs/harness/plan.md` §5.4.3
+- ADR 0017 (ローカルポーリング駆動、サブエージェント並列実行)
 - ADR 0019 (`code-reviewer` 8 aspect + Coordinator)
+- `docs/harness/plan.md` §5.4.3 / R-13 / R-37
 - `.claude/skills/code-reviewer/SKILL.md`
-- `.claude/rules/merge-readiness.md` (A3 で本格化)
+- `.claude/rules/{merge-readiness,pr-draft-policy,implementation-workflow,pii,secrets,naming,spec-traceability,coverage-100,mutation-testing,design-tokens,ui-snapshot,behavior-preservation}.md`

--- a/.claude/rules/commit-message.md
+++ b/.claude/rules/commit-message.md
@@ -1,7 +1,7 @@
 ---
 id: rules-commit-message
 title: コミットメッセージ規約 (Conventional Commits)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "scripts/install-git-hooks.sh"
@@ -17,7 +17,8 @@ related_adrs:
 > Conventional Commits ベース。Renovate `extends: [:semanticCommits]` と整合し、
 > 機械検証 (`scripts/install-git-hooks.sh` 配置の `.git/hooks/commit-msg`) で強制する。
 > 詳細仕様は `docs/harness/plan.md` §4.7 を Single Source of Truth とする。
-> **本ファイルは A2-1 で新規作成、A2-3 で本格化予定**。
+> A2-1 で新規作成、**A2-3 で subject 言語ポリシーを本文セクション化** (PR #121 レトロ Try
+> 「本文 vs Gotchas での『英語』記述の位置整理」反映)。
 
 ## 形式
 
@@ -52,9 +53,34 @@ related_adrs:
 | 要素 | 規約 |
 |---|---|
 | `<scope>` | 影響範囲。Skill 名 (`roadmap-tracker`)、モジュール (`core/data`)、機能領域 (`api`, `auth`)、フェーズ ID (`A6`, `A2-1`) 等。複数横断時は省略可。空 `()` は不可 |
-| `<subject>` | **英語推奨** (Phase A 期間中は日本語混在を許容、詳細は Gotchas)、現在形・命令形動詞で開始 (`Add` / `Drop` / `Fix` / `Trim` / `起草` / `消化` 等)。**72 文字以内推奨、100 文字 hard limit**、末尾ピリオドなし。固有名詞 (パス / 識別子) はそのまま |
-| `<body>` | 1 行空けて記述。「何を変えたか」より「**なぜ変えたか / どんなトレードオフを選んだか**」を主軸。日本語可 (本計画の他 Markdown と整合)。72 文字で改行推奨。複数段落可 |
+| `<subject>` | 言語ポリシーは §subject 言語ポリシー 参照。現在形・命令形動詞で開始 (`Add` / `Drop` / `Fix` / `Trim` / `起草` / `消化` 等)。**72 文字以内推奨、100 文字 hard limit**、末尾ピリオドなし。固有名詞 (パス / 識別子) はそのまま |
+| `<body>` | 1 行空けて記述。「何を変えたか」より「**なぜ変えたか / どんなトレードオフを選んだか**」を主軸。日本語可。72 文字で改行推奨。複数段落可 |
 | `<footer>` | `Refs: PLAN-NNN / EPIC-NNN / ADR-NNNN / SPEC-NNN-N` (該当時、複数可) + `Co-Authored-By: <AI モデル名> <noreply@anthropic.com>` (AI が commit した場合必須) |
+
+## subject 言語ポリシー (PR #121 レトロ Try 反映)
+
+| ポリシー | 内容 | 適用フェーズ |
+|---|---|---|
+| **英語推奨** | Conventional Commits 公式 / Renovate 自動 PR との整合 / GitHub web UI 視認性の観点から英語が望ましい | 全フェーズ通じて推奨 |
+| **Phase A 経過措置** | A1〜A10 期間中は日本語混在を許容、subject 中の英語動詞 (`add` / `drop` / `fix` 等) の代わりに日本語動詞・名詞 (`〜起草` / `〜消化` / `〜本格化` 等) を含む subject を許容 | A1〜A10 |
+| **Phase B 以降の判断** | A6 で `commit-msg` hook 拡張時に英語強制を機械検証で本格化するか再評価。一律強制が現実的でなければ `docs(harness)` / `feat(harness)` の `harness` scope のみ日本語可など段階導入も検討 | A6 着手時に再評価 |
+
+### 過去コミット実体との整合
+
+Phase A 期間中の経過措置は **過去コミットの実体に合わせる経過措置** であり、`commit-message.md` (本ファイル) を遡及的に違反扱いしないための規約:
+
+| コミット例 | 言語 | 判定 |
+|---|---|---|
+| `feat(harness): A1 ADR 0001-0027 一括起草` | 日本語混在 | ✅ Phase A 期間中許容 |
+| `feat(harness): A2-1 A1 レトロ即時消化 + EPIC-A2 起票` | 日本語混在 | ✅ 同上 |
+| `feat(roadmap-tracker): add concurrency-aware ranking` | 英語 | ✅ 推奨形式 |
+| `feat(api): drop /v1/users endpoint` | 英語 + 破壊的変更 (`!` 必須) | ❌ `!` 抜けで NG → `feat(api)!: drop /v1/users endpoint` |
+
+### body / footer は日本語可 (全フェーズ通じて)
+
+- **body**: 「なぜ変えたか / どんなトレードオフを選んだか」を主軸、日本語可
+- **footer**: `Refs: ...` / `Co-Authored-By: ...` は英語固定 (parse 規約)
+- 日本語混在 subject + 英語 footer は許容 (Phase A 経過措置の標準形)
 
 ## subject 長について (A1 レトロ Problem #9 / EPIC-A2 decisions.md)
 
@@ -110,18 +136,16 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 - **`--no-verify` で commit hook をスキップしない** (R-26 同等)。hook 失敗は新規 commit で修正、`--amend` 禁止 (Co-Authored-By が消える)
 - **Merge / Revert / fixup! / squash! コミットは検証スキップ** (`commit-msg` hook 冒頭で除外)
-- subject 言語ポリシー:
-  - **英語推奨** (Conventional Commits 公式 / Renovate 自動 PR との整合 / GitHub web UI での視認性)
-  - **Phase A (A1〜A10) 期間中は日本語混在を許容** (経過措置): 過去コミット `feat(harness): A1 ADR 0001-0027 一括起草` / `feat(harness): A2-1 A1 レトロ即時消化` 等の実体と整合。本 rule は Phase A の期間中、subject 中の英語動詞 (`add` / `drop` / `fix` 等) の代わりに日本語動詞・名詞 (`〜起草` / `〜消化` / `〜本格化` 等) を含むことを許容する
-  - **Phase B (A6 で `commit-msg` hook 拡張時) に英語強制を機械検証で本格化** する判断は A6 着手時に再評価。一律強制が現実的でなければ、`docs(harness)` / `feat(harness)` の `harness` scope のみ日本語可など段階導入も検討
-- body は日本語可。AI 駆動の場合は body にも「なぜこの判断にしたか」を残すこと (人間レビュアーが PR description だけで完結しない場合の補助情報)
-- subject 長 50 → 72/100 字緩和は A2-1 マージ時に `scripts/install-git-hooks.sh` も同時更新済 (整合性確保)
+- **subject 言語ポリシーは §subject 言語ポリシー セクションで SoT 化** (PR #121 レトロ Try 反映)、Gotchas には詳細を書かない
+- **body は日本語可**: AI 駆動の場合は body にも「なぜこの判断にしたか」を残す (人間レビュアーが PR description だけで完結しない場合の補助情報)
+- **subject 長 50 → 72/100 字緩和**: A2-1 マージ時に `scripts/install-git-hooks.sh` も同時更新済 (整合性確保)
+- **`Co-Authored-By` の機械検証** は A3 / A6 で hook 拡張時に `@noreply.anthropic.com` / `@users.noreply.github.com` のみ許可するパターン検証を追加予定 (現状は人間レビュー任せ、PR #119 レトロ Problem #11 該当)
 
 ## 関連
 
 - `docs/harness/plan.md` §4.7 (Single Source of Truth)
 - `scripts/install-git-hooks.sh` (commit-msg hook 実装)
 - ADR 0017 (ローカル Claude Code ポーリング駆動、AI コミットの位置付け)
-- ADR 0027 (テンプレート言語、subject は英語固定の例外)
-- `.claude/rules/{branch-naming,pr-template}.md` (A2-3 で本格化)
+- ADR 0027 (テンプレート言語、subject 言語ポリシーの例外)
+- `.claude/rules/{branch-naming,pr-template,template-language}.md`
 - EPIC-A2 `decisions.md` (subject 長 50 → 72/100 緩和の判断記録)

--- a/.claude/rules/design-tokens.md
+++ b/.claude/rules/design-tokens.md
@@ -1,16 +1,17 @@
 ---
 id: rules-design-tokens
 title: DESIGN.md とデザイントークン規約
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "feature/**/*.kt"
   - "core/**/*.kt"
   - "composeApp/**/*.kt"
   - "DESIGN.md"
-related_plan: docs/harness/plan.md §3.9 / ADR 0023
+  - "docs/design/**"
 related_adrs:
   - ADR-0023
+related_plan: docs/harness/plan.md §3.9 / R-23
 ---
 
 # design-tokens.md — DESIGN.md とデザイントークン規約
@@ -21,39 +22,102 @@ related_adrs:
 
 ## DESIGN.md の 3 階層構造 (Google Stitch 準拠)
 
-| 階層 | 内容 | 例 |
+| 階層 | 内容 | Kotlin マッピング例 |
 |---|---|---|
-| **Primitive** | 原始値 (hex / sp / dp / ms 等の生の値) | `colors.brand.imas-cg-rin: #5F4F8A` |
-| **Semantic** | 意味的命名 (Primitive を参照) | `semantic.surface.brand.cg-rin: colors.brand.imas-cg-rin` |
-| **Component** | コンポーネント別命名 (Semantic を参照) | `component.idolCard.borderColor.cg-rin: semantic.surface.brand.cg-rin` |
+| **Primitive** | 原始値 (hex / sp / dp / ms 等の生の値) | `object Primitive { val ImasCgRin = Color(0xFF5F4F8A) }` |
+| **Semantic** | 意味的命名 (Primitive を参照) | `object Semantic { val SurfaceBrandCgRin = Primitive.ImasCgRin }` |
+| **Component** | コンポーネント別命名 (Semantic を参照) | `object IdolCardTokens { val BorderColorCgRin = Semantic.SurfaceBrandCgRin }` |
 
 実コードからは原則 **Component 階層を参照**。Semantic / Primitive は内部実装。
 
-## ハードコード禁止
+## DESIGN.md の構造例
 
-- Kotlin / Compose コード内に hex (`#XXXXXX` / `0xFFXXXXXX`) を書かない
-- `sp` / `dp` の固定値を書かない (`16.dp` / `14.sp` 等もデザイントークン経由)
-- `Color.Red` のような Material 直接参照も避ける (テーマ非対応になる)
+```markdown
+# DESIGN.md
+
+> 5 行以内 summary
+
+## Primitive (原始値)
+
+### Colors
+
+| トークン名 | hex | 用途 |
+|---|---|---|
+| `Primitive.ImasCgRin` | `#5F4F8A` | imas-cg リン担当カラー |
+| ... | ... | ... |
+
+### Typography
+
+| トークン名 | sp | 用途 |
+|---|---|---|
+| `Primitive.HeadingLargeSize` | 24 | 画面タイトル |
+
+### Spacing
+
+| トークン名 | dp | 用途 |
+|---|---|---|
+| `Primitive.SpacingMedium` | 16 | カード内余白 |
+
+## Semantic (意味的命名)
+
+...
+
+## Component (コンポーネント別命名)
+
+...
+```
+
+## ハードコード禁止パターン
+
+| パターン | 検出 regex | 例外 |
+|---|---|---|
+| Hex 色 (`Color(0xFFXXXXXX)`) | `Color\(0x[0-9A-Fa-f]{8}\)` | テストコード (`*Test.kt` / `*Spec.kt`) |
+| Hex 色 (`#XXXXXX` 文字列) | `"#[0-9A-Fa-f]{6,8}"` | DESIGN.md Primitive 表内 |
+| `*.sp` / `*.dp` リテラル | `(\d+)\.(sp\|dp)\b` | テストコード / Roborazzi baseline 用 Preview |
+| Material 色直接参照 | `Color\.(Red\|Blue\|...)` | テストコード |
+| `MaterialTheme.colors.primary` ハードコーディング | コードレビューで検出 | テーマ切替対応時のみ許可 |
 
 ## 機械検証 (A6 + A10 で段階導入)
 
-- **A6**: Konsist で「`feature/**` / `core/**` Kotlin source に `Color(0x...)` / `#[0-9A-Fa-f]{6}` パターン無し」
-- **A10**: DESIGN.md の Primitive 値以外を実コードから検出したら CI 失敗
+- **A6**: Konsist で `feature/**` / `core/**` / `composeApp/**` の Kotlin source 内に `Color(0x...)` / `#[0-9A-Fa-f]{6}` / `\d+\.(sp|dp)` パターンの混入なし
+- **A10**: DESIGN.md の Primitive 値以外を実コードから参照したら CI 失敗 (`code-reviewer` design-tokens aspect が検証)
+- **A10**: Roborazzi screenshot test で 4 パターン baseline (`ui-snapshot.md`) と DESIGN.md トークン値の整合を確認
 
 ## 例外
 
-- テストコード (`*Test.kt` / `*Spec.kt`) は対象外 (色比較が必要なケース)
-- Roborazzi baseline 用の Preview パラメータ (デザイントークン経由が望ましいが、可読性優先で許容)
+- **テストコード** (`*Test.kt` / `*Spec.kt`): 対象外 (色比較が必要なケース、unit test の独立性確保)
+- **Roborazzi baseline 用 Preview パラメータ**: デザイントークン経由が望ましいが、可読性優先で許容
+- **A10 完了前のレガシーコード**: 凍結フェーズ A10 完了までは部分的にハードコード残存を許容、Phase C リファクタで段階的に解消
+- **DESIGN.md 内 Primitive 表**: hex / sp / dp の生値を記述する場所、ハードコード規約は適用外
+
+## アイドル別ブランドカラーの扱い (im@s 固有)
+
+- **Primitive 階層で全カラーを列挙**: 「283-icg」「283-mr」「283-sl」「283-stage-2」等の brand-id ごとに hex を定義
+- **Semantic 階層で `brand-<brand-id>-<color-role>` 命名**: `SurfaceBrandImasCgRin` / `OnSurfaceBrandImasCgRin` 等
+- **Component 階層でアイドル UI 要素にマッピング**: `IdolCardTokens` / `BrandChipTokens` / `ColorSwatchTokens` 等
+- 動的色 (アイドル選択で切り替わる) は **Composable パラメータで brand-id を渡す**、ハードコードしない
+
+## DESIGN.md 生成と編集
+
+- **A10 で `ui-snapshot` Skill が自動生成** (DESIGN.md + UI Inventory + Roborazzi baseline の三本柱、ADR 0023)
+- **生成後の編集は human approve 必須** (ブランド一貫性のため)
+- 編集 PR は `refactor.md` テンプレ (Behavior Preservation 証拠必須) または `docs.md` テンプレ (token 追加のみで実コード変更ゼロ)
 
 ## Gotchas
 
-- **DESIGN.md は A10 で自動生成** (`ui-snapshot` Skill)。それまで本ファイルは骨格のみ。
-- **DESIGN.md の編集は human approve 必須** (ブランド一貫性のため)。
-- ブランドカラー (アイドル別) は Primitive 階層で全カラーを列挙、Semantic で `brand-cg-rin` のような命名にする。
+- **DESIGN.md は A10 で自動生成** (`ui-snapshot` Skill)、それまで本ファイルは骨格のみ
+- **DESIGN.md の編集は human approve 必須** (ブランド一貫性のため、`pr-draft-policy.md` 3 条件と整合)
+- **ブランドカラー (アイドル別) は Primitive 階層で全カラーを列挙**、Semantic で `brand-cg-rin` のような命名にする
+- **A10 完了前のハードコード許容範囲**: レガシー実コードのみ、新規追加コードは Component 階層参照を強制 (A6 Konsist で部分検出)
+- **テストコードの例外は緩く**: 色比較 / Roborazzi parameter / Material 直接参照は許容、ただし production code に混入させない
+- **動的ブランドカラー**: ハードコード回避のため Composable パラメータで brand-id を渡し、Component 階層で Semantic.SurfaceBrand<BrandId> をルックアップ
+- **`Color.Red` 等の Material 直接参照禁止**: テーマ非対応 (Light/Dark 切替で壊れる) になるため Component 階層経由を強制
 
 ## 関連
 
 - ADR 0023 (UI 凍結三本柱: DESIGN.md + UI Inventory + Roborazzi baseline)
 - `docs/harness/plan.md` §3.9 / R-23
-- `.claude/rules/{ui-snapshot,ui-inventory,behavior-preservation}.md`
+- `.claude/rules/{ui-snapshot,ui-inventory,behavior-preservation,code-reviewer-aspects,composable}.md`
 - `.claude/skills/ui-snapshot/SKILL.md`
+- DESIGN.md (A10 で自動生成、リポジトリルート配置予定)
+- `docs/design/` (補助ファイル、`docs/design/inventory/` / `docs/design/screenshots/`)

--- a/.claude/rules/docs-structure.md
+++ b/.claude/rules/docs-structure.md
@@ -1,7 +1,7 @@
 ---
 id: rules-docs-structure
 title: docs/ 構造と命名規約、AI が読む順序
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "docs/**/*.md"
@@ -105,17 +105,23 @@ flow 形式 (`[A, B, C]`) は **禁止**。
 例:
 
 ```yaml
-# OK (block)
+# ✅ OK (block 形式) — 本リポジトリ全 docs / rule / Skill SKILL.md でこの形式を採用
 related_adrs:
   - ADR-0001
   - ADR-0011
 related_specs:
   - SPEC-IDOL-001-3
 
-# NG (flow / inline) — 機械検証で reject 予定 (A6)
+# ❌ NG (flow / inline 形式) — 機械検証で reject 予定 (A6)
+# 以下はあくまで「禁止例」として記載しており、本リポジトリの実体には混入させないこと
 related_adrs: [ADR-0001, ADR-0011]
 related_specs: [SPEC-IDOL-001-3]
 ```
+
+> **注**: 上記の `❌ NG` ブロックは比較のための参考表記であり、A6 で機械検証 (Gradle カスタム
+> タスク) を導入した時点で flow 形式の検出は CI 失敗となる。PR #121 レビュー
+> (spec-conformance aspect) で「`docs-structure.md:116-117` の NG 例にコメント注記なし」
+> と指摘されたため A2-3 で明示化。
 
 ### 空配列の表記
 
@@ -160,5 +166,6 @@ related_adrs:      # NG (これは null 扱いになる)
 
 - ADR 0027 (docs 構造 + 命名規約 + 5 行 summary + lazy-load + 日本語化)
 - `docs/harness/plan.md` §4
-- `.claude/rules/{template-language,roadmap,adr}.md`
+- `.claude/rules/{template-language,markdown,roadmap,adr,plan,epic,spec-living-sync}.md`
 - `docs/README.md` (AI 用エントリポイント)
+- `docs/traceability.md` (A6 自動生成、双方向リンク機械検証)

--- a/.claude/rules/docs-structure.md
+++ b/.claude/rules/docs-structure.md
@@ -23,7 +23,7 @@ related_adrs:
 
 詳細骨格は `docs/harness/plan.md` §4.0.1 を参照。主要ディレクトリ:
 
-```
+```text
 DESIGN.md                  ★ repo root
 docs/
   README.md                ★ AI 用エントリポイント

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -1,42 +1,52 @@
 ---
 id: rules-harness-evolution
 title: harness-evolution Skill 運用規約 (外部情報源ホワイトリスト + 手動起動)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - ".claude/skills/harness-evolution/**"
   - "docs/harness/evolution-proposals/**"
-related_plan: docs/harness/plan.md §5.3 / §5.4.6 / ADR 0026
 related_adrs:
   - ADR-0026
+related_plan: docs/harness/plan.md §5.3 / §5.4.6 / R-29 / R-30 / R-31
 ---
 
 # harness-evolution.md — harness-evolution 運用規約
 
 > 外部研究・ベストプラクティス駆動の改善ループを **手動起動のみ** で運用する規約。
-> 内部 KPT 駆動の `harness-meta` と二系統補完で動作。
+> 内部 KPT 駆動の `harness-meta` と二系統補完で動作 (ADR 0026)。
+> 出典 URL + 引用日付の記録、Context7 MCP 引用検証、harness-meta との重複回避を明文化。
 
 ## 起動方式
 
 - **手動起動のみ** (Claude API コスト抑制のため cron 不採用、ADR 0026)
 - ユーザーが必要時に Claude Code で `harness-evolution` を呼び出す
 - 月次相当の頻度を推奨 (`anthropics/skills` の更新確認を兼ねる、R-30)
+- 起動コマンド: `Skill skill="harness-evolution" args="<focus area or 'general'>"`
 
 ## 外部情報源ホワイトリスト
 
-| カテゴリ | 情報源 |
-|---|---|
-| Anthropic 公式 | Anthropic engineering blog / `anthropics/skills` GitHub / Claude Code docs |
-| MCP 仕様 | MCP spec (modelcontextprotocol.io) |
-| AI Coding Agent | awesome-harness-engineering / Augment Code / HumanLayer / Cognition (Devin) |
-| 学術 | arxiv (AI agents / autonomous coding 系) |
-| 業界ブログ | Martin Fowler / Red Hat Developer / GitHub blog |
+| カテゴリ | 情報源 | アクセス手段 |
+|---|---|---|
+| Anthropic 公式 | Anthropic engineering blog / `anthropics/skills` GitHub / Claude Code docs | WebFetch + WebSearch |
+| MCP 仕様 | MCP spec (https://modelcontextprotocol.io) | WebFetch + Context7 MCP |
+| AI Coding Agent | awesome-harness-engineering / Augment Code / HumanLayer / Cognition (Devin) blog | WebSearch + WebFetch |
+| 学術 | arxiv (AI agents / autonomous coding 系) | WebSearch + WebFetch |
+| 業界ブログ | Martin Fowler / Red Hat Developer / GitHub blog | WebFetch |
+| ライブラリ docs | Kotlin / Compose MP / Ktor / SQLDelight / Roborazzi 等のバージョン固有 API | **Context7 MCP** (R-28) |
 
-ホワイトリスト追加は Plan 起票 + 人間 approve 必須。
+ホワイトリスト追加は Plan 起票 + 人間 approve 必須 (orchestrator subroh0508 判断)。
+
+## ホワイトリスト追加手順
+
+1. 新規情報源候補を `docs/plans/PLAN-NNN-<slug>.md` で起票 (`type: harness`)
+2. 採用根拠: 信頼性 / 更新頻度 / 引用可能性 / ライセンス
+3. orchestrator approve → Plan completed → 本 rule のホワイトリスト表に行追加
+4. `harness-evolution` Skill の system prompt にも反映 (`.claude/skills/harness-evolution/SKILL.md` 改修)
 
 ## 出力フォーマット
 
-```
+```text
 docs/harness/evolution-proposals/YYYY-MM-DD.md
 ```
 
@@ -49,8 +59,12 @@ status: draft | reviewed | actioned
 generator: harness-evolution Skill (vX.Y.Z)
 generated_at: YYYY-MM-DDTHH:MM:SSZ
 sources:
-  - { url: https://..., title: ..., accessed_at: YYYY-MM-DD }
-  - { url: https://..., title: ..., accessed_at: YYYY-MM-DD }
+  - url: https://...
+    title: ...
+    accessed_at: YYYY-MM-DD
+  - url: https://...
+    title: ...
+    accessed_at: YYYY-MM-DD
 ---
 
 # 概要 (5 行以内)
@@ -80,17 +94,58 @@ sources:
 |---|---|---|
 ```
 
+- frontmatter `sources` は block 形式必須 (URL + title + accessed_at の 3 キー)
+- 5 行 summary は冒頭 blockquote (>) ではなく `# 概要 (5 行以内)` 直下に記述 (本フォーマット固有)
+- 改善提案プレフィックスは `[skill]` / `[rule]` / `[remove]` に加え **`[mcp]`** を追加 (harness-evolution 固有、新規 MCP 採用余地検討用)
+
+## Context7 MCP による引用検証 (R-28)
+
+- AI が取得した外部知見のうち **ライブラリ API / バージョン情報** は **必ず Context7 MCP で再検証**
+- 古い API / 存在しない API / hallucination 起源の API を提案するリスクを抑制
+- 例: 「Kotlin Coroutines の `Flow.combine` の signature」を arxiv で見かけた場合、Context7 MCP で Kotlin 公式 docs を引いて確認
+- 検証失敗 (Context7 MCP が該当 API を返さない) 時はその提案を見送り、`docs/harness/evolution-proposals/YYYY-MM-DD.md` に「Context7 引けず見送り」と明記
+
+## harness-meta との重複防止 (R-31)
+
+- 既に `docs/harness/learnings/*.md` の `🤖 ハーネス改善提案` で指摘済の提案は **harness-evolution 側を見送り**
+- 重複判定方法: harness-evolution Skill 起動時に直近 N 件の learning ファイルを Read、提案セクションを diff
+- 重複時の処理: `docs/harness/evolution-proposals/YYYY-MM-DD.md` に「harness-meta で既出のため見送り、出典のみ記録」と明記
+- 改修 PR のラベル分離: harness-meta 採用 PR は `harness-meta` ラベル、harness-evolution 採用 PR は `harness-evolution` ラベル
+- 優先度: **harness-meta を優先** (内部実体験ベース、R-31)
+
+## 採用提案の Plan / Epic 起票
+
+- 重要案は `docs/plans/PLAN-NNN-<slug>.md` (1 PR スコープ) または `docs/epics/EPIC-NNN-<slug>/` (複数 PR スコープ) で起票
+- 起票判定: `plan.md` §Epic 昇格条件 (`>=2 PR` 想定なら Epic、単一 PR で完結なら Plan)
+- 起票後は本ファイル `## 採用提案` 表に Plan / Epic リンクを追記、status を `actioned` に更新
+
+## 出典記録の必須要件 (R-29)
+
+- **URL + 引用日付 (accessed_at) を必ず記録**: 後追い検証可能性のため
+- アーカイブ推奨: Wayback Machine / archive.today で snapshot を取得して URL を frontmatter `archive_url` (任意キー) に追記
+- ライセンス確認: 引用元のライセンス (MIT / Apache 2.0 / CC-BY 等) を `sources` 表のメモ列で記録
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: `docs/harness/evolution-proposals/*.md` の frontmatter `sources` 必須キー (URL / title / accessed_at) 検証、ホワイトリスト URL prefix マッチ
+- **GitHub Actions**: evolution-proposal PR の merge 直前に URL 到達性 check + Context7 MCP 引用検証ログの存在確認
+- **harness-evolution Skill 自体**: 出力前に `pii.md` / `secrets.md` redaction を必ず通す (R-26)
+
 ## Gotchas
 
 - **必ず出典 URL + 引用日付** を記録 (R-29、後追い検証可能性のため)
 - **Context7 MCP で API 引用検証** (古い・存在しない API を提案しない、R-28)
 - **harness-meta との提案重複防止**: 既に learning ファイルで指摘済の提案は harness-evolution 側を見送り (R-31)
-- 改修 PR は `harness-meta` / `harness-evolution` の **ラベル分離** で運用、harness-meta 側を優先
-- ホワイトリスト先頭に `anthropics/skills` の更新確認を組み込み (R-30)
+- **改修 PR のラベル分離** (`harness-meta` vs `harness-evolution`)、harness-meta 側を優先
+- **ホワイトリスト先頭に `anthropics/skills` の更新確認** を組み込み (R-30、月次推奨)
+- **手動起動のみ** (cron / wakeup 不採用、ADR 0026、Claude API コスト抑制)
+- **PII / secrets redaction を必ず通す**: 外部情報源にも個人情報が混入する可能性 (`pii.md` / `secrets.md`)
+- **新規 MCP 採用検討は `[mcp]` プレフィックス**: 既存 3 MCP (JetBrains / Context7 / Cloudflare) との overlap / コスト / セキュリティ境界を判断材料に明記
 
 ## 関連
 
-- ADR 0026 (harness-evolution Skill 採用)
+- ADR 0026 (harness-evolution Skill 採用、二系統補完設計の SoT)
 - `docs/harness/plan.md` §5.4.6 / R-29 / R-30 / R-31
 - `.claude/skills/harness-evolution/SKILL.md`
-- `.claude/rules/{skill-authoring,mcp-usage}.md`
+- `.claude/rules/{harness-meta-criteria,skill-authoring,mcp-usage,retrospective-format,pii,secrets}.md`
+- `docs/harness/evolution-proposals/` (出力先ディレクトリ)

--- a/.claude/rules/harness-meta-criteria.md
+++ b/.claude/rules/harness-meta-criteria.md
@@ -1,0 +1,112 @@
+---
+id: rules-harness-meta-criteria
+title: harness-meta 採用 / 見送り / 撤去判定基準 + pr-poller 起動閾値
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".claude/skills/harness-meta/**"
+  - ".claude/skills/pr-poller/**"
+related_adrs:
+  - ADR-0026
+related_plan: docs/harness/plan.md §5.4.5 / R-31
+---
+
+# harness-meta-criteria.md — harness-meta 採用 / 見送り / 撤去判定基準
+
+> `harness-meta` Skill (A4 で本格化) が `pr-retrospective` の learning ファイルから集約した
+> ハーネス改善提案について **採用 (=> 改修 PR 起票) / 見送り / 撤去** を判定する基準を規定。
+> `pr-poller` の起動閾値もここで上書き可能。
+
+## harness-meta vs harness-evolution の責務分離
+
+| 観点 | `harness-meta` | `harness-evolution` |
+|---|---|---|
+| 駆動契機 | 内部 KPT (learning ファイル) | 外部研究 / ベストプラクティス |
+| 起動 | `pr-poller` から自動起動 (閾値到達時) | **手動起動のみ** (`harness-evolution.md` 参照) |
+| 入力 | `docs/harness/learnings/*.md` の `🤖 ハーネス改善提案` セクション | ホワイトリスト情報源 + Context7 MCP |
+| 出力 | 改修 PR description / `harness-meta フィードバック` 追記 | `docs/harness/evolution-proposals/YYYY-MM-DD.md` + 重要案の Plan / Epic 起票 |
+| ラベル | `harness-meta` (PR) | `harness-evolution` (PR) |
+| 優先度 | **harness-meta を優先** (内部実体験ベース、R-31) | harness-meta との重複を見送り (R-31) |
+
+## 改善提案の 4 プレフィックス (`retrospective-format.md` と整合)
+
+| プレフィックス | 意味 | 採用時のアクション |
+|---|---|---|
+| `[rule]` | `.claude/rules/*.md` の新規追加・改修 | rule ファイル直接編集 PR (本 PR のような形式) |
+| `[skill]` | `.claude/skills/*/` の新規追加・改修 | `example-skills:skill-creator` 経由で SKILL.md 改修 (`skill-authoring.md` 参照) |
+| `[template]` | テンプレート Markdown (PR / Plan / Epic / Learning 等) の改修 | テンプレファイル直接編集 PR |
+| `[remove]` | 未使用 rule / dormant Skill の撤去候補 | rule / Skill 削除 PR + `rules-index.md` / `docs/epics/EPIC-A2-rules-docs-extension/decisions.md` 等に削除理由記録 |
+
+## 採用判定基準 (採用 = 改修 PR 起票)
+
+以下のいずれかを満たすときに採用:
+
+1. **複数 PR (>=2) の learning で同じ提案が反復**: 一過性の問題ではなく構造的課題
+2. **A1 レトロ 15 提案のような ADR / Plan / Epic で明示的に予約された項目**: 起票根拠が明確
+3. **R-XX (`docs/harness/plan.md` の規約 ID) と直接対応**: 規約整合化の必要性
+4. **Critical findings から派生**: code-reviewer Critical の根本原因解消につながる提案
+5. **orchestrator (subroh0508) が手動で「採用」と明示**: 内部レビューで採用判断
+
+採用時の起票プロセス: 改修 PR (`harness/<purpose>` ブランチ、`harness.md` テンプレ) → `code-reviewer` Skill → Ready 昇格 → merge → `pr-retrospective` の `📝 harness-meta フィードバック` セクションに採用結果を追記
+
+## 見送り判定基準 (見送り = `📝 harness-meta フィードバック` セクションに保留 / 見送り記録)
+
+以下のいずれかを満たすときに見送り:
+
+1. **後続フェーズに移行**: A3 / A4 / A6 / A7 / A10 / Phase B / Phase C で対応予定の項目 (例: A1 レトロの `pr-retrospective` Skill 本格化は A3 へ)
+2. **提案重複**: 既に他 learning で採用済 / 同 PR で対応済
+3. **コスト / 効果の不均衡**: 改修コストが高く、現状運用で代替可能 (例: `Co-Authored-By` の機械検証は A3 / A6 で実装、現状は人間レビュー任せ)
+4. **harness-evolution との重複**: 外部研究側で既に提案済 (R-31)
+5. **orchestrator (subroh0508) が手動で「見送り」と明示**: 内部判断
+
+見送り時の記録: 対象 learning の `📝 harness-meta フィードバック` セクション「見送り (後続フェーズへ)」表に「提案 → 移行先フェーズ / 見送り理由」を記録
+
+## 撤去判定基準 (撤去 = rule / Skill 削除 PR)
+
+以下のすべてを満たすときに撤去:
+
+1. **対象 rule / Skill が直近 3 ヶ月の learning / commit / PR で参照されていない**: dormant 確定
+2. **撤去によって他 rule / Skill / docs に dangling 参照が発生しない**: grep-based / Konsist で確認
+3. **orchestrator (subroh0508) の事前承認**: 削除は不可逆性が高いため明示承認必須
+
+撤去時のプロセス: `[remove]` PR で rule / Skill ファイル削除 + `rules-index.md` / `docs/epics/<id>/decisions.md` / 関連 ADR (該当時) に削除理由を記録、関連 docs のリンク張り替え
+
+## pr-poller 起動閾値 (harness-meta 自動起動)
+
+`pr-poller.md` の既定値を本 rule で上書き可能:
+
+| パラメータ | 既定値 | 上書き条件 |
+|---|---|---|
+| 未処理 learning 件数 | 10 件 | 「重要改修 PR が直近に merge された」「フェーズ ID 切替時」等で 5 件に下げる (一時的) |
+| 前回 harness-meta 実行からの経過日数 | 7 日 | 同上で 3 日に下げる |
+| 連続実行間隔 | 24 時間 | 緊急時のみ 6 時間に下げる (debug / 手動) |
+
+上書きは `.claude/rules/harness-meta-criteria.md` 本ファイル末尾の「実行時パラメータ」セクション (将来追加) または `pr-poller` 起動時の引数で指定。
+
+## 改修 PR の品質基準 (採用時)
+
+- **影響範囲を 1 PR で完結させる**: rule 1 件 + 関連 docs 微修正 + rules-index 更新で 5 ファイル以内が目安
+- **複数 rule 改修が必要な場合は Epic に昇格**: `plan.md` §Epic 昇格条件、本 PR (EPIC-A2 配下 A2-3) のような分割
+- **code-reviewer 4 aspect 並列を必ず通す**: harness 改修は spec-conformance / architecture / security / code-quality の 4 aspect で十分 (test-quality / performance / visual-regression / design-tokens は skip 妥当な場合が多い)
+- **PR description の「採用根拠」セクション**: 対象 learning ファイル + 採用判定基準 1〜5 のどれを満たすかを明記
+
+## 機械検証 (A6 で導入予定)
+
+- **`pr-poller` Skill の閾値判定**: `harness-meta-criteria.md` 本ファイルの「pr-poller 起動閾値」表を parse して既定値を上書き
+- **Gradle カスタムタスク**: `📝 harness-meta フィードバック` セクションの構造化テーブルが retrospective-format.md の規格に合致するか検証 (A6 / Markdown 機械検証と統合)
+- **GitHub Actions**: harness 改修 PR が `code-reviewer` 4 aspect を通過しているか check 連携 (A4 で Skill 統合後)
+
+## Gotchas
+
+- **採用基準 5 / 見送り基準 5 / 撤去基準 3 の「orchestrator 明示」は最終判断**: AI が自律判定する範囲は基準 1-4 まで、5 (撤去は 3) は人間判断
+- **改修 PR は harness.md テンプレ必須** (`pr-template.md` / `branch-naming.md` と整合): `harness/<purpose>` ブランチ + `harness.md` テンプレ + `feat(harness)` / `docs(harness)` commit
+- **撤去 PR は不可逆性が高いため細心の注意**: dangling 参照検証を grep-based で確認、`rules-index.md` の status を `removed` に変更してから次 PR で削除する 2 段階運用を推奨 (将来追加)
+- **harness-meta vs harness-evolution の提案重複**: harness-evolution 側で出力 (`docs/harness/evolution-proposals/YYYY-MM-DD.md`) を確認してから採用判定 (R-31)
+- **本 rule の閾値変更も harness-meta-criteria.md 改修 PR として扱う**: メタな自己改修ループ、A4 / A6 完了後に運用熟成
+
+## 関連
+
+- ADR 0026 (harness-evolution Skill 採用、harness-meta との二系統補完)
+- `docs/harness/plan.md` §5.4.5 / R-29 / R-30 / R-31
+- `.claude/rules/{pr-poller,retrospective-format,harness-evolution,skill-authoring,rules-index}.md`
+- `.claude/skills/{harness-meta,pr-poller,pr-retrospective}/SKILL.md`

--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -1,27 +1,52 @@
 ---
 id: rules-implementation-workflow
 title: implementation-workflow 10 フェーズ手順規約
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - ".claude/skills/implementation-workflow/**"
-related_plan: docs/harness/plan.md §5.3 / §5.4.2 / ADR 0018
+related_adrs:
+  - ADR-0017
+  - ADR-0018
+related_plan: docs/harness/plan.md §5.3 / §5.4.2 / R-14 / R-15
 ---
 
 # implementation-workflow.md — 10 フェーズ手順規約
 
 > `implementation-workflow` Skill が Plan / Epic 確定後の実装着手から worktree 削除までを
-> 10 フェーズで統合管理する際の詳細手順。
+> 10 フェーズで統合管理する際の詳細手順。各 Phase の入出力 / 成功条件 / 失敗時 fallback /
+> 並行実装基盤 (worktree) を規定。
 
-## Phase 0: Worktree 作成
+## 全 10 Phase 概要
+
+| Phase | 名称 | 主出力 | 成功条件 |
+|---|---|---|---|
+| 0 | Worktree 作成 | worktree path + ブランチ | `git worktree list` に新エントリ |
+| 1 | docs Read | 要件 / 基本設計 / 詳細設計の理解 | 関連 SPEC / ADR / Plan / Epic を全て読み込み済 |
+| 2 | Spec 整合チェック | 整合性レポート | ID 重複・dangling リンクゼロ |
+| 3 | 実装 + Lint + Test | commit (fix loop ≤3 回) | `./gradlew check` green |
+| 4 | Self-Verification | 三層指標差分 + rule 違反チェック | `@Spec` 整合 + PII / secrets ゼロ |
+| 5 | Draft PR 作成 | `gh pr create --draft --template <type>.md` | PR URL 取得 |
+| 6 | code-reviewer 呼出 | Coordinator レビューコメント | Critical = 0 (fix loop 後) |
+| 7 | 人間 approve → squash merge | merge commit | 3 条件充足 (CI/Critical/approve) |
+| 8 | pr-poller + roadmap-tracker | learning ファイル + roadmap 更新 | (該当時) mirror PR 起票 |
+| 9 | Worktree 削除 | worktree クリーンアップ | branch -d 成功 |
+
+## Phase 0: Worktree 作成 + master fetch (PR #121 レトロ Try 反映)
 
 ```bash
-git worktree add ../<repo-name>-worktrees/<branch-slug> -b <branch-name>
+# 1. master を最新化 (本 worktree とは別の作業ディレクトリで実行)
+git fetch origin master
+
+# 2. worktree + ブランチ作成 (origin/master ベース)
+git worktree add ../<repo-name>-worktrees/<branch-slug> -b <branch-name> origin/master
 ```
 
-- `<branch-name>` は `.claude/rules/branch-naming.md` に従う (`feature/PLAN-NNN-<slug>` / `epic/EPIC-NNN-<slug>-pr-NN` / `harness/<purpose>` / `chore/<purpose>`)
+- **`git fetch origin master` を必ず Phase 0 冒頭で実行** (PR #121 レトロ Try、PR #120 との rebase 競合再発防止)
+- `<branch-name>` は `.claude/rules/branch-naming.md` に従う (`feature/PLAN-NNN-<slug>` / `feature/EPIC-NNN-<slug>-pr-NN` / `harness/<purpose>` 等)
 - `<branch-slug>` はブランチ名のスラッシュをハイフン化 (`feature/PLAN-007-add-search` → `feature-PLAN-007-add-search`)
-- **以降の全 Phase はこの worktree 内で実行**
+- **以降の全 Phase はこの worktree 内で実行** (chdir または cwd 指定)
+- 並行実装中の touch ファイル重複は worktree 物理分離で回避 (EPIC-A2 A2-2 / A2-4 / A2-5 の並走実績)
 
 ## Phase 1: 要件 / 基本設計 / 詳細設計 Markdown を Read
 
@@ -29,72 +54,126 @@ git worktree add ../<repo-name>-worktrees/<branch-slug> -b <branch-name>
 - `docs/specifications/basic/SPEC-NNN-*.md`
 - `docs/specifications/detail/SPEC-NNN-*.md`
 - frontmatter の `related_*` を辿って関連 ADR / Epic / Plan を Read
+- harness PR の場合: `docs/harness/plan.md` 関連章 + 対象 rule / Skill の現状を Read
+- mirror PR の場合: 対象フェーズの roadmap.md + 完了済 PR の commit / merge ログを Read
 
 ## Phase 2: Spec 整合性チェック
 
-- SPEC-ID 採番の重複なし
+- SPEC-ID 採番の重複なし (`docs/specifications/{basic,detail}/` の `id:` 一意性)
 - `related_basic` / `related_detail` の双方向リンク有効
-- frontmatter 必須キー JSON Schema 検証 (A6 で機械化)
+- frontmatter 必須キー JSON Schema 検証 (A6 で機械化、現状は目視)
+- 設計書本文にコード断片混入なし (`docs-structure.md` §4.6 のコード禁止原則)
+- harness PR は `rules-index.md` status と実体の整合チェック (A2-1 / A2-2 で正規化済)
 
 ## Phase 3: 実装 + Lint + Test (fix loop)
 
-- `.claude/rules/rules-index.md` から実装ファイル種別に応じた rules を Read
+- `.claude/rules/rules-index.md` の lookup table から実装ファイル種別に応じた rules を Read (CLAUDE.md と二重チェック)
 - 実装 → `./gradlew check` → 失敗時は修正して再実行
-- **fix loop 上限はデフォルト 3 回** (R-14)、超過したら Plan に `status: blocked` を書き込み人間に通知
+- **fix loop 上限はデフォルト 3 回** (R-14)、超過したら Plan status を `blocked` に書き換え人間に通知
+- spec-living-sync (`.claude/rules/spec-living-sync.md`) 発動時は同 PR で docs 修正、PR description「仕様変更箇所」セクション記入
+- commit-msg hook (`scripts/install-git-hooks.sh`) で Conventional Commits 形式検証
 
 ## Phase 4: Self-Verification
 
-- 三層指標 (line/branch coverage 差分 100% / Spec coverage 差分 100% / mutation score 計測)
-- rules 違反がないか自己チェック (PII / secrets / 設計書コード断片混入 等)
+- 三層指標差分 (Line / Branch coverage 差分、Spec coverage 差分、Mutation score) を計測 (A7 完了前は N/A 明記)
+- rule 違反チェック (Konsist / Gradle カスタムタスク / 目視):
+  - PII / secrets が code / docs / commit に混入していないか
+  - 設計書本文にコード断片がないか
+  - frontmatter 配列が block 形式か
+  - 日本語見出し / 命名規約準拠か
+- harness PR は `rules-index.md` の status 整合を再確認
 
 ## Phase 5: Draft PR 作成
 
 ```bash
-gh pr create --draft --template <type>.md --body-file <draft>
+gh pr create --draft \
+  --base master \
+  --head <branch-name> \
+  --title "<conventional-commits-subject>" \
+  --template <type>.md
 ```
 
-- type は `feature` / `bugfix` / `refactor` / `dependency-upgrade` / `harness` / `docs` から選択 (§4.8)
-- frontmatter に `type` / `related_plan` / `related_epic` / `related_adrs` / `related_specs` / `expected_modules` を必ず含める
+- `--template` は **必須** (`pr-template.md` 規約)
+- `--draft` は **既定** (`pr-draft-policy.md` 規約)、orchestrator 明示指示時のみ即 Ready で起票可
+- PR description frontmatter (HTML コメント `<!-- pr-frontmatter ... -->`) に必須キー (`type` / `related_plan` / `related_epic` / `related_specs` / `related_adrs` / `expected_modules`) を埋める
+- mirror PR は `--draft` 省略可 (`pr-draft-policy.md` Gotchas 参照)
 
 ## Phase 6: code-reviewer 呼出 (Evaluation)
 
 - `code-reviewer` Skill を起動 (Generator と独立した Evaluator、R-13)
-- 8 aspect をローカル Claude Code のサブエージェントで並列実行 (R-37)
-- Critical findings あり → Phase 3 に戻る (fix loop)
+- 4〜8 aspect をローカル Claude Code のサブエージェントで並列実行 (R-37)
+- harness PR の既定 4 aspect: `spec-conformance` / `architecture` / `security` / `code-quality`
+- feature PR の既定 6 aspect: 上記 + `test-quality` + `performance`
+- A10 完了後 enable: `visual-regression` / `design-tokens`
+- Critical findings あり → Phase 3 に戻る (fix loop)、累計 fix loop 上限 3 回 (R-14)
 - Critical findings = 0 → Phase 7 へ
 
 ## Phase 7: 人間 approve → squash merge
 
-- CI green + 全 aspect pass + **人間 approve** の 3 条件で Ready 昇格
-- `gh pr merge --squash`
-- **auto-merge は禁止** (GitHub Agentic Workflows 原則、R-15)
+- **3 条件** (`merge-readiness.md`):
+  1. CI green (`gh pr checks`)
+  2. code-reviewer Critical = 0
+  3. 人間 approve または orchestrator 事前承認テキスト
+- 3 条件充足後に `gh pr ready` → `gh pr merge --squash` (または `--merge`)
+- **auto-merge は禁止** (`merge-readiness.md` R-15)、orchestrator 明示承認による R-15 代替パスは許可
 
 ## Phase 8: pr-poller 即時起動 + roadmap-tracker
 
-- `pr-poller` を即時起動して `pr-retrospective` を駆動 (learning ファイル生成)
-- `roadmap-tracker` を起動して完了根拠を登録 (**Epic 配下 PR または B-A-C フェーズ項目に該当時のみ**、Plan 単体は対象外)
+- `pr-poller` を即時起動して `pr-retrospective` を駆動 → learning ファイル生成 (`docs/harness/learnings/YYYY-MM-DD-pr-<N>.md`)
+- `roadmap-tracker` を起動 (**Epic 配下 PR / B-A-C フェーズ項目に該当時のみ**、Plan 単体は対象外、R-34)
+- mirror PR が必要な場合 (`implementation-workflow` を経由しないマージ + Epic / フェーズ項目該当) は `harness/roadmap-mirror-<phase-id>` ブランチで mirror PR 起票 (`roadmap.md` §手動マージ時の同 PR 更新ルール 参照)
+- learning ファイルは `harness/learnings-batch-YYYY-WW` ブランチに集約、週次 / 件数閾値到達時に PR 起票
 
 ## Phase 9: Worktree 削除
 
 ```bash
-git branch --merged main | grep <branch-name>  # マージ済確認
+# 1. マージ済確認
+git branch --merged origin/master | grep <branch-name>
+
+# 2. worktree 削除 + ブランチ削除
 git worktree remove ../<repo-name>-worktrees/<branch-slug>
 git branch -d <branch-name>
 ```
 
 - **未マージなら停止して人間に通知** (worktree / branch を残す)
+- `branch -d` (`-D` ではない) でマージ確認、未マージ時はエラー出力で警告
+
+## Fix loop の上限と blocked 判定
+
+- **Phase 3 fix loop**: `./gradlew check` 失敗 → 修正 → 再実行 を 3 回まで
+- **Phase 6 fix loop**: code-reviewer Critical 修正 → 再実行 を 3 回まで
+- **累計 fix loop が 3 回超過** したら Plan / Epic の `decisions.md` (Epic 配下時) または Plan 本体 (Plan 単体時) に `status: blocked` を書き込み、人間に通知 (`docs/harness/plan.md` R-14)
+
+## 並行実装基盤 (worktree)
+
+- **複数 Claude Code セッションの並走** は worktree 物理分離で実現 (EPIC-A2 A2-2 / A2-4 / A2-5 並走実績)
+- touch ファイル衝突回避:
+  - A2-2 (`.claude/rules/`) vs A2-4 (`docs/`) vs A2-5 (`docs/architecture` + `docs/api`) は touch ファイル重複ゼロで並走完走
+  - A2-2 / A2-3 は `rules-index.md` の連続編集を回避するため **直列実行** (A2-2 マージ後 A2-3 着手)
+- 並走時の rebase 競合は roadmap.md / progress.md / rules-index.md で発生しやすい (PR #121 / #125 / #126 の実績) → mirror PR で解消
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: `git worktree list` で未削除 worktree が 3 個以上の状態を warning (Phase 9 漏れ検知)
+- **GitHub Actions**: PR merge イベントで「Phase 8 起動済か (learning ファイル + roadmap 更新が同日中に push されたか)」を check (A4 で Skill 統合後)
+- **commit-msg hook 拡張**: branch-naming 違反を `pre-push` で検出 (A6 で導入予定、`scripts/install-git-hooks.sh` 拡張)
 
 ## Gotchas
 
-- **Phase 0 と Phase 9 はペア**。Phase 9 を忘れると worktree が肥大化する。
-- **Phase 3 fix loop 上限 3 回** (R-14)。
-- **Phase 6 の code-reviewer は Claude API 直接呼び出しではなくサブエージェント並列** (R-37 / ADR 0017)。
-- **Phase 7 で auto-merge 禁止** (R-15)。
-- **Phase 8 で `roadmap-tracker` を呼ぶのは Epic 配下 PR / B-A-C フェーズ項目のみ**。Plan は対象外 (R-34)。
+- **Phase 0 で `git fetch origin master` を省略しない** (PR #121 レトロ Try、PR #120 との rebase 競合再発防止)
+- **Phase 0 と Phase 9 はペア**、Phase 9 を忘れると worktree が肥大化
+- **Phase 3 fix loop 上限 3 回** (R-14)、超過時は blocked + 人間通知
+- **Phase 6 の code-reviewer は Claude API 直接呼び出しではなくサブエージェント並列** (R-37 / ADR 0017)
+- **Phase 7 で auto-merge 禁止** (R-15)、orchestrator 明示承認テキストでの代替パスは許可
+- **Phase 8 で `roadmap-tracker` を呼ぶのは Epic 配下 PR / B-A-C フェーズ項目のみ**、Plan 単体は対象外 (R-34)
+- **Phase 9 の `branch -d` は `-D` 禁止** (未マージ強制削除を防ぐ)、未マージ検知時は worktree / branch を残して人間判断
+- **worktree path の slug は `branch-naming.md` 規約に厳密に従う**: スラッシュをハイフンに置換、特殊文字なし
+- **並走中の rules-index.md / roadmap.md / progress.md の rebase 競合** は EPIC-A2 で頻発、mirror PR で統合解消するパターンを A2-2 / A2-4 / A2-5 で確立
 
 ## 関連
 
-- `docs/harness/plan.md` §5.3 / §5.4.2
-- ADR 0018 (10 フェーズ設計)
-- `.claude/rules/{merge-readiness,pr-draft-policy,spec-living-sync,branch-naming,code-reviewer-aspects}.md`
+- ADR 0017 (ローカル Claude Code ポーリング駆動、Generator/Evaluator 分離の前提)
+- ADR 0018 (10 フェーズ設計の SoT)
+- `docs/harness/plan.md` §5.3 / §5.4.2 / R-14 / R-15 / R-34 / R-37
+- `.claude/rules/{branch-naming,pr-template,pr-draft-policy,merge-readiness,code-reviewer-aspects,spec-living-sync,roadmap,pr-poller}.md`
 - `.claude/skills/implementation-workflow/SKILL.md`

--- a/.claude/rules/merge-readiness.md
+++ b/.claude/rules/merge-readiness.md
@@ -1,0 +1,95 @@
+---
+id: rules-merge-readiness
+title: Merge 可否判定 (CI + Critical + 人間 approve の 3 条件)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".claude/skills/code-reviewer/**"
+  - ".claude/skills/implementation-workflow/**"
+related_adrs:
+  - ADR-0018
+  - ADR-0019
+related_plan: docs/harness/plan.md §5.4.3 / R-15
+---
+
+# merge-readiness.md — Merge 可否判定規約
+
+> `implementation-workflow` Phase 7 で PR を Ready 昇格 → squash merge する前に
+> 充足すべき 3 条件を規定。auto-merge 禁止 (R-15) と orchestrator 明示承認による
+> R-15 代替パスの位置付けも明記。
+
+## Ready 昇格の 3 条件 (すべて必須)
+
+| 条件 | 判定方法 | 失敗時の対応 |
+|---|---|---|
+| **CI green** | `gh pr checks <PR#>` で全 check が `pass` または `neutral` | 失敗 check の logs を `gh run view --log` で取得 → Phase 3 fix loop に戻る |
+| **code-reviewer Critical = 0** | Phase 6 の Coordinator 集約結果で全 aspect の Critical findings がゼロ | Critical を修正 → Phase 3 → Phase 6 を再実行 (fix loop) |
+| **人間 approve** | orchestrator (subroh0508) または GitHub `Approve` review | approve 取得まで待機、自動マージ禁止 |
+
+3 条件のうち 1 つでも欠けたら **Ready 昇格不可**。Draft で維持し Phase 3 / 6 に戻る。
+
+## auto-merge 禁止 (R-15)
+
+- **GitHub の `auto-merge` 機能を使わない**: PR が approve + check 通過時に自動マージされる挙動は採用しない
+- 理由: GitHub Agentic Workflows 原則 (人間が最終判断、AI は補助)、Critical 0 でも人間が「もう少し見たい」と判断する余地を残す
+- 機械強制: GitHub branch protection で `Require a pull request before merging` + `Dismiss stale pull request approvals` を有効化 (A6 で本格化)、`Allow auto-merge` は OFF
+- 違反検出: `pr-poller` Phase 2 で「approve 後 N 分以内に自動マージされた PR」を検出して warning (A4 / A6 で導入)
+
+## orchestrator 明示承認による R-15 代替パス
+
+- **本 PR が「ハーネス改修 / レトロ起票 / EPIC 配下 PR / mirror PR」かつ orchestrator (subroh0508) が事前承認済み** の場合のみ、AI が `gh pr merge --squash` (または `--merge`) を直接実行することを許可
+- 事前承認の形式: ユーザー指示テキスト中に「self-merge」「Phase 7 含む承認」「orchestrator 明示承認」等の文言を含む
+- 実績: A2-2 (PR #125 `--merge`) / A2-4 (PR #123) / A2-5 (PR #126) で運用、本 rule の確立は本 PR (A2-3)
+- 代替パスでも **3 条件 (CI green + Critical 0 + 事前承認テキスト) は全て必須**: 事前承認は 3 条件目「人間 approve」の同等物として扱う
+- **GitHub Approve review は不要** (orchestrator がコメントで approve を兼ねる)、ただし PR description / merge commit message に「orchestrator 明示承認による R-15 代替」を必ず記録
+
+## squash merge vs merge commit
+
+| 種別 | コマンド | 採用基準 |
+|---|---|---|
+| **squash merge (既定)** | `gh pr merge --squash <PR#>` | 単一論点の Plan / Epic 配下 PR / 小型 harness PR (大多数のケース) |
+| **merge commit** | `gh pr merge --merge <PR#>` | 複数 commit の独立性を保ちたい場合 (A2-2 PR #125 が `--merge` 採用、35 ファイル本格化の commit 履歴保持) |
+| **rebase merge** | `gh pr merge --rebase <PR#>` | 採用しない (linear history は squash で十分) |
+
+## merge 前のチェックリスト
+
+```text
+- [ ] CI 全 check が pass / neutral (gh pr checks)
+- [ ] code-reviewer 4-8 aspect の Critical findings = 0 (Coordinator 集約結果)
+- [ ] 人間 approve または orchestrator 事前承認テキストあり
+- [ ] PR description frontmatter の type / related_plan / related_epic / related_specs / related_adrs / expected_modules が埋まっている
+- [ ] commit-message subject が Conventional Commits 形式に準拠
+- [ ] master との rebase 状況確認 (`gh pr view <PR#> --json mergeable`)
+- [ ] (mirror PR の場合) 対象フェーズ ID / 完了根拠表更新内容を本文に記載
+- [ ] (refactor PR の場合) Behavior Preservation 証拠 (`./gradlew check` + Roborazzi diff) を本文に記載
+- [ ] (Renovate PR の場合) 互換性影響セクションが埋まっている
+```
+
+## merge 後の追跡アクション (Phase 8)
+
+- **pr-poller 即時起動** → `pr-retrospective` Skill で learning ファイル生成 (`harness/learnings-batch-YYYY-WW` ブランチ)
+- **roadmap-tracker 起動** (Epic 配下 PR / B-A-C フェーズ項目のみ、Plan 単体は対象外) → `docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` の完了根拠表 + 着手順変更履歴を更新
+- **mirror PR がない場合は手動更新 PR を別途起票** (`harness/roadmap-mirror-<phase-id>`、A3 まで継続)
+- 詳細は `.claude/rules/implementation-workflow.md` Phase 8 + `.claude/rules/roadmap.md` 参照
+
+## 機械検証 (A6 で導入予定)
+
+- **GitHub branch protection**: `Allow auto-merge` を OFF、`Require approvals: 1` (orchestrator)、`Require status checks to pass before merging` を有効化
+- **GitHub Actions**: PR merge イベントで「auto-merge=true で merge された PR」を検出 → orchestrator に警告通知 (R-15 違反検出)
+- **Gradle カスタムタスク**: `pr-poller` 起動時に最近 N 日の merged PR について「Critical = 0 のレビューが Coordinator から post されている」「人間 approve または orchestrator 事前承認テキストの存在」を二重チェック
+
+## Gotchas
+
+- **`Allow auto-merge` を OFF に保つ**: GitHub branch protection 設定変更時 (A6) も auto-merge は無効化のまま
+- **Critical 0 でも保留判断は OK**: code-reviewer Coordinator が「Critical = 0 → Ready」と判定しても、人間が「もう少し見たい」と判断したら Ready 昇格を保留する
+- **orchestrator 明示承認は本 PR の type で記録**: PR description に承認文言の引用 (orchestrator 指示テキストの抜粋) を残し、後追い監査可能性を担保
+- **fix loop 上限超過 (3 回) で merge readiness 不可** (`implementation-workflow.md` R-14)、Plan status を `blocked` に書き換えて人間に通知
+- **mirror PR は merge readiness の 3 条件が緩和される**: CI 対象が docs のみ (実装コード変更ゼロ) のため `pass / neutral` 判定、code-reviewer は spec-conformance / architecture / security の 3 aspect で十分 (visual-regression / design-tokens / performance / test-quality / code-quality は skip 妥当)、人間 approve は orchestrator 事前承認で代替可
+
+## 関連
+
+- ADR 0018 (`implementation-workflow` 10 フェーズ設計)
+- ADR 0019 (`code-reviewer` 8 aspect + Coordinator + Merge readiness 判定)
+- `docs/harness/plan.md` §5.4.3 / R-15
+- `.claude/rules/{implementation-workflow,code-reviewer-aspects,pr-draft-policy,pr-template,roadmap}.md`
+- `.claude/skills/{implementation-workflow,code-reviewer}/SKILL.md`

--- a/.claude/rules/merge-readiness.md
+++ b/.claude/rules/merge-readiness.md
@@ -84,7 +84,7 @@ related_plan: docs/harness/plan.md §5.4.3 / R-15
 - **Critical 0 でも保留判断は OK**: code-reviewer Coordinator が「Critical = 0 → Ready」と判定しても、人間が「もう少し見たい」と判断したら Ready 昇格を保留する
 - **orchestrator 明示承認は本 PR の type で記録**: PR description に承認文言の引用 (orchestrator 指示テキストの抜粋) を残し、後追い監査可能性を担保
 - **fix loop 上限超過 (3 回) で merge readiness 不可** (`implementation-workflow.md` R-14)、Plan status を `blocked` に書き換えて人間に通知
-- **mirror PR は merge readiness の 3 条件が緩和される**: CI 対象が docs のみ (実装コード変更ゼロ) のため `pass / neutral` 判定、code-reviewer は spec-conformance / architecture / security の 3 aspect で十分 (visual-regression / design-tokens / performance / test-quality / code-quality は skip 妥当)、人間 approve は orchestrator 事前承認で代替可
+- **mirror PR は merge readiness の 3 条件が緩和される**: CI 対象が docs のみ (実装コード変更ゼロ) のため `pass / neutral` 判定、code-reviewer の aspect セットは `code-reviewer-aspects.md` Gotchas で SoT 化 (mirror PR は spec-conformance / architecture / security の 3 aspect、harness PR は code-quality を加えた 4 aspect)、人間 approve は orchestrator 事前承認で代替可
 
 ## 関連
 

--- a/.claude/rules/pr-draft-policy.md
+++ b/.claude/rules/pr-draft-policy.md
@@ -1,0 +1,95 @@
+---
+id: rules-pr-draft-policy
+title: Draft PR ポリシー (Draft → Ready 昇格条件)
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".claude/skills/implementation-workflow/**"
+related_adrs:
+  - ADR-0018
+related_plan: docs/harness/plan.md §5.4.2 / R-15
+---
+
+# pr-draft-policy.md — Draft PR ポリシー
+
+> `implementation-workflow` Phase 5 で起票する PR は **既定で Draft** とし、code-reviewer 通過 +
+> 人間 approve を経て Ready に昇格する。本 rule は Draft で push する状況と Ready 昇格条件、
+> Draft 中の WIP commit ポリシーを規定。
+
+## 既定: Phase 5 は `--draft` で起票
+
+```bash
+gh pr create --draft --template <type>.md ...
+```
+
+- Phase 5 (`implementation-workflow.md` 参照) で `--draft` を必ず付与
+- 理由: code-reviewer (Phase 6) 通過前の状態を Ready で公開すると、orchestrator や他レビュアーが「もう merge 可」と誤認するリスク
+- 例外: orchestrator が「Draft 不要、即 Ready で起票」と明示指示した場合のみ Ready で起票可
+
+## Draft で push / 維持する状況
+
+| 状況 | 説明 | 次のアクション |
+|---|---|---|
+| Phase 5 直後 | code-reviewer 未起動、初回 commit push のみ | Phase 6 を起動 |
+| Phase 6 fix loop 中 | Critical 修正中 (1〜3 回目) | 修正 commit を追加 push、Phase 6 を再起動 |
+| WIP / 進捗共有 | 大規模 PR で途中まで実装、レビュアーから方針 feedback を受けたい | description に `WIP: <現状>` セクションを追加、Ready 化は方針確定後 |
+| セルフチェック中 | 自分の差分を `gh pr diff` で再確認 / commit 整理中 | `git rebase -i` 等で整理後、Phase 6 へ |
+| CI 失敗修正中 | `./gradlew check` の lint / test 失敗を修正中 | 修正 commit push、Phase 6 へ |
+
+## Ready 昇格条件 (3 条件、`merge-readiness.md` と整合)
+
+| 条件 | 判定方法 |
+|---|---|
+| CI green | `gh pr checks <PR#>` で全 check pass / neutral |
+| code-reviewer Critical = 0 | Phase 6 Coordinator 集約で全 aspect の Critical findings ゼロ |
+| 人間 approve または orchestrator 事前承認 | `gh pr review --approve` または PR description / orchestrator 指示テキストに明示承認 |
+
+3 条件充足後に:
+
+```bash
+gh pr ready <PR#>
+```
+
+で Ready 昇格。
+
+## Draft 中の WIP commit ポリシー
+
+- **WIP commit は許容** (`commit-message.md` 規約は満たしつつ、subject に `WIP:` プレフィックスを付与せず Conventional Commits 形式維持)
+- **squash merge で WIP 履歴は集約される** ため、Draft 中の中間 commit は粒度を気にしすぎない
+- **`--amend` は NG**: hook 失敗時も新規 commit を作成 (`commit-message.md` Gotchas と整合)
+- **fixup commit (`git commit --fixup`) は許容**: squash merge で消えるため、PR 内部の整理用途として使ってよい
+- **stash / WIP branch 切り替え** で他作業と並行する場合は worktree 並列を優先 (`branch-naming.md` / `implementation-workflow.md` Phase 0)
+
+## Draft → Ready 昇格時のチェックリスト
+
+```text
+- [ ] CI 全 check pass / neutral (gh pr checks)
+- [ ] code-reviewer Coordinator が「Critical = 0、Ready」と判定 (PR コメント post 済)
+- [ ] PR description frontmatter (HTML コメント) の必須キーが埋まっている
+- [ ] PR description 本文の必須セクション (type 別) が記入済
+- [ ] 三層指標差分セクションが N/A 明記 (A7 完了前) または値が記入済 (A7 完了後)
+- [ ] (refactor PR) Behavior Preservation 証拠記入済
+- [ ] (Renovate PR) 互換性影響セクション記入済
+- [ ] (Epic 配下 PR / mirror PR) 対象 Phase ID / 完了根拠表更新内容記入済
+- [ ] commit-message subject が Conventional Commits 形式準拠 (機械検証は commit-msg hook で実施済のはず)
+```
+
+## 機械検証 (A6 で導入予定)
+
+- **GitHub Actions**: PR が `ready_for_review` イベントを発火したときに上記チェックリストを検証、未充足項目があれば warning コメント + Ready 昇格を block するか継続するかを orchestrator 判断
+- **`gh pr view --json isDraft`** を pr-poller が定期実行、Draft 状態が 7 日以上継続している PR をリストアップ (stale PR 検知)
+
+## Gotchas
+
+- **Draft の長期放置は避ける**: 7 日以上 Draft が続く PR は status (実装方針見直し / 着手停止 / 削除) を明示。pr-poller が stale 検出 (A4 / A6 で本格化)
+- **`gh pr ready` を呼ぶ前に必ず 3 条件確認**: Ready 昇格後に Critical 発覚 → `gh pr ready --undo` で Draft に戻すのは可能だが、レビュアーの混乱を招く
+- **Draft でも CI は走る**: Phase 6 と並行して CI green を確認、CI 失敗時は code-reviewer の前に Phase 3 fix loop に戻る
+- **Draft PR にも `.github/PULL_REQUEST_TEMPLATE/<type>.md` が適用される**: `--template` 省略禁止は Draft / Ready 共通 (`pr-template.md` 規約)
+- **mirror PR (`harness/roadmap-mirror-<phase-id>`) は Draft 経由を省略可**: 完了根拠表 + 着手順変更履歴の追記のみで実装コード変更ゼロのため、`--draft` なしで起票して即 Ready (orchestrator 事前承認による R-15 代替パス、`merge-readiness.md` 参照)
+
+## 関連
+
+- ADR 0018 (`implementation-workflow` 10 フェーズ設計、Phase 5 / Phase 7 の位置付け)
+- `docs/harness/plan.md` §5.4.2 / R-15
+- `.claude/rules/{implementation-workflow,merge-readiness,pr-template,code-reviewer-aspects,commit-message,branch-naming}.md`
+- `.claude/skills/implementation-workflow/SKILL.md`

--- a/.claude/rules/pr-poller.md
+++ b/.claude/rules/pr-poller.md
@@ -1,64 +1,109 @@
 ---
 id: rules-pr-poller
 title: pr-poller ローカルポーリング規約
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - ".claude/skills/pr-poller/**"
   - ".claude/locks/**"
-  - ".claude/rules/harness-meta-criteria.md"
-related_plan: docs/harness/plan.md §5.3 / §6.2 A4 / ADR 0017
+related_adrs:
+  - ADR-0017
+related_plan: docs/harness/plan.md §5.3 / §6.2 A4 / R-11 / R-12
 ---
 
 # pr-poller.md — ローカルポーリング規約
 
 > `pr-poller` Skill の動作規約。3 系統の起動経路に対応した排他制御と
-> 未処理 PR 検出ロジックを規定。
+> 未処理 PR 検出ロジック、Renovate 系 PR の自動判別、キャッチアップ動作を規定。
 
-## 起動経路 (3 系統)
+## 3 系統の起動経路
 
 | 経路 | 契機 | 導入時期 |
 |---|---|---|
-| 手動起動 | ローカル Claude Code 起動直後のユーザー指示 | **B0 から利用可** |
-| `CronCreate` | 日次 09:00 JST のスケジュール起動 | A4 で導入 |
-| `ScheduleWakeup` | 継続ループ (前回処理から N 時間後) | A4 で導入 |
+| **手動起動** | ローカル Claude Code 起動直後のユーザー指示 (`/pr-poller` 等) | **B0 から利用可** |
+| **CronCreate (日次)** | 09:00 JST のスケジュール起動 (Claude Code routine) | A4 で導入 |
+| **ScheduleWakeup (継続ループ)** | 前回処理から N 時間後の自動再起動 (`/loop` skill 経由) | A4 で導入 |
 
 ## 排他制御
 
-- 起動時に `.claude/locks/pr-poller.lock` を排他取得 (PID + 取得時刻を記録)
-- 既存ロックが **N 分以内** (デフォルト 30 分) なら no-op で終了
-- N 分超過なら stale lock と判定して上書き取得
-- 正常終了時に lock を削除
+- 起動時に `.claude/locks/pr-poller.lock` を排他取得
+- ロックファイル内容: `<PID>\n<取得時刻 ISO8601>\n<起動経路 (manual/cron/wakeup)>`
+- 既存ロックが **N 分以内** (デフォルト 30 分) なら no-op で終了 (二重起動防止)
+- N 分超過なら stale lock と判定して上書き取得 + warning ログ出力
+- 正常終了時に lock を削除、異常終了 (SIGKILL 等) で残ったロックは次回 stale 判定で自動削除
 
-## 検出ロジック
+## 検出ロジック (Phase 1: merged/closed PR)
 
-1. `gh pr list --state merged,closed --search "merged:>$LAST_RUN"` で未処理候補 PR を取得
+1. **`gh pr list --state merged,closed --search "merged:>$LAST_RUN"`** で未処理候補 PR を取得
+   - `$LAST_RUN` は前回処理時刻 (`.claude/locks/pr-poller.last-run` に記録、なければ 7 日前)
 2. `docs/harness/learnings/YYYY-MM-DD-pr-<N>.md` の存在をチェックして処理済 PR を除外
-3. 残りに対して `pr-retrospective` Skill を順次起動
-4. open PR で `labels:renovate` が付くものを別途検出 → `dependency-upgrade` Skill を起動 (R-37 / ADR 0017)
-5. `roadmap-tracker` の `<!-- evidence:pending-fetch -->` 項目を再走査 (R-35)
+3. 残りに対して `pr-retrospective` Skill を順次起動 (`retrospective-format.md` 規約)
+4. learning ファイル生成と同時に `harness/learnings-batch-YYYY-WW` ブランチへ push (R-12 ロスト対策)
+
+## 検出ロジック (Phase 2: Renovate ラベル open PR)
+
+5. **`gh pr list --state open --label renovate`** で Renovate 系 open PR を取得
+6. 残りに対して `dependency-upgrade` Skill を起動 (R-37 / ADR 0017、A4 で本格化)
+   - `dependency-upgrade.md` PR テンプレ + `dependency-upgrade` Plan type と整合 (`pr-template.md` / `plan.md`)
+7. **Renovate ラベルの自動判別**: `labels:renovate` / `dependencies` / `renovate-bot` のいずれか付与で対象
+
+## 検出ロジック (Phase 3: pending-fetch 再走査)
+
+8. `roadmap-tracker` の `<!-- evidence:pending-fetch -->` コメント有項目を再走査 (R-35)
+9. 該当 PR の `gh pr view` 取得を再試行、成功時は roadmap.md の完了根拠を埋める + コメントを削除
 
 ## harness-meta 起動閾値
 
-以下のいずれかを満たしたら `harness-meta` を自動起動 (デフォルト値、`harness-meta-criteria.md` で上書き可能):
+以下のいずれかを満たしたら `harness-meta` Skill を自動起動 (デフォルト値、`harness-meta-criteria.md` で上書き可能):
 
-- 未処理 learning が **10 件** 蓄積
-- 前回 `harness-meta` 実行から **7 日経過**
+| 条件 | デフォルト値 |
+|---|---|
+| 未処理 learning が蓄積 | **10 件** |
+| 前回 `harness-meta` 実行からの経過 | **7 日** |
+| 連続実行間隔 (最小) | 24 時間 |
+
+上書きは `harness-meta-criteria.md` §pr-poller 起動閾値 (本格化済) または `pr-poller` 起動引数で指定。
 
 ## キャッチアップ動作 (R-11 対策)
 
-長期不在後の再開で取りこぼしを防ぐため、起動時に「最後の処理から N 日経過した PR」を
-最優先で処理する。
+長期不在後の再開で取りこぼしを防ぐため、起動時に以下を実行:
+
+1. `$LAST_RUN` が **3 日以上前** なら「最後の処理から経過した PR」を最優先で処理
+2. 件数が 30 件超なら orchestrator に warning 通知 + 古い順から 10 件ずつ batch 処理
+3. batch 処理中に新たな merged PR を発見しても優先順位は変えず (FIFO)
+
+## gh CLI 失敗時のリトライ
+
+- 指数バックオフ (1s → 2s → 4s)、最大 3 回
+- それでも失敗したら当該 PR を次回再試行に回し warning ログ
+- 連続 5 件失敗 (`gh` CLI 自体の不調) で `pr-poller` を緊急停止、orchestrator に通知
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: `.claude/locks/pr-poller.lock` の stale 検出 (60 分超過は orchestrator 通知)
+- **GitHub Actions**: merged PR について N 日以内に learning ファイルが起票されているか check (R-12 ロスト検出)
+- **`pr-poller` Skill 自体の self-check**: 起動時に `.claude/skills/pr-poller/SKILL.md` の status と本 rule の整合確認
+
+## A3 / A4 で本格化する MVP
+
+- **A3**: Phase 1 (merged PR → pr-retrospective) を Skill 駆動で本格化、現状は手動代替 (PR #117 / #119 / #121 の learning は手動生成)
+- **A4**: Phase 2 (Renovate ラベル PR → dependency-upgrade) を Skill 駆動で本格化、CronCreate / ScheduleWakeup の自動起動経路を追加
+- **A4**: harness-meta 自動起動閾値の機械化 (本 rule の閾値表を parse)
 
 ## Gotchas
 
-- **GitHub Actions では呼ばない** (Claude API コスト回避、ADR 0017)。
-- gh CLI 失敗時はリトライ (指数バックオフ、最大 3 回)、それでも失敗したら警告を出して当該 PR を次回再試行に回す。
-- learning ファイル生成と同時に `harness/learnings-batch-YYYY-WW` ブランチへ push (R-12 ロスト対策)。
+- **GitHub Actions では呼ばない** (Claude API コスト回避、ADR 0017)、ローカル Claude Code 内のみで動作
+- **gh CLI 失敗時はリトライ + 当該 PR を次回再試行に回す**、無限ループ禁止
+- **learning ファイル生成と `harness/learnings-batch-YYYY-WW` ブランチへの push は同時実行** (R-12 ロスト対策、片方の失敗で他方も rollback)
+- **`harness-meta` の二重起動防止**: pr-poller が `harness-meta` 自動起動した直後に手動起動された場合、`.claude/locks/harness-meta.lock` で排他制御 (A4 で導入)
+- **PII / secrets redaction を必ず通す** (`.claude/rules/pii.md` / `secrets.md`)、`gh pr view` 出力 / CI ログ抜粋 / MCP 結果に注意
+- **キャッチアップ動作中の新規 PR**: 優先順位を変えず FIFO で処理、batch 完走後に新規分を次回処理
+- **`labels:renovate` 判別** は `dependencies` / `renovate-bot` ラベルも対象 (Renovate 設定変更時に追加可能)
 
 ## 関連
 
-- `docs/harness/plan.md` §5.3 / §6.2 A4 / R-11 / R-12
-- ADR 0017 (ローカル Claude Code ポーリング駆動)
-- `.claude/skills/pr-poller/SKILL.md`
-- `.claude/rules/harness-meta-criteria.md` (A4 で本格化、起動閾値を上書き可能)
+- ADR 0017 (ローカル Claude Code ポーリング駆動、GitHub Actions から呼ばない原則)
+- `docs/harness/plan.md` §5.3 / §6.2 A4 / R-11 / R-12 / R-35
+- `.claude/rules/{retrospective-format,harness-meta-criteria,harness-evolution,roadmap}.md`
+- `.claude/skills/{pr-poller,pr-retrospective,harness-meta,dependency-upgrade}/SKILL.md`
+- `docs/harness/learnings/INDEX.md` (learning 索引)

--- a/.claude/rules/pr-template.md
+++ b/.claude/rules/pr-template.md
@@ -1,0 +1,140 @@
+---
+id: rules-pr-template
+title: PR テンプレート選択と gh pr create 運用規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - ".github/PULL_REQUEST_TEMPLATE/**"
+  - ".github/pull_request_template.md"
+  - ".claude/skills/implementation-workflow/**"
+related_adrs:
+  - ADR-0024
+  - ADR-0027
+related_plan: docs/harness/plan.md §4.8 / §5.4.2
+---
+
+# pr-template.md — PR テンプレート選択と gh pr create 運用規約
+
+> 本リポジトリの全 PR は `.github/PULL_REQUEST_TEMPLATE/<type>.md` から該当 type を
+> 選択し、`gh pr create --template <type>.md` で起票する。デフォルト
+> `.github/pull_request_template.md` は最小フォールバックのみ。詳細運用は本 rule で SoT 化。
+
+## 6 種類のテンプレート
+
+| ファイル | 用途 | ブランチ prefix | commit type | 関連 Plan type |
+|---|---|---|---|---|
+| `feature.md` | 新機能追加 | `feature/PLAN-NNN-*` または `feature/EPIC-NNN-*-pr-NN` | `feat` | `feature-request` |
+| `bugfix.md` | バグ修正 | `fix/PLAN-NNN-*` | `fix` | `bug-fix` |
+| `refactor.md` | リファクタ (振る舞い不変) | `refactor/PLAN-NNN-*` | `refactor` | `refactor` |
+| `dependency-upgrade.md` | 依存更新 (Renovate / 手動) | `renovate/*` (自動) または `chore/<slug>` | `chore` / `build` | `dependency-upgrade` |
+| `docs.md` | docs 単独更新 | `docs/PLAN-NNN-*` | `docs` | `docs` |
+| `harness.md` | ハーネス改修 / レトロ起票 / mirror | `harness/<purpose>` | `feat(harness)` / `docs(harness)` | `harness` |
+
+## 起票コマンド
+
+```bash
+gh pr create \
+  --base master \
+  --head <branch-name> \
+  --title "<conventional-commits-subject>" \
+  --template <type>.md \
+  --draft
+```
+
+- **`--template` は必須**: 省略するとデフォルトテンプレが選ばれ、type 別の必須セクション (Behavior Preservation / レトロ要約等) が抜ける
+- **`--draft` は Phase 5 の既定**: Draft → Ready 昇格は `.claude/rules/pr-draft-policy.md` 参照
+- **`--body-file` 代替**: 大量の自動生成本文 (フェーズ ID / Plan ID / Epic ID 等の埋め込み済 body) を流し込む場合は `--body-file <path>` を `--template` 代わりに使用 (テンプレ構造は手動で揃える)
+
+## PR description frontmatter 規約
+
+各テンプレ冒頭に以下の YAML frontmatter (コメント擬装の HTML フォーマット) を必須化:
+
+```html
+<!-- pr-frontmatter
+type: feature | bugfix | refactor | dependency-upgrade | docs | harness
+related_plan: PLAN-NNN | null
+related_epic: EPIC-NNN | null
+related_specs:
+  - SPEC-NNN-N
+related_adrs:
+  - ADR-NNNN
+expected_modules:
+  - <touch 予定の glob>
+-->
+```
+
+- frontmatter は HTML コメント (`<!-- pr-frontmatter ... -->`) として埋め込む (GitHub は YAML frontmatter を render しないため)
+- `pr-poller` / `code-reviewer` / `roadmap-tracker` が parse 対象
+- 配列は block 形式必須 (`docs-structure.md` と整合)
+
+## 必須セクション (type 別)
+
+### feature.md / bugfix.md / refactor.md
+
+- 概要 (3 行以内 summary)
+- 変更内容 (主要ファイル + 差分要約)
+- 受け入れ基準 (AC) チェックリスト
+- 三層指標差分 (Line / Branch / Spec coverage、Mutation score)
+- レビュー観点 (人間レビュアー向け)
+- 関連: Plan / Epic / ADR / SPEC リンク
+
+### refactor.md (追加)
+
+- **Behavior Preservation 証拠**: `./gradlew check` 結果 + `verifyRoborazziDebug` 結果 + visual-regression diff の human review 結果
+
+### dependency-upgrade.md
+
+- 更新パッケージ一覧 (before / after バージョン)
+- 互換性影響 (Breaking change の有無)
+- 検証手順 (`./gradlew check` + 影響範囲のスモークテスト)
+
+### docs.md
+
+- 更新 docs 一覧 (ファイル + 主旨)
+- SoT 影響 (plan.md / ADR / rules への波及有無)
+- レビュー観点 (技術的正確性 vs 表記揺れ)
+
+### harness.md
+
+- 対象 PR / KPT 要約 (レトロ起票時)
+- ハーネス改善提案件数 (採用 / 見送り / 保留)
+- 関連 learning ファイル / evolution proposal リンク
+- mirror PR の場合: 対象フェーズ ID / 自動同期の手動代替である旨
+
+## 三層指標差分セクションの空欄ルール
+
+A7 完了前は **三層指標 (Kover / Konsist Spec coverage / PITest) が未導入** のため、`feature.md` / `bugfix.md` / `refactor.md` テンプレの「三層指標差分」セクションは:
+
+- **A7 完了まで**: `N/A (Kover/Konsist Spec/PITest 未導入、A7 で導入予定)` と記載 (空欄禁止、誤読防止)
+- **A10 完了まで**: UI 変更時は Roborazzi screenshot 添付のみで可、`visual-regression` aspect の binary checklist は skip 妥当
+- **A7 完了後**: Before / After / Δ を Kover / Konsist / PITest の出力値で埋める
+
+詳細は各テンプレ冒頭の注記参照。
+
+## auto-merge 禁止
+
+- **GitHub の auto-merge 機能は使わない** (R-15 / `.claude/rules/merge-readiness.md`)
+- 人間 approve 後に `gh pr merge --squash` (または `--merge`) を手動実行
+- orchestrator (subroh0508) からの明示的事前承認による R-15 代替は許可 (A2-2 / A2-5 の実績、本格化は A3 で `.claude/rules/merge-readiness.md` 参照)
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: `.github/PULL_REQUEST_TEMPLATE/*.md` 各ファイルが必須セクション 5-7 種を含むか検証 (frontmatter 必須キー JSON Schema、本文 H2 リスト)
+- **GitHub Actions**: PR open 時に body の `<!-- pr-frontmatter ... -->` を parse し、必須キー (`type` / `related_plan` または `related_epic`) の存在を warning コメント (A6 / detekt 統合と同時)
+
+## Gotchas
+
+- **`--template` 省略は禁止**: デフォルトテンプレ (`.github/pull_request_template.md`) は最小骨格、type 別必須セクションが抜けるため
+- **frontmatter は HTML コメント形式**: GitHub Markdown 仕様で YAML frontmatter を render しないため、`<!-- pr-frontmatter ... -->` で擬装
+- **harness.md は branch-naming `harness/<purpose>` 専用**: feature/bugfix/refactor 等の Plan PR では使わない (`branch-naming.md` と整合)
+- **三層指標差分セクションは A7 完了まで `N/A` 必須記載** (空欄での暗黙了解は禁止、A1 レトロ Problem の防止)
+- **mirror PR は harness.md 必須**: `roadmap-tracker` Phase 8 自動同期の手動代替 PR (`harness/roadmap-mirror-<phase-id>`) は harness.md を選択、対象フェーズ ID と完了根拠表更新内容を本文に明記
+- **draft / ready の昇格条件**: `.claude/rules/pr-draft-policy.md` 参照、本 rule では「Phase 5 で `--draft` 起票が既定」のみ規定
+
+## 関連
+
+- ADR 0024 (`gh` CLI 採用、PR 操作の SoT)
+- ADR 0027 (テンプレ言語 / docs 構造)
+- `docs/harness/plan.md` §4.8 / §5.4.2
+- `.github/PULL_REQUEST_TEMPLATE/{feature,bugfix,refactor,dependency-upgrade,docs,harness}.md`
+- `.claude/rules/{branch-naming,commit-message,pr-draft-policy,merge-readiness,implementation-workflow}.md`

--- a/.claude/rules/retrospective-format.md
+++ b/.claude/rules/retrospective-format.md
@@ -1,100 +1,200 @@
 ---
 id: rules-retrospective-format
 title: pr-retrospective が生成する learning ファイルの構造化フォーマット
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "docs/harness/learnings/**/*.md"
   - ".claude/skills/pr-retrospective/**"
   - ".claude/skills/pr-poller/**"
   - ".claude/skills/harness-meta/**"
-related_plan: docs/harness/plan.md §4.4 / §5.5
+related_adrs:
+  - ADR-0026
+  - ADR-0027
+related_plan: docs/harness/plan.md §4.4 / §5.4.5 / R-12
 ---
 
 # retrospective-format.md — learning ファイル構造化フォーマット
 
 > `pr-retrospective` Skill が `docs/harness/learnings/YYYY-MM-DD-pr-<n>.md` を生成する際の
 > 構造化フォーマット定義。`harness-meta` は本フォーマットに依存して提案セクションを parse する。
+> harness-meta / harness-evolution / pr-poller の入力規格として SoT 化。
 
 ## ファイル名規約
 
-```
+```text
 docs/harness/learnings/YYYY-MM-DD-pr-<n>.md
 ```
 
-`YYYY-MM-DD` は PR のマージ日。`<n>` は PR 番号。1 PR = 1 ファイル。
+- `YYYY-MM-DD` は PR のマージ日 (UTC または JST、`generated_at` で明示)
+- `<n>` は PR 番号 (`#NNN` の `NNN` 部分)
+- 1 PR = 1 ファイル
+- 補助ファイル: `docs/harness/learnings/INDEX.md` (索引) / `flaky-tests.md` (フレーキー再現条件蓄積、A2-1 で追加済)
 
-## frontmatter
+## frontmatter (必須)
 
 ```yaml
 ---
 id: learning-pr-NNN
-title: PR #NNN レトロスペクティブ
+title: PR #NNN レトロスペクティブ (<簡潔な要約>)
 type: learning
 status: draft | reviewed | actioned
 related_pr: NNN
-related_plan: PLAN-NNN
-related_epic: EPIC-NNN
+related_plan: PLAN-NNN | —
+related_epic: EPIC-NNN | —
 generated_at: YYYY-MM-DDTHH:MM:SSZ
-generator: pr-retrospective Skill (vX.Y.Z)
+generator: pr-retrospective Skill (vX.Y.Z) | pr-retrospective (skeleton、本ペインで手動代替実行)
 ---
 ```
 
-## 本文フォーマット (日本語見出し、§5.5 例)
+- 配列は block 形式必須 (`docs-structure.md` frontmatter 規約)
+- `related_plan` / `related_epic` は該当時のみ記入、不在は `—` で明示 (空欄禁止)
+- `generator` 値は skeleton 段階 (A3 本格化前) は手動代替実行を明示
+
+## 本文構造 (日本語見出し、§5.5 例)
 
 ```markdown
 # PR #NNN レトロスペクティブ
 
-> 生成: pr-retrospective Skill (v1.0.0) at YYYY-MM-DDTHH:MM:SSZ
+> 生成: pr-retrospective Skill (vX.Y.Z) at YYYY-MM-DDTHH:MM:SSZ
 > 関連 Plan: PLAN-NNN / 関連 Epic: EPIC-NNN
+> 対象 PR: [<commit subject> #NNN](https://github.com/<owner>/<repo>/pull/NNN) (squash merged at YYYY-MM-DDTHH:MM:SSZ、commit `<sha>`、from head `<sha>`)
+> 差分: <ファイル数> ファイル / +<追加> / -<削除> (<diff 行数> diff 行)、commits: <初回> + <fix loop> (該当時)
 
 ## ✅ Keep (継続したいこと)
+
 - ...
 
 ## ⚠️ Problem (詰まったこと / 制約)
+
 - ...
 
 ## 🚀 Try (次回からの改善案)
+
 - ...
 
 ## 📊 指標
-| 指標 | Before | After | Δ |
-|---|---|---|---|
-| Line coverage | 100.00% | 100.00% | ±0 |
-| Branch coverage | 100.00% | 100.00% | ±0 |
-| Spec coverage | 98.4% | 100.0% | +1.6 |
-| Mutation score | 86.2% | 88.1% | +1.9 |
+
+| 指標 | Before | After | Δ | 備考 |
+|---|---|---|---|---|
+| Line coverage | 100.00% | 100.00% | ±0 | Kover (A7 完了後) / N/A (A7 完了前) |
+| Branch coverage | 100.00% | 100.00% | ±0 | 同上 |
+| Spec coverage | 98.4% | 100.0% | +1.6 | Konsist `@Spec` カバー率 (A7 完了後) / N/A |
+| Mutation score | 86.2% | 88.1% | +1.9 | PITest (A7 完了後) / N/A |
+| Lint 違反数 | 0 | 0 | ±0 | Spotless / ktlint / detekt / markdownlint-cli2 (A6 完了後) / N/A |
+| (任意) ファイル数 / 行数 / 他 PR 固有指標 | ... | ... | ... | ... |
 
 ## 🤖 ハーネス改善提案
+
 <!-- harness-meta が parse する正規構造 -->
+
 - [ ] `[rule]` ...
 - [ ] `[skill]` ...
 - [ ] `[template]` ...
 - [ ] `[remove]` ...
 
 ## 📝 harness-meta フィードバック
+
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
+
+### YYYY-MM-DD <PR ID> で消化 (採用)
+
+| 提案 | <PR ID> での消化内容 |
+|---|---|
+
+### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+
+| 提案 | 見送り理由 / 移行先 |
+|---|---|
+
+### YYYY-MM-DD <PR ID> で保留 (要再評価)
+
+| 提案 | 保留理由 |
+|---|---|
 ```
 
-## ハーネス改善提案のプレフィックス
+## 各セクションの規約
+
+### ✅ Keep / ⚠️ Problem / 🚀 Try
+
+- **Keep**: 継続したい運用 / 構造 / 判断 (成功要因の言語化)
+- **Problem**: 詰まった点 / 制約 / latent contradiction (PR #121 plan.md L1125 / PR #117 「既存」誤宣言のような構造的課題)
+- **Try**: 次回 PR / フェーズで実施したい改善 (Plan / Epic / ADR / rule 単位まで具体化)
+- 各セクション最低 3 項目、推奨 5-10 項目
+- 各項目に **consensus 表記 (どの aspect が指摘したか)** を併記推奨 (例: `consensus: spec-conformance + architecture`)
+
+### 📊 指標
+
+- 三層指標 (Line / Branch / Spec / Mutation) は A7 完了前は `N/A` 必須 (空欄禁止)
+- Lint 違反数は A6 完了前は `N/A`
+- PR 固有指標 (ファイル数 / 行数 / Critical findings / binary checklist 通過率) を任意で追加可
+- Before / After / Δ / 備考 の 4 列固定
+
+### 🤖 ハーネス改善提案
 
 `harness-meta` は以下のプレフィックスを parse して分類する:
 
-| プレフィックス | 意味 |
-|---|---|
-| `[rule]` | `.claude/rules/*.md` の新規追加・改修 |
-| `[skill]` | `.claude/skills/*/` の新規追加・改修 |
-| `[template]` | テンプレート Markdown (PR / Plan / Epic / Learning 等) の改修 |
-| `[remove]` | 未使用 rule / dormant Skill の撤去候補 |
+| プレフィックス | 意味 | 採用時の対応先 rule / Skill |
+|---|---|---|
+| `[rule]` | `.claude/rules/*.md` の新規追加・改修 | 該当 rule 直接編集 PR (`harness-meta-criteria.md` 採用判定) |
+| `[skill]` | `.claude/skills/*/` の新規追加・改修 | `example-skills:skill-creator` 経由 (`skill-authoring.md`) |
+| `[template]` | テンプレート Markdown 改修 | テンプレファイル直接編集 PR |
+| `[remove]` | 未使用 rule / dormant Skill の撤去候補 | `harness-meta-criteria.md` 撤去基準充足時のみ |
+
+- 各項目は **チェックボックス `[ ]` で起票**、`harness-meta` 採用時に `[x]` + 採用先 PR リンクを追記
+- 各項目に **採用判定基準該当箇所 (1〜5、`harness-meta-criteria.md`)** を併記推奨
+
+### 📝 harness-meta フィードバック
+
+- 採用 / 見送り / 保留の 3 表を含む
+- 各表は `harness-meta` Skill が追記、人間レビューでも追記可
+- 1 ファイル内で「提案 → 結果」の往復ログを完結 (R-12 learning ロスト対策)
+
+## redaction チェックポイント (Skill 出力前)
+
+`pr-retrospective` Skill が learning ファイルを生成する直前に以下を確認:
+
+- [ ] CI ログ抜粋 / `gh pr view` 出力 / MCP 結果に PII / secrets が含まれていない (`.claude/rules/pii.md` / `secrets.md` redaction)
+- [ ] 「Reviewed by X」「Authored by Y」等の自然文に display name が混入していない
+- [ ] スタックトレース / エラーメッセージに `sub` claim 値が含まれていない
+- [ ] 「📝 harness-meta フィードバック」セクションは空でも見出しを残す (`harness-meta` が後追記する場所)
+- [ ] frontmatter 配列が block 形式
+- [ ] 5 行 summary が冒頭 blockquote (>) に存在
+
+検出時は `[REDACTED-*]` プレースホルダ置換してから出力 (`pii.md` / `secrets.md` 同等)。
+
+## PR コメント post の禁止
+
+- **PR コメントとして retrospective を post しない**、learning ファイルが Single Source of Truth (§4.4)
+- `code-reviewer` の Coordinator レビューコメントは別運用 (`code-reviewer-aspects.md` 参照)、retrospective は merge **後** に生成
+
+## learning ファイルの集約と週次 PR
+
+- 各 learning ファイルは `harness/learnings-batch-YYYY-WW` ブランチに集約 (`YYYY-WW` は ISO 週番号)
+- 週次 (or 件数閾値到達時) に `harness.md` テンプレで PR 起票 → orchestrator approve → merge
+- `harness-meta` 起動閾値 (10 件 / 7 日、`pr-poller.md` / `harness-meta-criteria.md`) と連動
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク** (commonmark + SnakeYAML): frontmatter 必須キー検証、5 行 summary 存在、ハーネス改善提案プレフィックス 4 種の正規表現マッチ、redaction 漏れ検出
+- **GitHub Actions**: learning PR の merge 直前に上記検証を CI 実行 (A6 / detekt 統合と同時)
+- **harness-meta Skill**: 提案セクションを parse して採用 / 見送り / 撤去判定 (A4 で本格化)
 
 ## Gotchas
 
-- **PR コメントは出さない**。learning ファイルが Single Source of Truth (§4.4)。
-- PII / secrets が含まれないよう `.claude/rules/pii.md` の redaction を必ず通す。
-- `📝 harness-meta フィードバック` セクションは空でも見出しを残す (harness-meta が後追記する場所)。
+- **PR コメントは出さない**、learning ファイルが SoT (§4.4)
+- **PII / secrets redaction は必ず通す** (`.claude/rules/pii.md` / `secrets.md`)
+- **`📝 harness-meta フィードバック` セクションは空でも見出しを残す** (harness-meta が後追記する場所)
+- **三層指標 N/A 明記**: A7 完了前は空欄ではなく `N/A` 明示 (A1 レトロ Problem 防止)
+- **consensus 表記推奨**: どの aspect が指摘したかを Keep / Problem 各項目に併記すると harness-meta の重み付け精度が上がる
+- **手動代替実行時 (A3 本格化前) は `generator` 値で明示**: `pr-retrospective (skeleton、本ペインで手動代替実行)`
+- **対象 PR の commit / merge 情報は冒頭 blockquote で必須記載**: PR URL / commit sha / マージ日時 / 差分ファイル数 + 行数
 
 ## 関連
 
-- `docs/harness/plan.md` §4.4 / §5.5
-- `.claude/skills/pr-retrospective/SKILL.md`
-- `.claude/skills/harness-meta/SKILL.md` (A3 で配置予定)
+- ADR 0026 (harness-evolution Skill 採用、retrospective format との連携)
+- ADR 0027 (テンプレ言語、日本語化方針)
+- `docs/harness/plan.md` §4.4 / §5.4.5 / R-12
+- `.claude/rules/{pr-poller,harness-meta-criteria,harness-evolution,pii,secrets,docs-structure}.md`
+- `.claude/skills/{pr-retrospective,pr-poller,harness-meta}/SKILL.md`
+- `docs/harness/learnings/{INDEX,flaky-tests}.md` (補助ファイル)

--- a/.claude/rules/rules-index.md
+++ b/.claude/rules/rules-index.md
@@ -37,9 +37,16 @@ last_updated: 2026-05-17
 | 値 | 意味 |
 |---|---|
 | `skeleton (B0)` | B0 (PR #117) で配置済の骨格。本文薄め、Gotchas / 関連リンクは揃っている。本格化フェーズで肉付け |
-| `stable (X)` | フェーズ X (例: A2-1、A2-2) で本格化済み。実装・運用に耐える本文と Gotchas が揃っている |
-| `planned (X)` | まだ実体なし。フェーズ X (例: A2-3、A3、A6、A7、Phase C) で新規作成予定 |
+| `stable (X)` | フェーズ X (例: A2-1、A2-2、A2-3) で本格化済み。実装・運用に耐える本文と Gotchas が揃っている |
+| `planned (X)` | まだ実体なし。フェーズ X (例: A3、A6、A7、Phase C) で新規作成予定 |
 | `living` | 索引・ロードマップ等で常に更新される文書 |
+
+**A2-3 (本 PR) で `stable (A2-3)` に正規化されたファイル一覧** (18 件 + 索引 1 件):
+
+- 新規 6: `pr-template` / `branch-naming` / `merge-readiness` / `pr-draft-policy` / `spec-living-sync` / `harness-meta-criteria`
+- skeleton 本格化 11: `retrospective-format` / `pr-poller` / `skill-authoring` / `harness-evolution` / `implementation-workflow` / `code-reviewer-aspects` / `design-tokens` / `ui-snapshot` / `ui-inventory` / `behavior-preservation` / `docs-structure`
+- 微調整 2: `template-language` (Phase A 経過措置を本文化) / `commit-message` (subject 言語ポリシーをセクション化、PR #121 レトロ Try 反映)
+- 索引更新 1: 本ファイル `rules-index.md` (status 正規化、上記 18 件を `stable (A2-3)` 表記に統一)
 
 ## カテゴリ別索引
 
@@ -93,52 +100,52 @@ last_updated: 2026-05-17
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `design-tokens.md` | skeleton (B0、A2-3 で本格化) | DESIGN.md 3 階層構造、hex/sp/dp ハードコード禁止 |
-| `ui-snapshot.md` | skeleton (B0、A2-3 で本格化) | Preview + screenshot baseline 維持、human approve 必須 |
-| `ui-inventory.md` | skeleton (B0、A2-3 で本格化) | `docs/design/inventory/` の構造と更新規約 |
-| `behavior-preservation.md` | skeleton (B0、A2-3 で本格化) | リファクタ時の振る舞い維持原則 |
+| `design-tokens.md` | stable (A2-3、A10 で DESIGN.md 自動生成) | DESIGN.md 3 階層構造、hex/sp/dp ハードコード禁止 |
+| `ui-snapshot.md` | stable (A2-3、Roborazzi 本格運用は A10) | Preview + screenshot baseline 維持、human approve 必須 |
+| `ui-inventory.md` | stable (A2-3、本格生成は A10) | `docs/design/inventory/` の構造と更新規約 |
+| `behavior-preservation.md` | stable (A2-3、検証本格化は A10) | リファクタ時の振る舞い維持原則 |
 
 ### MCP
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `mcp-usage.md` | skeleton (B0、A2-1 で Gotchas 追記 / A2-3 で本格化) | MCP サーバの使い分け、認証情報の取り扱い |
+| `mcp-usage.md` | stable (A2-1 で本格化) | MCP サーバの使い分け、認証情報の取り扱い |
 
 ### プロセス
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `pr-template.md` | planned (A2-3) | PR テンプレート選択 / `gh pr create --template <type>.md` 運用規約 |
-| `commit-message.md` | skeleton (A2-1 で新規作成、A2-3 で本格化) | Conventional Commits 規約 / subject 長 / Co-Authored-By 必須 |
-| `branch-naming.md` | planned (A2-3) | ブランチ命名規約 (feature / epic / harness / chore / fix) |
+| `pr-template.md` | stable (A2-3) | PR テンプレート選択 / `gh pr create --template <type>.md` 運用規約 |
+| `commit-message.md` | stable (A2-3、subject 言語ポリシーをセクション化) | Conventional Commits 規約 / subject 長 / Co-Authored-By 必須 |
+| `branch-naming.md` | stable (A2-3) | ブランチ命名規約 (feature / epic / harness / chore / fix / docs / refactor) |
+| `merge-readiness.md` | stable (A2-3) | Merge 可否判定 (CI green + Critical 0 + 人間 approve の 3 条件) |
+| `pr-draft-policy.md` | stable (A2-3) | Draft → Ready 昇格条件、Draft 中の WIP commit ポリシー |
+| `spec-living-sync.md` | stable (A2-3) | 実装中の仕様変更時の双方向同期 (基本設計 / 詳細設計 ⇄ 実装コード) |
 
 ### ハーネス改善ループ
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `retrospective-format.md` | skeleton (B0、A2-3 で本格化) | learning ファイル構造化フォーマット |
-| `pr-poller.md` | skeleton (B0、A2-3 で本格化、Skill 本格実装は A3/A4) | ローカルポーリング規約、排他制御 |
-| `harness-meta-criteria.md` | planned (A2-3、Skill 統合は A4) | 改修 PR 採用/見送り/撤去の判定基準 |
-| `skill-authoring.md` | skeleton (B0、A2-3 で本格化) | Skill 作成は `example-skills:skill-creator` 経由 |
-| `harness-evolution.md` | skeleton (B0、A2-3 で本格化) | 外部情報源ホワイトリスト、出力フォーマット |
-| `docs-structure.md` | skeleton (B0、A2-3 で本格化) | `docs/` の歩き方、命名規約、5 行 summary + lazy-load |
+| `retrospective-format.md` | stable (A2-3) | learning ファイル構造化フォーマット、`📝 harness-meta フィードバック` 追記ルール |
+| `pr-poller.md` | stable (A2-3、Skill 本格実装は A3/A4) | ローカルポーリング規約、排他制御、3 系統起動経路 |
+| `harness-meta-criteria.md` | stable (A2-3、Skill 統合は A4) | 改修 PR 採用 / 見送り / 撤去の判定基準、pr-poller 起動閾値上書き |
+| `skill-authoring.md` | stable (A2-3) | Skill 作成は `example-skills:skill-creator` 経由、100-point rubric |
+| `harness-evolution.md` | stable (A2-3) | 外部情報源ホワイトリスト、出力フォーマット、Context7 MCP 引用検証 |
+| `docs-structure.md` | stable (A2-3、NG 例明示) | `docs/` の歩き方、命名規約、5 行 summary + lazy-load |
 
 ### 実装ワークフロー
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `implementation-workflow.md` | skeleton (B0、A2-3 で本格化、Skill 本格実装は A3) | 10 フェーズ手順、fix loop 上限、worktree 未マージ検知 |
-| `code-reviewer-aspects.md` | skeleton (B0、A2-3 で本格化、Skill 本格実装は A3) | 8 aspect の binary eval checklist、Coordinator 形式 |
-| `merge-readiness.md` | planned (A2-3) | Merge 可否判定 |
-| `pr-draft-policy.md` | planned (A2-3) | Draft → Ready 昇格条件 |
-| `spec-living-sync.md` | planned (A2-3) | 実装中の仕様変更時の双方向同期 |
+| `implementation-workflow.md` | stable (A2-3、Skill 本格実装は A3) | 10 フェーズ手順、Phase 0 で `git fetch origin master`、fix loop 上限 3、worktree 未マージ検知 |
+| `code-reviewer-aspects.md` | stable (A2-3、Skill 本格実装は A3) | 8 aspect の binary eval checklist (各 5-7 項目)、Coordinator 形式 |
 
 ### ドキュメント表記
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
 | `markdown.md` | stable (A2-2、markdownlint-cli2 統合は A6) | Markdown 表記規約 |
-| `template-language.md` | skeleton (B0、A2-1 で常時ロード化 / A2-3 で本格化) | 全テンプレ Markdown は日本語 (ADR 0027) |
+| `template-language.md` | stable (A2-3、Phase A 経過措置を本文化) | 全テンプレ Markdown は日本語 (ADR 0027)、Phase A 経過措置 |
 
 ### 同期 / Backend
 

--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -1,25 +1,27 @@
 ---
 id: rules-skill-authoring
 title: Skill 作成は example-skills:skill-creator 経由
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - ".claude/skills/**/SKILL.md"
-related_plan: docs/harness/plan.md §5.3 / ADR 0025
 related_adrs:
   - ADR-0025
+related_plan: docs/harness/plan.md §5.3 / R-30
 ---
 
 # skill-authoring.md — Skill 作成規約
 
 > 新規 Skill 作成・既存 Skill 改修は Claude Code ユーザースコープの **`example-skills:skill-creator`**
-> を呼び出して行う。本リポジトリには `skill-creator` を mirror しない。SKILL.md は Anthropic
-> "Complete Guide to Building Skills for Claude" + AgentSkills 2026 spec + 100-point rubric 準拠。
+> を呼び出して行う。本リポジトリには `skill-creator` を mirror しない (ADR 0025)。
+> SKILL.md は Anthropic "Complete Guide to Building Skills for Claude" + AgentSkills 2026 spec +
+> 100-point rubric 準拠。
 
 ## 起動方法
 
 - 他 Skill (`harness-bootstrap` / `harness-meta` / `harness-evolution`) や人間からの「新規 Skill 作成 / 既存 Skill 改修」要求時に呼び出す
-- 本リポジトリには `.claude/skills/skill-creator/` を配置しない (ユーザースコープにインストール済のため)
+- 本リポジトリには `.claude/skills/skill-creator/` を配置しない (ユーザースコープにインストール済のため、ADR 0025)
+- 起動コマンド: `Skill skill="example-skills:skill-creator" args="<task description>"`
 
 ## SKILL.md フォーマット
 
@@ -34,61 +36,122 @@ related_plan: <参照する plan.md 章番号>
 related_rules:
   - .claude/rules/<rule1>.md
   - .claude/rules/<rule2>.md
+related_adrs:
+  - ADR-NNNN
 ---
 
 # <skill-name>
 
 ## 役割
-...
 
 ## 入力
-...
 
 ## 出力
-...
+
+## フェーズ別動作 (該当時)
 
 ## Gotchas
-- ...
 
 ## 関連
-- ...
 ```
 
-## description の書き方 (Anthropic 公式準拠)
+- frontmatter 配列は block 形式必須 (`docs-structure.md` 規約と整合)
+- 各セクション最低 3 項目、推奨 5-10 項目
+- 日本語見出し (ADR 0027 / `template-language.md`)
 
-- **description = trigger**。「いつ呼ばれるか」を明示。
-- 1-3 文以内、200 文字以内推奨。
-- 「~を作成する」「~を生成する」より「~の指示を受けたとき」「~を必要とする状況で」のように **起動契機を明示**。
+## description = trigger の書き分けパターン
+
+- **description は trigger と等価**: 「いつ呼ばれるか」を明示
+- 1-3 文以内、200 文字以内推奨 (Anthropic 公式準拠)
+- 「~を作成する」「~を生成する」より「~の指示を受けたとき」「~を必要とする状況で」のように **起動契機を明示**
+- 複数 trigger を持つ場合は **箇条書きまたは「または」接続** で並列化
+
+### ✅ 良い例
+
+```yaml
+description: |
+  Plan / Epic 確定後の実装着手 → Lint/Test → AI Review → マージ → レトロ起動 →
+  worktree クリーンアップを 10 フェーズ (Phase 0-9) で統合管理するオーケストレーター。
+  Phase 0 で git worktree を作成し、Phase 9 で削除することで複数 Claude Code セッションの
+  並行実装を物理分離する。
+```
+
+→ Trigger 明示 (Plan/Epic 確定後の実装着手要求時) + 達成目標明示 (10 フェーズ統合管理 + worktree 並行) + 副次効果明示 (物理分離)
+
+### ❌ 悪い例
+
+```yaml
+description: |
+  10 フェーズで実装を管理する Skill。
+```
+
+→ Trigger 不明確 (いつ呼ばれるか書いていない) + 達成目標が曖昧
 
 ## 必須項目
 
-- **Gotchas セクション**: 罠 / 注意点 / 例外を必ず列挙
-- **関連セクション**: 参照する rules / Plan 章 / 他 Skill を列挙
-- **明示的な status**: `skeleton` / `active` / `archived`
+| 項目 | 内容 |
+|---|---|
+| **Gotchas セクション** | 罠 / 注意点 / 例外を必ず列挙 (最低 3 項目) |
+| **関連セクション** | 参照する rules / Plan 章 / 他 Skill を列挙 |
+| **明示的な status** | `skeleton` / `active` / `archived` |
+| **phase** | 導入フェーズ (`B0` / `A3` / `A4` / `A10` 等)、本格化 PR で更新 |
+| **入力 / 出力** | 受け取る引数 / 生成するファイル / 副作用を明示 |
+| **フェーズ別動作** (該当時) | `implementation-workflow` の 10 フェーズや `pr-poller` の 3 系統等、複数モードがある場合 |
+
+## status 値の遷移
+
+| 値 | 意味 | 遷移条件 |
+|---|---|---|
+| `skeleton` | B0 で配置済の骨格、本格動作は未稼働 | 該当フェーズ (A3 等) の本格化 PR で `active` 化 |
+| `active` | 本格化済み、Skill 駆動で実行可能 | dormant 確定 (3 ヶ月未使用) で `archived` 化、または harness-meta 撤去判定で削除 |
+| `archived` | 撤去候補、参照のみ可能、削除待ち | 削除 PR で物理削除 (`harness-meta-criteria.md` 撤去判定基準 3 項目充足時) |
 
 ## 禁止表現
 
-- `MUST` / `ALWAYS` / `NEVER` を多用しない (Claude の挙動を硬直化させる)
+- **`MUST` / `ALWAYS` / `NEVER` を多用しない** (Claude の挙動を硬直化させる)
 - 代わりに「~するべき」「~を推奨」「~してはいけない (理由付き)」で記述
+- 数値・閾値はそのまま記述 (例: 「fix loop 上限 3 回」)、「絶対に超えてはならない」のような断定は理由併記
 
 ## 100-point rubric チェック (skill-creator が評価)
 
-- description が trigger を明示している (20 点)
-- Gotchas が具体的に列挙されている (15 点)
-- 関連 rules / Plan 章へのリンクが正確 (15 点)
-- 入力 / 出力が明示されている (10 点)
-- ステータス値が定義済み (5 点)
-- ...
+`example-skills:skill-creator` が SKILL.md を生成 / 改修する際に以下の rubric を評価:
+
+| 項目 | 配点 | 評価ポイント |
+|---|---|---|
+| description が trigger を明示 | 20 | 「いつ呼ばれるか」「何を達成するか」が 1-3 文以内で明確 |
+| Gotchas が具体的に列挙 | 15 | 抽象論ではなく具体的な罠・例外を 3 項目以上列挙 |
+| 関連 rules / Plan 章へのリンクが正確 | 15 | dangling 参照ゼロ、双方向リンク (該当時) |
+| 入力 / 出力が明示 | 10 | 引数 / 副作用 / 生成ファイルが明示 |
+| ステータス値が定義済み | 5 | frontmatter `status` が 3 値のいずれか + `phase` 記入 |
+| フォーマット規範準拠 | 10 | template-language / docs-structure / frontmatter block 形式 |
+| 禁止表現の回避 | 5 | MUST / ALWAYS / NEVER 多用なし |
+| Skill 間の責務分離 | 10 | 他 Skill との overlap 最小化 (例: harness-meta vs harness-evolution) |
+| 単独テスト可能性 | 5 | Skill 単体で起動可能 (依存 Skill の事前起動が前提化されていない) |
+| 改修履歴の追跡 | 5 | last_updated / phase 更新時に履歴を残す (将来追加) |
+
+合計 80 点以上で合格、不合格時は skill-creator が改善提案を出す。
+
+## 公式アップデートへの追従
+
+- **`anthropics/skills` GitHub repo の更新を `harness-evolution` Skill の手動実行時に確認** (R-30、月次頻度推奨)
+- 更新事項を `docs/harness/evolution-proposals/YYYY-MM-DD.md` に取り込み、重要案を Plan / Epic 起票
 
 ## Gotchas
 
-- **本リポジトリに `skill-creator` を mirror しない**: Claude Code ユーザースコープにインストール済 (ADR 0025)
-- **公式アップデートに追従**: `anthropics/skills` の更新を `harness-evolution` Skill の手動実行時に確認 (R-30、月次頻度推奨)
-- **既存 Skill 改修も `skill-creator` 経由**: 直接編集禁止ではないが、フォーマット drift を防ぐため経由を推奨
+- **本リポジトリに `skill-creator` を mirror しない** (ADR 0025、ユーザースコープにインストール済)
+- **公式アップデートに追従**: `anthropics/skills` の更新を harness-evolution 手動実行時に確認 (R-30、月次頻度推奨)
+- **既存 Skill 改修も `skill-creator` 経由を推奨**: 直接編集禁止ではないが、フォーマット drift / 100-point rubric 不合格を防ぐため経由を推奨
+- **frontmatter 配列は block 形式**: flow 形式 `[A, B]` は禁止 (`docs-structure.md` 規約)
+- **description は trigger 明示**: 「~を作成する」のような目的説明だけでは Claude Code が起動契機を判定できない
+- **status `archived` は削除待ち**: 物理削除は別 PR で行い、archived 期間中に dangling 参照を解消
+- **Skill 間の責務 overlap 回避**: 例 `harness-meta` (内部 KPT 駆動) vs `harness-evolution` (外部研究駆動)、`pr-retrospective` (1 PR 単位) vs `harness-meta` (複数 PR 集約) の境界を明確化
+- **新規 Skill は plan.md §5.3 に追加** + `.claude/skills/<name>/SKILL.md` 配置 + 関連 rules 双方向リンク同時更新
 
 ## 関連
 
 - ADR 0025 (Skill 作成は `example-skills:skill-creator` 経由)
 - `docs/harness/plan.md` §5.3 / R-30
 - Anthropic "Complete Guide to Building Skills for Claude" (https://docs.anthropic.com/skills/)
-- `.claude/skills/*/SKILL.md` (全 Skill の規範例)
+- `anthropics/skills` GitHub (公式 Skill サンプル)
+- `.claude/skills/*/SKILL.md` (本リポジトリ全 Skill の規範例)
+- `.claude/rules/{harness-evolution,harness-meta-criteria,docs-structure,template-language}.md`

--- a/.claude/rules/spec-living-sync.md
+++ b/.claude/rules/spec-living-sync.md
@@ -1,0 +1,95 @@
+---
+id: rules-spec-living-sync
+title: 実装中の仕様変更時の双方向同期規約
+status: stable
+last_updated: 2026-05-17
+paths:
+  - "docs/requirements/**"
+  - "docs/specifications/**"
+  - ".claude/skills/implementation-workflow/**"
+related_adrs:
+  - ADR-0027
+related_plan: docs/harness/plan.md §4.6 / R-32 / R-33
+---
+
+# spec-living-sync.md — 実装中の仕様変更時の双方向同期規約
+
+> 実装フェーズ (Phase 3) で要件 / 基本設計 / 詳細設計に齟齬が見つかった場合に、
+> 実装と spec docs を **同 PR 内で同時更新** するルール。docs の SoT 性を維持しつつ、
+> living docs として実装中の発見を取り込む手順を規定。
+
+## 基本原則
+
+- **docs は SoT、実装はその実体化** (ADR 0027): 実装中に「docs の記述が誤っている」「不足している」「曖昧」と判明したら docs を先に修正
+- **同 PR 内で同時更新が既定**: 別 PR に分けると docs と実装の乖離期間が発生する
+- **大規模な仕様変更 (REQ-NNN / SPEC-NNN-N 1 件の章立てを書き換える等) は別 Plan / Epic に切り出す**: 1 PR で完結しないと判明したら Phase 3 を中断、Plan / Epic の昇格 (`plan.md` §Epic 昇格条件)
+
+## 同期パターン分類
+
+| パターン | 例 | 対応 |
+|---|---|---|
+| **docs 軽微訂正** | 用語の typo / 曖昧な表現の明確化 / SPEC 内のサンプル ID 修正 | 同 PR で docs 修正、PR description「仕様変更箇所」セクションに記載 |
+| **docs 内容追加** | 実装中に発見した追加 AC / エラーケースの記述 | 同 PR で docs 追加 (REQ / SPEC の Acceptance criteria に行追加)、PR description 記載 |
+| **docs 内容削除** | 実装で不要と判明した AC / フィールド | 同 PR で docs 削除 + ADR 起票要否を `adr.md` §起票基準で判定、Plan の Scope 内変更で済むなら ADR 不要 |
+| **アーキテクチャ的変更** | レイヤー越境 / 既存 ADR と矛盾 | **同 PR は中断**、ADR 起票 (新規 or supersedes) → Plan / Epic 昇格 |
+| **API 仕様変更 (Breaking)** | OpenAPI スキーマ変更 / 認証境界変更 | 別 Plan / Epic に切り出す (PR 分割) |
+
+## PR description「仕様変更箇所」セクション
+
+仕様変更を含む PR は description に以下を必ず記載:
+
+```markdown
+## 仕様変更箇所 (spec-living-sync)
+
+| 変更前 | 変更後 | 影響範囲 (REQ/SPEC ID) | 同 PR で対応 | 別 PR 切り出し |
+|---|---|---|---|---|
+| `SPEC-IDOL-001-3` の Acceptance criteria 4 「name 検索で大文字小文字区別」 | 大文字小文字区別なし (デフォルト) | SPEC-IDOL-001-3 / REQ-001 | ✅ | — |
+| ... | ... | ... | ... | ... |
+```
+
+- **変更前 / 変更後 は SPEC-ID + 行参照** (`file_path:line` 形式) で明示
+- **影響範囲** は REQ / SPEC ID リストで網羅
+- **同 PR で対応 / 別 PR 切り出し** のいずれか必須選択
+
+## 双方向リンクの維持
+
+- REQ ⇄ SPEC-basic ⇄ SPEC-detail の frontmatter `related_*` リンクを実装と同期
+- 例: SPEC-IDOL-001-3 に Acceptance criteria を追加したら `related_basic` / `related_detail` ペアの整合を確認
+- 詳細は `docs-structure.md` §frontmatter 必須キー表 + `docs/traceability.md` (A6 自動生成) 参照
+
+## 実装と spec の対応付け (`@Spec` annotation)
+
+- 実装変更時に対応する `@Spec("SPEC-NNN-N")` annotation をテスト側に追加 / 更新 (`spec-traceability.md` A7 で本格化)
+- code-reviewer spec-conformance aspect が検証 (`code-reviewer-aspects.md` 参照)
+- PR description「仕様変更箇所」表で「対応 `@Spec` テストファイル」列を追加可
+
+## Phase 3 → Phase 5 の流れ (spec-living-sync 発動時)
+
+1. **Phase 3 実装中に齟齬発見** → 種別判定 (軽微訂正 / 追加 / 削除 / アーキテクチャ / Breaking)
+2. **軽微訂正 / 追加 / 削除**: 同 PR で docs 修正、テスト + 実装と一緒に commit
+3. **アーキテクチャ / Breaking**: Phase 3 中断、ADR 起票 → Plan / Epic 昇格 → 新 Plan / Epic で再着手
+4. **Phase 5 PR 起票時**: description「仕様変更箇所」セクション記入
+5. **Phase 6 code-reviewer**: spec-conformance aspect が SPEC-ID 整合 / frontmatter リンク有効性を検証
+
+## 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: REQ ⇄ SPEC-basic ⇄ SPEC-detail の frontmatter `related_*` 双方向参照を検証 (片方向リンクは warning)
+- **Konsist**: `@Spec("SPEC-NNN-N")` annotation の SPEC-ID が `docs/specifications/{basic,detail}/` に実在することを検証
+- **docs/traceability.md 自動生成** (A6): REQ / SPEC / EPIC / PLAN / ADR / 実装ファイルの対応表を機械生成、`spec-living-sync` の同期漏れを検知
+
+## Gotchas
+
+- **docs を後追い更新する誘惑を断つ**: 「実装が先、docs は次の PR で」は SoT 性を壊す。Phase 3 で発見したら同 PR で docs 修正
+- **設計書本文にコード断片を書かない** (`docs-structure.md` §4.6 のコード禁止原則): docs 修正時もコード断片を混入させず、`file_path:line` 参照で代替
+- **アーキテクチャ変更は ADR 起票が前提**: ADR を起票せずに plan.md / SPEC の根幹を変えると SoT が二重化する (PR #119 レトロ Problem #1 と同様の循環参照リスク)
+- **PR description「仕様変更箇所」セクション空欄禁止**: 「軽微訂正なし」の場合も「N/A」と明示 (A1 レトロ Problem #4 と同様、誤読防止)
+- **Epic 配下 PR は decisions.md にも記録**: EPIC 配下 PR で仕様変更を行った場合、`docs/epics/<id>/decisions.md` にも判断ログを残す (`epic.md` 参照)
+- **複数 PR にまたがる spec drift は traceability.md で検出** (A6 完了後): 同期漏れは A6 機械検証で検知、それ以前は人間レビュー + code-reviewer spec-conformance aspect 任せ
+
+## 関連
+
+- ADR 0027 (docs 構造 + 5 行 summary + 日本語化、docs SoT 性の根拠)
+- `docs/harness/plan.md` §4.6 / R-32 / R-33
+- `.claude/rules/{docs-structure,implementation-workflow,code-reviewer-aspects,adr,plan,epic}.md`
+- `.claude/rules/spec-traceability.md` (A7 で本格化、`@Spec` annotation 規約)
+- `docs/traceability.md` (A6 自動生成、双方向リンク機械検証)

--- a/.claude/rules/template-language.md
+++ b/.claude/rules/template-language.md
@@ -1,7 +1,7 @@
 ---
 id: rules-template-language
 title: テンプレート言語ポリシー (日本語必須)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 # 注意: 全 Markdown 共通の規約のため `paths` を意図的に未設定 (常時ロード)。
 # rules-index.md / CLAUDE.md の「常時ロード (paths 未設定の rule)」リストと整合させるため、
@@ -40,6 +40,15 @@ related_adrs:
 - ステータス値 (`proposed`, `in-progress`, `completed`, `abandoned`, `promoted` 等)
 - コマンド・ファイルパス・コード断片
 - 識別子 (SPEC-IDOL-001-3, EPIC-NNN, PLAN-NNN, ADR 0001 等)
+- Conventional Commits の type / scope (`feat` / `fix` / `refactor` / `docs(harness)` 等、`.claude/rules/commit-message.md` 参照)
+- ブランチ名 prefix (`feature/` / `harness/` / `chore/` 等、`.claude/rules/branch-naming.md` 参照)
+
+## Phase A 期間中の経過措置
+
+- **commit message subject**: 英語推奨だが Phase A (A1〜A10) 期間中は日本語混在を許容 (`.claude/rules/commit-message.md` §subject 言語ポリシー参照)
+- **PR title**: commit subject と同じポリシー (Conventional Commits 形式 + 日本語混在許容)
+- **PR description body**: 日本語推奨 (本 rule の日本語化対象に含まれる)、コード断片は英語
+- **GitHub Issues / Discussions**: 日本語推奨、外部コラボレーション時のみ英語可
 
 ## 機械検証 (A6 で導入)
 
@@ -50,12 +59,17 @@ related_adrs:
 
 ## Gotchas
 
-- ADR / Plan / Epic の **タイトル** は日本語で簡潔・現在形・断定的に記述。
-- code 例 (Kotlin / Gradle DSL / SQL / シェル等) はそのまま英語。コメントは日本語可。
-- 識別子 (SPEC-NNN-N 等) と enum 値 (status / type 等) を日本語訳しない (parse 不可能になる)。
+- **ADR / Plan / Epic のタイトル** は日本語で簡潔・現在形・断定的に記述
+- **code 例 (Kotlin / Gradle DSL / SQL / シェル等) はそのまま英語**、コメントは日本語可
+- **識別子 (SPEC-NNN-N 等) と enum 値 (status / type 等) を日本語訳しない** (parse 不可能になる)
+- **`paths` 未設定で常時ロード**: A2-1 で `paths: ["**/*.md"]` 削除、rules-index.md / CLAUDE.md の「常時ロード (paths 未設定の rule)」リストと整合 (PR #117 A1 レトロ Problem #2 解消)
+- **本 rule は安全網として PII / Secrets / rules-index と同じ常時ロード群** に含まれる: 全 Markdown 共通の規約のため、起動時に無条件ロード
+- **過去コミット (A1 / A2-1 等) の日本語混在 subject** は Phase A 経過措置で許容、Phase B (A6 で `commit-msg` hook 拡張時) に英語強制を再評価
+- **Markdown 表記規約は `.claude/rules/markdown.md`** が担当、本 rule は言語ポリシー (日本語必須 + 例外列挙) に集中
 
 ## 関連
 
 - ADR 0027 (docs 構造 + 命名規約 + 日本語化方針)
 - `docs/harness/plan.md` §5.5 (テンプレート言語ポリシー)
-- `.claude/rules/markdown.md` (Markdown 全般の表記規約)
+- `.claude/rules/{markdown,docs-structure,commit-message,branch-naming,pr-template}.md`
+- `docs/epics/EPIC-A2-rules-docs-extension/decisions.md` (A2-1 paths 削除の判断記録)

--- a/.claude/rules/ui-inventory.md
+++ b/.claude/rules/ui-inventory.md
@@ -1,49 +1,62 @@
 ---
 id: rules-ui-inventory
 title: UI Inventory 規約 (docs/design/inventory/ の構造と更新)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "docs/design/inventory/**"
-related_plan: docs/harness/plan.md §3.9 / ADR 0023
 related_adrs:
   - ADR-0023
+related_plan: docs/harness/plan.md §3.9 / R-22
 ---
 
 # ui-inventory.md — UI Inventory 規約
 
 > `docs/design/inventory/` 配下に画面・コンポーネント・状態・フローの記録を網羅的に置き、
 > リファクタ時の Behavior Preservation の根拠とする規約。
-> 本格生成は A10 で `ui-snapshot` Skill が担当。
+> 本格生成は A10 で `ui-snapshot` Skill が担当 (ADR 0023)。
 
 ## ディレクトリ構造
 
 | ディレクトリ | 内容 | ファイル例 |
 |---|---|---|
-| `docs/design/inventory/screens/` | 画面ごと | `home.md`, `search.md`, `preview.md`, `myidols.md` |
-| `docs/design/inventory/components/` | コンポーネントごと | `idol-card.md`, `brand-chip.md`, `color-swatch.md` |
-| `docs/design/inventory/states/` | 状態パターン | `empty.md`, `loading.md`, `error.md`, `partially-loaded.md` |
-| `docs/design/inventory/flows/` | ユーザーフロー | `login.md`, `add-favorite.md`, `share-list.md` |
+| `docs/design/inventory/screens/` | 画面ごと | `home.md` / `search.md` / `preview.md` / `myidols.md` |
+| `docs/design/inventory/components/` | コンポーネントごと | `idol-card.md` / `brand-chip.md` / `color-swatch.md` |
+| `docs/design/inventory/states/` | 状態パターン | `empty.md` / `loading.md` / `error.md` / `partially-loaded.md` |
+| `docs/design/inventory/flows/` | ユーザーフロー | `login.md` / `add-favorite.md` / `share-list.md` |
 | `docs/design/inventory/screenshots/` | Roborazzi 生成 baseline PNG | `<composable>-<device>-<theme>.png` |
 
-## 各ファイル frontmatter
+## 各種別の frontmatter 必須キー
+
+### screens / components / states / flows 共通
 
 ```yaml
 ---
-id: inventory-screen-home
+id: inventory-<type>-<slug>
 type: screen | component | state | flow
 title: <タイトル>
+status: living
+last_updated: YYYY-MM-DD
 related_specs:
-  - SPEC-NNN-N
+  - SPEC-IDOL-001-3
 related_screenshots:
   - <composable>-mobile-light.png
   - <composable>-mobile-dark.png
+  - <composable>-desktop-light.png
+  - <composable>-desktop-dark.png
 related_design_tokens:
   - colors.brand.imas-cg-rin
-  # 必要に応じて追加
-last_updated: YYYY-MM-DD
+  - typography.heading-large
+  - spacing.medium
+related_components:
+  - inventory-component-idol-card
 ---
 ```
+
+- 配列は block 形式必須 (`docs-structure.md` 規約)
+- `related_screenshots` は 4 パターン全て列挙 (1 パターン欠落は CI 警告、A10 完了後)
+- `related_design_tokens` は Component 階層トークンを優先 (`design-tokens.md` 3 階層構造と整合)
+- `related_components` で他 Inventory ファイルへの双方向リンク
 
 ## 本文構造
 
@@ -55,23 +68,67 @@ last_updated: YYYY-MM-DD
 | データソース | どの API / Repository / SPEC を参照するか |
 | アクセシビリティ | semantic role / contentDescription / フォーカス順序 |
 | 参考 screenshot | `docs/design/inventory/screenshots/` への相対リンク (4 パターン) |
-| Open Questions | 未解決の意思決定 |
+| Open Questions | 未解決の意思決定 (append-only) |
+
+## Mermaid 例 (状態と遷移)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty
+    Empty --> Loading: ユーザー検索開始
+    Loading --> PartiallyLoaded: 最初のレスポンス到着
+    Loading --> Error: ネットワーク失敗
+    PartiallyLoaded --> Loaded: 全件取得完了
+    PartiallyLoaded --> Error: 途中失敗
+    Error --> Loading: リトライ
+    Loaded --> [*]
+```
+
+## 構成要素テーブル例
+
+| 要素 | コンポーネント | 関連 SPEC | 動的色 |
+|---|---|---|---|
+| アイドルカード | `IdolCard` | SPEC-IDOL-001-3 | ✅ (brand color) |
+| ブランドチップ | `BrandChip` | SPEC-BRAND-002-1 | ✅ |
+| カラーパレット | `ColorSwatch` | SPEC-COLOR-003-2 | ✅ |
+| 検索バー | `SearchBar` | SPEC-SEARCH-001-1 | ❌ (Semantic.Primary 固定) |
 
 ## 更新ポリシー
 
-- 新規 Composable / 状態を追加したら、対応する Inventory ファイルを作成 (`ui-snapshot` Skill が Plan 起票)
-- リファクタで構造が変わったら **Behavior Preservation 検証** (visual regression + spec-conformance) を通した上で Inventory を更新
-- 削除されたコンポーネントは Inventory ファイルも削除し、削除コミットメッセージに理由を明記
+- **新規 Composable / 状態を追加したら、対応する Inventory ファイルを作成** (`ui-snapshot` Skill が Plan 起票)
+- **リファクタで構造が変わったら Behavior Preservation 検証** (visual regression + spec-conformance) を通した上で Inventory を更新
+- **削除されたコンポーネントは Inventory ファイルも削除**、削除コミットメッセージに理由を明記
+- **Open Questions は append-only**、解決時は別行に解決日と方法を追記
+
+## Inventory ⇄ Spec ⇄ 実装の対応
+
+- `related_specs` で SPEC-ID 双方向リンク (`docs-structure.md` 規約)
+- `related_screenshots` で Roborazzi baseline 双方向リンク (`ui-snapshot.md`)
+- `related_design_tokens` で DESIGN.md トークン双方向リンク (`design-tokens.md`)
+- `related_components` で Inventory ファイル間の双方向リンク (`component → screen` の包含関係等)
+
+## 機械検証 (A6 + A10 で段階導入)
+
+- **A6**: Gradle カスタムタスクで frontmatter 必須キー + 5 行 summary + 日本語見出し検証
+- **A6**: `related_screenshots` の参照先ファイル実在検証 (4 パターン揃いの warning)
+- **A10**: Konsist で全 Composable に対応する Inventory ファイル存在検証 (新規 Composable → Inventory 不在は CI 警告)
+- **A10**: `related_design_tokens` の参照先トークンが DESIGN.md Component 階層に実在検証
 
 ## Gotchas
 
-- Inventory は **AI が次のリファクタを設計する際の Behavior Preservation 根拠**。網羅性が重要。
-- 4 パターン screenshot を必ずペアでリンク (1 パターン欠落 = CI 失敗を A10 完了後に enable)
+- **Inventory は AI が次のリファクタを設計する際の Behavior Preservation 根拠**、網羅性が重要
+- **4 パターン screenshot を必ずペアでリンク** (1 パターン欠落 = CI 警告を A10 完了後に enable)
+- **新規 Composable 追加時は Inventory ファイル作成を必ず Plan 起票**: `ui-snapshot` Skill が検出 → Plan 起票、人間レビュー
+- **Open Questions は append-only**、削除禁止、解決時は別行追記
+- **Mermaid `stateDiagram-v2` の構文エラー**: 文法ミスで render されない、`mermaid.live` 等で事前確認推奨
+- **`related_components` の双方向性**: `IdolCard` (component) → `home-screen` (screen) のように上向きリンクも双方向で記録
+- **アクセシビリティセクション必須**: semantic role / contentDescription / フォーカス順序を明記、TalkBack / VoiceOver で動作確認
 
 ## 関連
 
 - ADR 0023 (UI 凍結三本柱)
-- `docs/harness/plan.md` §3.9
-- `.claude/rules/{ui-snapshot,design-tokens,behavior-preservation}.md`
+- `docs/harness/plan.md` §3.9 / R-22
+- `.claude/rules/{ui-snapshot,design-tokens,behavior-preservation,composable,docs-structure}.md`
 - `.claude/skills/ui-snapshot/SKILL.md`
-- `docs/design/README.md`
+- `docs/design/README.md` (補助ドキュメント、A10 で本格化)
+- `docs/design/inventory/screenshots/` (baseline 配置先)

--- a/.claude/rules/ui-snapshot.md
+++ b/.claude/rules/ui-snapshot.md
@@ -1,25 +1,26 @@
 ---
 id: rules-ui-snapshot
 title: UI screenshot baseline 維持規約 (Roborazzi)
-status: skeleton
+status: stable
 last_updated: 2026-05-17
 paths:
   - "feature/**/*.kt"
   - "composeApp/**/*.kt"
   - "docs/design/inventory/screenshots/**"
   - ".claude/skills/ui-snapshot/**"
-related_plan: docs/harness/plan.md §3.9 / ADR 0023
 related_adrs:
   - ADR-0023
+related_plan: docs/harness/plan.md §3.9 / R-22 / R-23 / R-24
 ---
 
 # ui-snapshot.md — UI screenshot baseline 維持規約
 
 > Roborazzi (Compose Desktop + Android Robolectric) で 4 パターンの screenshot baseline を
 > 維持し、リファクタ時の意図しない UI 変化を visual regression として検出する規約。
-> 本格運用は A10 開始後。
+> 本格運用は A10 開始後、`ui-snapshot` Skill が DESIGN.md / UI Inventory / baseline の
+> 三本柱を自動生成する (ADR 0023)。
 
-## Baseline マトリックス
+## Baseline マトリックス (4 パターン)
 
 | デバイス | テーマ | パス |
 |---|---|---|
@@ -28,33 +29,84 @@ related_adrs:
 | desktop | light | `docs/design/inventory/screenshots/<composable>-desktop-light.png` |
 | desktop | dark | `docs/design/inventory/screenshots/<composable>-desktop-dark.png` |
 
+## 命名規約
+
+- **`<composable>`**: 対象 Composable 関数名を kebab-case (`HomeScreen` → `home-screen`)
+- **`<device>`**: `mobile` (Android Robolectric) または `desktop` (Compose Desktop)
+- **`<theme>`**: `light` または `dark`
+- **拡張子**: `.png` (Roborazzi 既定)
+- 例: `home-screen-mobile-light.png` / `idol-card-desktop-dark.png`
+
 ## 対象 Composable
 
-- 全 Composable に対応する `@Preview` を用意 (`ui-snapshot` Skill が不在を検出 → Plan 起票)
-- 重要画面 (Home / Search / Preview / MyIdols) を最優先で baseline 化、補助コンポーネントは Phase C 内で追加することも許容 (R-22)
-- wasmJs 固有 actual は Roborazzi 未対応のため対象外 (R-24)
+- 全 Composable に対応する **`@Preview` を用意** (`ui-snapshot` Skill が不在を検出 → Plan 起票)
+- **重要画面 (Home / Search / Preview / MyIdols) を最優先で baseline 化**、補助コンポーネントは Phase C 内で追加することも許容 (R-22)
+- **wasmJs 固有 actual は Roborazzi 未対応** のため対象外 (R-24)、commonMain は JVM (Compose Desktop) で screenshot test
+- 動的色 (ブランドカラー) は **代表ブランド (例: `imas-cg-rin`) で固定** + 別途 brand-color バリエーション Preview で網羅
 
 ## Baseline 更新ポリシー
 
-- **baseline 更新は human approve 必須** (誤検出抑制のための `changeThreshold` も併用、R-23)
+- **baseline 更新は human approve 必須** (`merge-readiness.md` 3 条件と整合)
 - 意図的な UI 変更時のみ更新 (リファクタで意図せず変わったら修正)
 - 更新コミットは別途切り出し、レビュアーが diff を視認できるように小さく保つ
+- PR description に「visual regression 意図的更新」を必ず明記 (`pr-template.md` refactor.md の Behavior Preservation 証拠と整合)
+
+## 誤検出抑制 (`changeThreshold` 既定値)
+
+- **`changeThreshold = 0.01` (1% 以下の pixel 差は許容)**: フォントレンダリング差 / GPU 微差で発生する false-positive を抑制
+- フォント差が大きい場合は **`compareOptions(ImageDiffComparator.ssim)`** を併用検討 (SSIM ベース、A10 で本格化)
+- 完全一致が必要なケース (重要画面の核心) は `changeThreshold = 0.0` で個別オーバーライド可
 
 ## 動的色 (ブランドカラー) の扱い
 
-- Preview ではアニメーション停止 + 代表 brand color を固定パラメータで指定 (R-23)
+- Preview ではアニメーション停止 + 代表 brand color を **固定パラメータ** で指定 (R-23)
 - 別途 brand-color バリエーション Preview を作成して網羅 (アイドル × カラー数 × デバイス × テーマ)
 - `changeThreshold` の許容しきい値も併用 (誤検出抑制)
+
+## Roborazzi 設定 (`build.gradle.kts`)
+
+```kotlin
+// 概要: A10 完了時に本格化
+// commonMain: Compose Desktop JVM target
+// androidMain: Robolectric (Android JVM target)
+// wasmJs: Roborazzi 未対応のため除外
+roborazzi {
+    outputDir.set(file("docs/design/inventory/screenshots"))
+    compareOptions {
+        changeThreshold.set(0.01)
+    }
+}
+```
+
+詳細は `.claude/rules/screenshot-test.md` (A10 で本格化) 参照。
+
+## Compose Desktop と Android Robolectric の差分
+
+- **描画微差は両方を baseline 化** して個別管理 (`*-mobile-*` / `*-desktop-*`)
+- フォント差: Desktop は OS フォント、Android Robolectric は Roboto (`Robolectric` の `LooperMode` 設定)
+- 解像度差: mobile = 1080x2400 (Pixel 7 相当)、desktop = 1920x1080 (FHD)
+- ピクセル密度: mobile = 3.5x (xxxhdpi)、desktop = 1x (`dp == px`)
+
+## 機械検証 (A6 + A10 で段階導入)
+
+- **A6**: Konsist で全 Composable (`@Composable` annotation) に対応する `@Preview` 存在検証
+- **A10**: `./gradlew verifyRoborazziDebug` を `./gradlew check` に統合、4 パターン baseline diff が `changeThreshold` 内で完走することを CI 必須化
+- **A10**: `code-reviewer` の visual-regression aspect で baseline 命名規約 / 4 パターン揃え / 意図的更新時の PR description 明記を検証
 
 ## Gotchas
 
 - **wasmJs Roborazzi 未対応**: commonMain は JVM (Compose Desktop) で screenshot test、wasmJs 固有 actual は Konsist + 単体テストで担保 (R-24)
-- Compose Desktop と Android Robolectric では描画微差があり得る → 両方を baseline 化
-- Baseline ファイルが PR diff に大量に出るため、PR description に「visual regression 意図的更新」と明記
+- **Compose Desktop と Android Robolectric では描画微差**があり得る → 両方を baseline 化
+- **Baseline ファイルが PR diff に大量に出る**ため、PR description に「visual regression 意図的更新」と明記、`refactor.md` テンプレの Behavior Preservation 証拠と統合
+- **4 パターン baseline は必ずペアでリンク** (`docs/design/inventory/<screen>.md` の `related_screenshots` で参照)、1 パターン欠落 = CI 失敗を A10 完了後に enable
+- **`changeThreshold` のデフォルトは 0.01**、core 画面は 0.0 で厳格化、補助コンポーネントは 0.05 まで緩和可
+- **動的色 Preview は代表ブランド固定 + バリエーション Preview 別建て**、ハードコード回避と網羅を両立 (`design-tokens.md` と整合)
+- **Roborazzi baseline 生成コマンド**: `./gradlew recordRoborazziDebug` (生成) / `./gradlew verifyRoborazziDebug` (検証)、誤って record を CI で実行しないよう注意
 
 ## 関連
 
 - ADR 0023 (UI 凍結三本柱)
 - `docs/harness/plan.md` §3.9 / R-22 / R-23 / R-24
-- `.claude/rules/{design-tokens,ui-inventory,behavior-preservation,screenshot-test}.md`
+- `.claude/rules/{design-tokens,ui-inventory,behavior-preservation,screenshot-test,composable,wasm-compat}.md`
 - `.claude/skills/ui-snapshot/SKILL.md`
+- `docs/design/inventory/screenshots/` (baseline 配置先)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,21 @@
 | `docs/epics/**/` | epic.md |
 | `docs/plans/*.md` | plan.md |
 | `docs/harness/roadmap.md`, `docs/epics/**/roadmap.md` | roadmap.md |
+| `docs/requirements/**`, `docs/specifications/**` (実装中の仕様変更) | spec-living-sync.md, docs-structure.md |
+| `docs/harness/learnings/**/*.md` | retrospective-format.md |
+| `docs/harness/evolution-proposals/**` | harness-evolution.md |
 | `data/users.db*` の追跡 | **禁止** (db-protection.md / pii.md / secrets.md / `.gitignore`) |
 | `data/idols.db` 関連 | sqlite-data-file.md |
 | Dockerfile | cloud-run-deploy.md, db-protection.md |
 | `.github/workflows/**` | gradle.md (CI で `./gradlew check` 起動)、Claude API は呼ばない (ADR 0017) |
+| `.github/PULL_REQUEST_TEMPLATE/**`, `.github/pull_request_template.md` | pr-template.md |
 | `.claude/skills/**/SKILL.md` | skill-authoring.md |
+| `.claude/skills/implementation-workflow/**` | implementation-workflow.md, branch-naming.md, pr-template.md, pr-draft-policy.md, merge-readiness.md, spec-living-sync.md |
+| `.claude/skills/code-reviewer/**` | code-reviewer-aspects.md, merge-readiness.md |
+| `.claude/skills/{harness-meta,pr-poller}/**` | harness-meta-criteria.md, pr-poller.md, retrospective-format.md |
+| `.claude/skills/harness-evolution/**` | harness-evolution.md |
+| `.claude/locks/**` | pr-poller.md |
+| `scripts/install-git-hooks.sh` | commit-message.md, branch-naming.md |
 | `.claude/rules/**` | rules-index.md, docs-structure.md, template-language.md |
 
 ## グローバルルール


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: EPIC-A2
related_adrs:
  - ADR-0017
  - ADR-0018
  - ADR-0019
  - ADR-0023
  - ADR-0025
  - ADR-0026
  - ADR-0027
related_specs: []
expected_modules:
  - .claude/rules/pr-template.md
  - .claude/rules/branch-naming.md
  - .claude/rules/merge-readiness.md
  - .claude/rules/pr-draft-policy.md
  - .claude/rules/spec-living-sync.md
  - .claude/rules/harness-meta-criteria.md
  - .claude/rules/retrospective-format.md
  - .claude/rules/pr-poller.md
  - .claude/rules/skill-authoring.md
  - .claude/rules/harness-evolution.md
  - .claude/rules/implementation-workflow.md
  - .claude/rules/code-reviewer-aspects.md
  - .claude/rules/design-tokens.md
  - .claude/rules/ui-snapshot.md
  - .claude/rules/ui-inventory.md
  - .claude/rules/behavior-preservation.md
  - .claude/rules/docs-structure.md
  - .claude/rules/template-language.md
  - .claude/rules/commit-message.md
  - .claude/rules/rules-index.md
-->

## 概要

EPIC-A2 配下 3 番目の PR。`.claude/rules/` の skeleton 状態だったプロセス系 / ハーネスループ系 / UI/UX 系の 12 ファイルを本格化し、さらに新規 6 ファイル (pr-template / branch-naming / merge-readiness / pr-draft-policy / spec-living-sync / harness-meta-criteria) を追加。合計 20 ファイル (新規 6 + 本格化 11 + 微調整 2 + 索引 1)、+1675 / -284 行 (net +1391 行)。

## 関連

- Plan: なし (1 PR 完結のため EPIC-A2 直下、Plan 不要)
- Epic: EPIC-A2-rules-docs-extension (A2-3)
- ADR: ADR-0017 (ローカル Claude Code ポーリング駆動) / ADR-0018 (10 フェーズ設計) / ADR-0019 (code-reviewer 8 aspect) / ADR-0023 (UI 凍結三本柱) / ADR-0025 (Skill 作成) / ADR-0026 (harness-evolution) / ADR-0027 (docs 構造 + 日本語化)
- 元 learnings: \`docs/harness/learnings/2026-05-17-pr-117.md\` / \`2026-05-17-pr-121.md\` / \`2026-05-17-pr-119.md\` (A1 / A2-1 レトロ Try で A2-3 該当項目を取り込み)

## PR の種別

- [x] **rules / Skill 本格化** (B0 雛形 → 本文充実)

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 |
|---|---|---|
| #121 (A2-1 レトロ) | implementation-workflow Phase 0 で \`git fetch origin master\` 明文化 | \`implementation-workflow.md\` Phase 0 に追記 |
| #121 (A2-1 レトロ) | code-reviewer binary checklist 各 aspect 5-7 項目確定 | \`code-reviewer-aspects.md\` で 5-7 項目化 |
| #121 (A2-1 レトロ) | docs-structure NG 例コメント明示 | \`docs-structure.md:116-117\` に注釈追加 |
| #121 (A2-1 レトロ) | commit-message 本文 vs Gotchas での「英語」記述位置整理 | \`commit-message.md\` で §subject 言語ポリシー セクション化 |

## 変更内容

| 区分 | パス | 変更内容 |
|---|---|---|
| rule (新規) | \`.claude/rules/pr-template.md\` | PR テンプレート選択 / \`gh pr create --template\` 運用規約 (140 行) |
| rule (新規) | \`.claude/rules/branch-naming.md\` | ブランチ命名規約 (98 行) |
| rule (新規) | \`.claude/rules/merge-readiness.md\` | Merge 可否判定 3 条件 (95 行) |
| rule (新規) | \`.claude/rules/pr-draft-policy.md\` | Draft → Ready 昇格条件 (95 行) |
| rule (新規) | \`.claude/rules/spec-living-sync.md\` | 仕様変更時の双方向同期 (95 行) |
| rule (新規) | \`.claude/rules/harness-meta-criteria.md\` | 採用 / 見送り / 撤去判定基準 (112 行) |
| rule (本格化) | \`.claude/rules/implementation-workflow.md\` | Phase 0 で \`git fetch origin master\` 明文化、10 Phase 詳細化 (179 行) |
| rule (本格化) | \`.claude/rules/code-reviewer-aspects.md\` | binary checklist 各 aspect 5-7 項目確定 (215 行) |
| rule (本格化) | \`.claude/rules/retrospective-format.md\` | learning ファイル構造、redaction チェックポイント (200 行) |
| rule (本格化) | \`.claude/rules/pr-poller.md\` | 3 系統起動経路、排他制御、キャッチアップ動作 (109 行) |
| rule (本格化) | \`.claude/rules/skill-authoring.md\` | 100-point rubric、description = trigger の書き分け (157 行) |
| rule (本格化) | \`.claude/rules/harness-evolution.md\` | 外部情報源ホワイトリスト、Context7 引用検証 (151 行) |
| rule (本格化) | \`.claude/rules/design-tokens.md\` | DESIGN.md 3 階層 + Kotlin マッピング例 (123 行) |
| rule (本格化) | \`.claude/rules/ui-snapshot.md\` | 4 パターン baseline + changeThreshold (112 行) |
| rule (本格化) | \`.claude/rules/ui-inventory.md\` | screens/components/states/flows + frontmatter (134 行) |
| rule (本格化) | \`.claude/rules/behavior-preservation.md\` | Behavior Preservation 証拠セクション、例外 4 ケース (129 行) |
| rule (本格化) | \`.claude/rules/docs-structure.md\` | NG 例コメント明示 (PR #121 レトロ)、関連リンク拡充 (171 行) |
| rule (微調整) | \`.claude/rules/template-language.md\` | Phase A 経過措置を本文化 (75 行) |
| rule (微調整) | \`.claude/rules/commit-message.md\` | §subject 言語ポリシー セクション化 (151 行) |
| rule (索引) | \`.claude/rules/rules-index.md\` | 18 件を stable (A2-3) に正規化 (175 行) |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| A1 / A2-1 レトロ Try (A2-3 該当分) | 4 (Phase 0 fetch / binary checklist / NG 例 / commit-message 整理) | 0 | 0 | 0 |
| EPIC-A2 README expected_modules | 18 ファイル全て | 0 | 0 | 0 |

## 三層指標差分

| 指標 | Before | After | Δ | 備考 |
|---|---|---|---|---|
| Line coverage | N/A | N/A | — | Kover 未導入 (A7 で導入予定) |
| Branch coverage | N/A | N/A | — | 同上 |
| Spec coverage | N/A | N/A | — | Konsist \`@Spec\` 未導入 (A7 で導入予定) |
| Mutation score | N/A | N/A | — | PITest 未導入 (A7 で導入予定) |
| Lint 違反数 | N/A | N/A | — | Spotless / ktlint / detekt / markdownlint-cli2 未導入 (A6 で導入予定) |
| Rule 数 (\`.claude/rules/\`) | 47 | 53 | +6 | 新規 6 件追加 |
| 本格化済 rule 数 | 35 | 53 | +18 | A2-3 で 18 件を stable (A2-3) に正規化 |

## レビュー観点

- frontmatter 配列が block 形式か (\`docs-structure.md\` 規約)
- 5 行 summary が冒頭 blockquote にあるか
- ADR 参照が一方向 (rule → ADR、A1 レトロ Problem #1 SoT 循環参照対策)
- 機械検証セクションが A6 / A7 / A10 のいずれかで明記されているか
- Gotchas セクション最低 3 項目
- 関連セクションで dangling 参照ゼロ
- PR #121 レトロ Try 4 件 (Phase 0 fetch / binary checklist / NG 例 / commit-message 整理) の反映確認

## マージ方針

- orchestrator (subroh0508) からの明示的事前承認済み (R-15 該当、本指示テキスト「Phase 1-9 含む self-merge」)
- code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) 並列 review 通過後、Critical 修正 → Ready 昇格 → \`gh pr merge --squash\` または \`--merge\`
- merge 後に Phase 8 mirror PR を起票して EPIC-A2 roadmap / progress を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)