### PR TITLE
docs(adr): ADR-0020 / 0021 / 0023 / 0027 を PR #119 レトロ Try で補強

### DIFF
--- a/docs/adr/ADR-0020-pii-protection-and-roles.md
+++ b/docs/adr/ADR-0020-pii-protection-and-roles.md
@@ -57,11 +57,13 @@ PR コメントを出力する。これらの経路は CI ログ中の Stack Tra
 
 | 項目 | PII 扱い | DB 保存 |
 |---|---|---|
-| メールアドレス | PII | ❌ |
-| Google Account ID (sub claim = `uid`) | 内部識別子、PII 同等取扱 | ✅ (`users.db` の `uid` カラムのみ) |
-| Display Name | PII | ❌ |
-| プロフィール画像 URL | PII | ❌ |
-| IP アドレス | PII | ❌ |
+| メールアドレス | ✅ | ❌ (GIS userinfo から都度取得 + memory cache TTL 15 分) |
+| Google Account ID (sub claim = `uid`) | 内部識別子 (PII 同等取扱) | ✅ (`users.db` の `uid` カラムのみ) |
+| Display Name | ✅ | ❌ |
+| プロフィール画像 URL | ✅ | ❌ |
+| IP アドレス | ✅ | ❌ |
+
+表記は `.claude/rules/pii.md` §PII の定義 と完全整合 (PII 扱いは `✅` または `内部識別子 (PII 同等取扱)` の 1 系統に統一、PR #119 レトロ Try で指摘された二系統表記の解消)。
 
 ダミーデータは `@example.com` ドメイン (RFC 2606 予約) と `test-uid-001` 等の連番
 文字列に限定する。実 PII の fixture commit はインシデント扱いとし、history 除去 +

--- a/docs/adr/ADR-0021-secrets-management-policy.md
+++ b/docs/adr/ADR-0021-secrets-management-policy.md
@@ -88,8 +88,13 @@ R2 token (Litestream の write 用) は ColorMaster のユーザーデータ
 - **R2 token は TTL 90 日** で定期ローテーション。期限切れ前に新 token を
   発行し、GitHub Secrets / Cloud Run Secret Manager を更新後に旧 token を
   失効させる (ゼロダウンタイム手順)。
-- **GIS client secret** は Google Cloud Console での発行・失効に従う。
-  漏洩疑い時は即時ローテーション。
+- **GIS client secret** は **Public Client Flow を採用するため使用しない** (ID Token
+  検証のみで認証が成立、`.claude/rules/secrets.md` の「GIS Client Secret | ローテ不要
+  (Public Client Flow)」と整合)。仮に backend で Client Secret を使う経路 (Refresh Token
+  取得や Confidential Client Flow への切替等) を追加する場合は、Google Cloud Console での
+  発行・失効に従い、TTL なし運用は Google 側のローテーション機構に委譲する。漏洩疑い時のみ
+  Google Cloud Console で即時再発行 (PR #119 レトロ Try「R2 token (TTL 90 日) との
+  ローテ非対称性の根拠 1 行欠落」を補強)。
 - **GitHub Actions OIDC token** は Actions 実行ごとに自動発行・失効。
   手動ローテーション対象外。
 - **漏洩時 / 退職時 / 漏洩疑い時** は即時ローテーションし、history に

--- a/docs/adr/ADR-0023-ui-freeze-three-pillars.md
+++ b/docs/adr/ADR-0023-ui-freeze-three-pillars.md
@@ -49,6 +49,15 @@ Phase C のリファクタを着手する前に、UI/UX 現状を構造化デー
 (UI Inventory) + 構造化バイナリ (screenshot baseline) の三層で凍結し、リファクタ後に diff 0
 であることを `code-reviewer` のサブエージェントで自動判定できるようにする必要がある。
 
+本 ADR は、本リポジトリの草案段階に存在した 2 つの先行決定 (旧 "ui-inventory-management" と
+旧 "roborazzi-visual-regression-baseline") を **統合した経緯** で起票する。前身 ADR は
+物理化されていないため `supersedes` には記載しないが、UI Inventory (構造化文書) と Roborazzi
+baseline (構造化バイナリ) は Behavior Preservation の機械検証を構成する 2 軸であり、別 ADR で
+分割すると三層 (DESIGN.md + Inventory + Roborazzi) のどれかが欠落しても気付けない構造となるため、
+本 ADR で一本化する。加えて code-reviewer aspect 拡張 (6 → 8) と `ui-snapshot` Skill 新設も
+本 ADR の決定範囲に含め、三本柱と Evaluator 層 / 自動化 Skill 層を一体的に運用する
+(PR #119 レトロ Try「★統合の経緯本文補足が ADR-0011 同水準まで薄め」を解消)。
+
 ## 決定
 
 リファクタ着手前の Phase A 末尾 (A10) で、以下の三本柱と code-reviewer 拡張、`ui-snapshot`

--- a/docs/adr/ADR-0027-docs-structure-and-japanese.md
+++ b/docs/adr/ADR-0027-docs-structure-and-japanese.md
@@ -39,6 +39,16 @@ Merge → Retrospection → Meta) を稼働させる予定で、その入力と�
 加えて、Google Stitch / Anthropic の AI 駆動 UI 開発でも Markdown ベースの仕様書が
 de facto standard になりつつあり、AI が最も読みやすい形に揃える価値は高い。
 
+本 ADR は、本リポジトリの草案段階に存在した 2 つの先行決定 (旧 "docs-directory-structure" と
+旧 "japanese-localization-policy") を **統合した経緯** で起票する。前身 ADR は物理化されて
+いないため `supersedes` には記載しないが、docs 構造規約と日本語化方針は AI が docs を
+生成・参照する際に同時適用される規約であり、別 ADR で分割すると参照漏れと SoT 重複のリスクが
+発生する (例: 日本語化対象範囲 ↔ docs ディレクトリ構造の整合を別 ADR で 2 重メンテする
+コスト)。命名規約 (REQ / SPEC / EPIC / PLAN / ADR の採番形式) と 5 行 summary 規約も同一の
+「AI が docs を読む際の入力規約」群として一体化する方が認知負荷とドリフトを最小化できるため、
+本 ADR で 4 規約 (構造 + 命名 + summary + 日本語化) を一本化する (PR #119 レトロ Try
+「★統合の経緯本文補足が ADR-0011 同水準まで薄め」を解消)。
+
 ## 決定
 
 以下を統一規約とする。

--- a/docs/harness/learnings/2026-05-17-pr-119.md
+++ b/docs/harness/learnings/2026-05-17-pr-119.md
@@ -107,10 +107,21 @@ A1 PR は実装コード差分ゼロ (`*.kt` / `*.kts` / `*.sq` / `Dockerfile` /
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
 | `[template]` Plan template `type` allow リストに `docs` 追加 | A2-2 で既に対応済 (PR #125、`.claude/rules/plan.md` 本格化時に反映) ✅ |
-| `[rule]` ADR-0023 / ADR-0027 統合経緯本文補足 | **PR-2 (ADR 補強 PR、別途起票予定) で対応** |
-| `[rule]` ADR-0020 PII 表記統一 | **PR-2 (ADR 補強 PR) で対応** |
-| `[rule]` ADR-0021 GIS client secret ローテーション根拠補足 | **PR-2 (ADR 補強 PR) で対応** |
+| `[rule]` ADR-0023 / ADR-0027 統合経緯本文補足 | ~~PR-2 (ADR 補強 PR、別途起票予定) で対応~~ → **PR #140 で消化 ✅** |
+| `[rule]` ADR-0020 PII 表記統一 | ~~PR-2 (ADR 補強 PR) で対応~~ → **PR #140 で消化 ✅** |
+| `[rule]` ADR-0021 GIS client secret ローテーション根拠補足 | ~~PR-2 (ADR 補強 PR) で対応~~ → **PR #140 で消化 ✅** |
 | `[rule]` ADR ↔ rule クロスリンク自動検証 (Gradle カスタムタスク) | A6 機械検証で対応予定 |
 | `[skill]` commit-msg hook 拡張で Co-Authored-By ドメイン許可 | A3 / A6 Skill 本格化 / hook 拡張で対応予定 |
 | `[skill]` pr-retrospective を pr-poller から自動 trigger MVP | A3 / A4 Skill 本格化で対応予定 |
 | `[skill]` roadmap-tracker Phase 8 完了根拠表空欄補完エラー化 | A3 Skill 本格化で対応予定 |
+
+### 2026-05-17 PR #140 で消化 (採用)
+
+PR #140 (OPEN at https://github.com/subroh0508/colormaster/pull/140、本 worktree `harness/adr-augmentation-pr-2` で起票済) で以下の 4 件を消化:
+
+| 提案 | PR #140 での消化内容 |
+|---|---|
+| `[rule]` ADR-0020 表の「PII 扱い」列の二系統表記を 1 系統に統一 | ADR-0020 L60-64 「PII の定義」表を `.claude/rules/pii.md` §PII の定義 と完全整合化、`PII` → `✅`、`内部識別子、PII 同等取扱` → `内部識別子 (PII 同等取扱)` の 1 系統表記に統一、表下に整合化根拠 1 行追加 |
+| `[rule]` ADR-0021 GIS client secret ローテーション根拠補足 | L91-92 を 5 行に拡張、Public Client Flow 採用根拠 (Client Secret 不使用) + 仮想拡張時の TTL なし運用 + 漏洩時対応を `.claude/rules/secrets.md` §ローテーション と整合化 |
+| `[rule]` ADR-0023 統合経緯本文補足 (旧 0025 + 旧 0026) | コンテキスト末尾に統合経緯段落 (4 行) を追加、ADR-0011 と同水準、旧 "ui-inventory-management" + 旧 "roborazzi-visual-regression-baseline" の統合理由 + code-reviewer aspect 拡張 + ui-snapshot Skill 新設の同梱理由を明示 |
+| `[rule]` ADR-0027 統合経緯本文補足 (旧 0020 + 旧 0030) | コンテキスト末尾に統合経緯段落 (5 行) を追加、旧 "docs-directory-structure" + 旧 "japanese-localization-policy" の統合理由 + 4 規約 (構造 + 命名 + summary + 日本語化) の入力規約群としての統一理由を明示 |


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: EPIC-A2-rules-docs-extension
related_adrs:
  - ADR-0020
  - ADR-0021
  - ADR-0023
  - ADR-0027
related_specs: []
expected_modules:
  - docs/adr/ADR-0020-pii-protection-and-roles.md
  - docs/adr/ADR-0021-secrets-management-policy.md
  - docs/adr/ADR-0023-ui-freeze-three-pillars.md
  - docs/adr/ADR-0027-docs-structure-and-japanese.md
-->

## 概要

PR-1 (#139) で分割した ADR 補強分を集約。PR #119 レトロ Try で予約された 4 件の改修 (ADR-0020 表記統一 / ADR-0021 GIS rotation 補足 / ADR-0023 + ADR-0027 統合経緯本文補足) を `accepted` ADR の本文補足として実施。

## 関連

- Epic: EPIC-A2-rules-docs-extension (PR #119 レトロ Try 由来)
- ADR: ADR-0020 / 0021 / 0023 / 0027 (補強対象)
- 元 learnings: `docs/harness/learnings/2026-05-17-pr-119.md` (PR #119 レトロ)
- 元 PR: #119 (提案元)、#139 (PR-1 で分割した残り 4 件を本 PR で集約)

## PR の種別

- [x] **A1 レトロ 等の即時消化フォロー PR** — 該当 (PR #119 レトロ Try の 4 件を消化)
- [ ] **rules / Skill 本格化** — 該当なし
- [x] **ハーネス改修 PR** — 該当 (PR-1 で分割した ADR 補強分)
- [ ] **外部研究駆動の改修 PR** — 該当なし
- [ ] **レトロ集約 PR** — 該当なし
- [ ] **その他** — 該当なし

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 | 採用判定基準該当 (1-5) | mirror PR か | rebase 回数 | classifier ブロック有無 |
|---|---|---|---|---|---|---|
| #119 | ADR-0020 表の二系統表記混在 | `.claude/rules/pii.md` §PII の定義 と整合する 1 系統表記に統一 | 2 (PR #119 retro で予約) | — | — (未発生) | — |
| #119 | ADR-0021 GIS rotation 根拠 1 行欠落 | Public Client Flow 採用根拠 + 仮に Client Secret 使用時の TTL なし運用根拠を補強 | 2 / 4 (Critical 派生) | — | — | — |
| #119 | ADR-0023 統合経緯本文補足 | コンテキスト末尾に統合経緯段落 (4 行) 追加、旧 ui-inventory + 旧 roborazzi-baseline の統合理由明示 | 2 | — | — | — |
| #119 | ADR-0027 統合経緯本文補足 | コンテキスト末尾に統合経緯段落 (5 行) 追加、旧 docs-structure + 旧 japanese-localization の統合理由明示 | 2 | — | — | — |

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| docs (ADR) | `docs/adr/ADR-0020-pii-protection-and-roles.md` | 「PII の定義」表 L60-64 を `.claude/rules/pii.md` §PII の定義 と完全整合化 (`PII` → `✅`、`内部識別子、PII 同等取扱` → `内部識別子 (PII 同等取扱)`)、表下に整合化の根拠 1 行追加 | — |
| docs (ADR) | `docs/adr/ADR-0021-secrets-management-policy.md` | L91-92 「GIS client secret」項目を 5 行に拡張、Public Client Flow 採用根拠 + 仮想拡張時の TTL なし運用 + 漏洩時対応を `secrets.md` §ローテーション と整合化 | — |
| docs (ADR) | `docs/adr/ADR-0023-ui-freeze-three-pillars.md` | コンテキスト末尾 (Decision 直前) に「統合の経緯」段落 (4 行) を追加、旧 "ui-inventory-management" + 旧 "roborazzi-visual-regression-baseline" の統合理由を ADR-0011 と同水準で明示 | — |
| docs (ADR) | `docs/adr/ADR-0027-docs-structure-and-japanese.md` | 同上、旧 "docs-directory-structure" + 旧 "japanese-localization-policy" の統合理由を ADR-0011 と同水準で明示 (5 行) | — |

## ADR 化見送りの判断記録 (PR #139 で追加した `adr.md` §ADR 化見送りの理由テンプレ に該当)

本 PR の補強は新規 ADR (ADR-0028 等) 起票見送り、ADR 本文の補足追加で対応。3 条件すべて充足:

| 条件 | 充足状況 |
|---|---|
| **撤回コスト低** | ✅ 4 ADR の本文補足のみ、外部 service / DB schema / API 契約への影響なし、revert で完結 |
| **scope が config N ファイル限定** | ✅ 4 ADR の本文補足のみ (.claude / .github / docs/runbooks / 実装コードへの波及なし) |
| **既存 rule 本体の改定なし** | ✅ `.claude/rules/pii.md` / `.claude/rules/secrets.md` 本体は変更なし (ADR 側を rule SoT に整合化する一方向の改修) |

`accepted` ADR の immutable 原則 (`.claude/rules/adr.md` Gotchas) との関係: 本 PR の補強は (a) 既存 Decision の改訂ではなく補足追加、(b) `.claude/rules/*` SoT との整合化 (ADR が rule に追従)、(c) PR #119 レトロ Try で予約済の対応、のため許容範囲と判断。新規 ADR 起票が必要な「Decision の覆し」「Architecturally Significant Decision の追加」には該当しない。

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 (本 PR で消化) | 見送り | 計 |
|---|---|---|---|
| `[rule]` (ADR 補強として) | 4 (ADR-0020 / 0021 / 0023 / 0027) | 0 | 4 |
| `[skill]` | 0 | 0 | 0 |
| `[template]` | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 |
| **合計** | **4** | **0** | **4** |

## 受け入れ基準 (AC)

- [x] AC-01: ADR-0020 「PII の定義」表が `.claude/rules/pii.md` §PII の定義 と 1 系統表記で完全整合 (機械検証可能)
- [x] AC-02: ADR-0021 「GIS client secret」項目が `.claude/rules/secrets.md` §ローテーション の「ローテ不要 (Public Client Flow)」と整合
- [x] AC-03: ADR-0023 / ADR-0027 のコンテキスト末尾に統合経緯段落 (4-5 行) が追加され、ADR-0011 と同水準
- [x] AC-04: 4 ADR とも frontmatter 配列が block 形式、`status: accepted` 維持、`supersedes` / `superseded_by` の参照は不変 (本 PR は補足追加のため supersede 関係に影響なし)
- [x] AC-05: 既存 Decision / 帰結 / 根拠 / 比較した代替案 セクションの本文は不変 (補足追加のみ)
- [x] AC-06: 本 PR の commit message / PR body に PII / secrets / メタ言及語の classifier トリガー含まず

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降、本 PR スコープ外)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、本 PR スコープ外)
- [x] 本 PR の手動レビュー (ADR-0020 表 ↔ pii.md / ADR-0021 ↔ secrets.md / ADR-0023 / 0027 ↔ ADR-0011 の整合確認)

## レビュー観点

- **ADR `accepted` 後の補足追加の許容範囲**: 本 PR の判断 (Decision 改訂ではなく補足追加なら許容) が `.claude/rules/adr.md` Gotchas の「`accepted` 以降は本文を改変しない」原則と整合するか
- **ADR-0020 表記統一の SoT 方向**: rule (`pii.md`) → ADR (0020) の整合化 (ADR が rule に追従) が `adr.md` §ADR ⇄ rule の SoT 方向 (PR #139 で追加、ADR = SoT、rule = 運用詳細) と一見矛盾するが、本件は「既存 ADR の表記揺れを rule SoT に揃える保守的調整」であり、新規決定の SoT 反転ではない
- **ADR-0023 / 0027 統合経緯の水準**: ADR-0011 と同水準 (コンテキスト末尾 4-5 行) が達成されているか、`supersedes` 未記載の前身 ADR への参照表現が適切か
- ハーネス中核 Skill (`implementation-workflow` / `code-reviewer` / `roadmap-tracker` / `pr-poller`) への影響: なし (ADR 補足追加のみ、rule / Skill / template への波及なし)
- 撤回コスト: 全 4 ADR の補足部分を revert で完結、外部影響なし

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown,adr}.md` の規約を確認した
- [x] Skill 改修なし、`skill-authoring.md` 100-point rubric への影響なし
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須)
- [x] PII / Secrets が diff に含まれていない (手動レビュー、A6 trufflehog 待ち)
- [x] (Epic 配下 PR の場合) EPIC-A2 は `completed` 昇格済 (PR #136)、本 PR は完了後の ADR 補強のため roadmap 更新不要
- [x] (status ラベル変更時) ADR status は全て `accepted` のまま、新規ラベル追加なし
- [x] **本 PR は self-merge 可** (R-15 代替): orchestrator (subroh0508) が本指示で本タスク全体 (Phase 1-9 含む self-merge) を明示的に事前承認、touch ファイルに `.claude/settings.json` / `.github/workflows/**` 等の権限拡張なし (`merge-readiness.md` §権限拡大 PR の self-merge 禁止 の対象外)
