### PR TITLE
feat(harness): dry-run phase 配置 (PR #141 retro Try 実装)

### DIFF
--- a/.claude/rules/harness-meta-criteria.md
+++ b/.claude/rules/harness-meta-criteria.md
@@ -112,6 +112,52 @@ Step 1 と Step 2 を同一 PR に統合する 1 段階運用は **禁止** (誤
 - **code-reviewer 4 aspect 並列を必ず通す**: harness 改修は spec-conformance / architecture / security / code-quality の 4 aspect で十分 (test-quality / performance / visual-regression / design-tokens は skip 妥当な場合が多い)
 - **PR description の「採用根拠」セクション**: 対象 learning ファイル + 採用判定基準 1〜5 のどれを満たすかを明記
 
+## dry-run 必須条件 (PR #141 レトロ Try / 人間追加最優先)
+
+`harness-meta` / `harness-bootstrap` (retro 集約改善モード) が改善提案を commit + push する前に
+**dry-run フェーズ** を経るべきかを判定する基準。dry-run の目的は **AI 出力品質改善の事前検証**
+(rule strict 化が誤検知を増やさないか / template 強化が本質的に AI のミスを減らすか / Skill フロー
+追加が context 圧迫の割に効果が出るか)、Generator-Evaluator 独立性 (R-13) と整合。
+本格的な dry-run 実装 (サブエージェント並列 + 出力比較 + 判定) は A3/A4 (harness-meta Skill 本格化) で実施、
+現状の `harness-bootstrap` (skeleton) では本セクションを参照しつつ手動で代替実行可。
+
+### dry-run 必須 (適用版 vs 未適用版の subagent 並列比較が必要)
+
+以下のいずれかに該当する改善提案は、commit + push 前に dry-run フェーズで AI 出力品質の改善有無を検証:
+
+| 区分 | 例 |
+|---|---|
+| **rule 全文書き換え** | 既存 rule の本文 50% 以上を改変、SoT 方向の変更、採用判定基準 / 必須条件等の核心セクション改修 |
+| **Skill 新規追加** | `.claude/skills/<new-name>/SKILL.md` の新規配置 (skeleton / active 問わず) |
+| **Skill フロー追加 / 削除** | 既存 Skill の入力 / 出力 / フェーズ別動作の追加 / 削除 |
+| **template 構造変更** | テンプレ Markdown のセクション追加 / 削除 / frontmatter 必須キー変更 |
+| **rule 間の SoT 反転** | 既存の rule A → rule B 参照方向を逆転、または同一トピックの SoT 移動 |
+| **`harness-meta` 採用判定基準 / 撤去基準の改修** | 本 rule §採用判定基準 / §撤去判定基準 の項目追加 / 削除 / 閾値変更 |
+
+### dry-run 不要 (commit + push に直接進んでよい)
+
+以下のいずれかに該当する改善提案は dry-run スキップ可:
+
+| 区分 | 例 |
+|---|---|
+| **typo / 表記揺れ修正** | 全角半角統一、識別子の表記正規化、機械検出可能な誤字 |
+| **リンク追加 / 修正** | rule 間クロスリンクの欠落補正、`docs/` への参照追加 |
+| **既存セクションへの例示追加** | 既存ルールの根拠を強化する事例追加 (rule 本体ルール不変) |
+| **frontmatter 値更新** | `last_updated` / `status` / `phase` の更新のみ |
+| **rules-index.md / CLAUDE.md lookup table の索引行追加** | 既存 rule の参照パターン明文化、新規 rule の追加に伴う索引同期 |
+| **撤回コスト低 + scope 限定 + 既存 rule 本体改定なし** (PR #140 `accepted` ADR 補足追加 3 条件) | ADR 補足追加、retro 📝 追記、横断 learnings への 1 行追加 |
+
+### dry-run 結果の記録先
+
+- dry-run 実施時は `docs/harness/dry-runs/YYYY-MM-DD-pr-NNN.md` (テンプレ: `docs/harness/dry-runs/template.md`、索引: `docs/harness/dry-runs/INDEX.md`) に **before/after の AI 出力差分** と **判定理由** を記録
+- 判定基準: 適用版が未適用版より明らかに望ましい出力 (誤検知減 / 規約遵守率向上 / 提案精度向上) を出す場合のみ commit + push に進む
+- 改善が見られない / 退化する場合は変更を破棄 or 別案検討 → `📝 harness-meta フィードバック` の「保留 (要再評価)」表に記録
+
+### 必須条件不一致時のフォールバック
+
+- 改善提案が **必須 / 不要のどちらにも明確に該当しない** (例: rule 改修だが scope 限定的、template 構造変更だが backward compatible 等) → orchestrator (subroh0508) に判定委任 (`harness-meta-criteria.md` 採用判定基準 5 と同等のエスカレーション)
+- dry-run コストが効果を上回ると判断される場合は **skip 理由を `📝 harness-meta フィードバック` に明示** (例: 「rule 改修だが採用バイアス対策のため即時反映、後続 PR で効果測定」)
+
 ## 即時消化 vs 持ち越し 判断基準 (PR #135 レトロ Try)
 
 採用判定基準 1-5 は「採用 = 改修 PR 起票」の基準であり、採用後に **同 PR 内で即時消化するか / 持ち越して別 PR にするか** の境界は別軸で判断する:

--- a/.claude/skills/harness-bootstrap/SKILL.md
+++ b/.claude/skills/harness-bootstrap/SKILL.md
@@ -2,8 +2,8 @@
 name: harness-bootstrap
 description: |
   Phase A の A1〜A10 を進める汎用 Skill。専用 Skill 群が揃うまで、入力パスから
-  タスク種別 (ADR 起草 / rules 拡充 / docs 拡充 / Skill 実装 / 撤去 / Lint 導入) を
-  自動判定して該当ファイルを起草する。A3 完了後に archived/ へ移動。
+  タスク種別 (ADR 起草 / rules 拡充 / docs 拡充 / Skill 実装 / 撤去 / Lint 導入 /
+  retro 集約改善) を自動判定して該当ファイルを起草する。A3 完了後に archived/ へ移動。
 status: skeleton
 phase: B0
 related_plan: docs/harness/plan.md §6.2
@@ -12,6 +12,8 @@ related_rules:
   - .claude/rules/docs-structure.md
   - .claude/rules/skill-authoring.md
   - .claude/rules/template-language.md
+  - .claude/rules/harness-meta-criteria.md
+  - .claude/rules/retrospective-format.md
 ---
 
 # harness-bootstrap (B0 骨格)
@@ -34,14 +36,58 @@ A3 完了後に `.claude/skills/archived/` へ移動し、CLAUDE.md からの参
 | `.claude/skills/*/` を作成 | Skill 実装モード (`example-skills:skill-creator` を呼び出す) |
 | モジュールディレクトリ削除指示 | 撤去モード |
 | `build.gradle.kts` / lint 設定追加 | Lint 導入モード |
+| 複数 merged retro の `🤖 ハーネス改善提案` を集約消化する指示 | retro 集約改善モード (PR #139 で実証、`harness-meta` Skill 本格化 A3/A4 までの暫定運用) |
 
 複数該当時はユーザーに確認する。
+
+## retro 集約改善モード (PR #141 レトロ Try / 人間追加最優先)
+
+PR #139 で 8 retro × 約 47 件の改善提案を 1 PR で集約消化した手動代替実行パターン。
+`harness-meta` Skill 本格化 (A3/A4) までの暫定運用として、本 Skill が以下の 4 ステップを担う。
+本格実装 (subagent 並列 dedupe + 採用判定 + dry-run + PR 起票) は A3/A4 harness-meta Skill に委任、
+本セクションは **配置のみ** (詳細仕様は `.claude/rules/harness-meta-criteria.md` を参照)。
+
+### ステップ 1: merged retro 全件 parse
+
+- 入力: `docs/harness/learnings/YYYY-MM-DD-pr-<n>.md` の `🤖 ハーネス改善提案` セクション
+- 抽出: `[rule]` / `[skill]` / `[template]` / `[remove]` プレフィックス付きの未消化提案
+- 出力: 提案リスト (PR 番号 × カテゴリ × プレフィックス × 採用判定基準該当箇所)
+
+### ステップ 2: dedupe + カテゴリ化 + スコープ分類
+
+- dedupe: 同一トピックの提案を 1 件に集約 (例: A1 レトロ rules-index 正規化 ⇄ A2-3 status drift)
+- カテゴリ化: rule / skill / template / docs / ADR / 横断 learnings 別
+- スコープ分類: 採用判定基準 1-5 (`harness-meta-criteria.md` §採用判定基準) のどれを満たすか
+
+### ステップ 3: dry-run フェーズ (PR #141 レトロ Try / 人間追加最優先)
+
+`.claude/rules/harness-meta-criteria.md` §dry-run 必須条件 を参照し、改善提案ごとに dry-run 必要 / 不要を判定。
+必要な提案については以下の 5 ステップで適用前検証を実施:
+
+1. **dry-run 入力**: 改善提案を適用した rule / template / skill / docs と、未適用の既存版 (両 commit / branch / worktree のどれを使うかは設計時に確定、A3/A4 本格化時に worktree 並列が候補)
+2. **dry-run 実行**: 適用版と未適用版それぞれに対して、過去 retro で問題視された具体的シナリオを **AI (サブエージェント、Generator 独立性のため別 system prompt)** に投げて出力を比較。シナリオ抽出元は対象 retrospective の `⚠️ Problem` セクション (再現条件 + 過去の AI 出力との対比で判定可能なもの)
+3. **判定基準**: 適用版が未適用版より明らかに望ましい出力 (誤検知減 / 規約遵守率向上 / 提案精度向上) を出す場合のみ commit + push に進む。改善が見られない / 退化する場合は変更を破棄 or 別案検討
+4. **dry-run 結果記録**: `docs/harness/dry-runs/YYYY-MM-DD-pr-NNN.md` (テンプレ: `docs/harness/dry-runs/template.md`、索引: `docs/harness/dry-runs/INDEX.md`) に before/after の AI 出力差分と判定理由を残す
+5. **必須条件参照**: 適用 / 未適用判定が曖昧な場合は `.claude/rules/harness-meta-criteria.md` §dry-run 必須条件 §必須条件不一致時のフォールバック に従い orchestrator (subroh0508) に判定委任
+
+dry-run スキップ可の提案 (typo 修正 / リンク追加等、`harness-meta-criteria.md` §dry-run 不要 表参照) は本ステップを skip して直接ステップ 4 へ。
+
+### ステップ 4: PR 起票 + `📝 harness-meta フィードバック` 一括追記
+
+- PR ブランチ: `harness/<purpose>` (`.claude/rules/branch-naming.md` 参照)
+- PR テンプレ: `.github/PULL_REQUEST_TEMPLATE/harness.md` (`.claude/rules/pr-template.md` 参照)
+- 各 retro の `📝 harness-meta フィードバック` セクションに「採用」「見送り」表を一括追記
+  (PR 番号は起票後に確定、placeholder 残存検出は A6 機械検証で実装予定)
+- N PR vs 1 PR 包括判断は `harness-meta-criteria.md` §分割粒度 を参照
 
 ## Gotchas
 
 - 本 Skill は B0 時点では雛形のみ。本格動作は Phase A で実装する。
 - ADR 起草モードでは `.claude/rules/adr.md` の起票基準を必ず参照する。
 - Skill 実装モードでは新規 Skill を本リポジトリに作成せず、Claude Code ユーザースコープの `example-skills:skill-creator` を呼び出すこと (ADR 0025)。
+- **retro 集約改善モードの dry-run フェーズは A3/A4 harness-meta Skill 本格化までは手動代替実行**: subagent 並列 / 出力比較 / 判定の自動化は未実装、本セクションは仕様の placeholder。本格実装は ADR 0025 (Skill 作成は `example-skills:skill-creator` 経由) に従い harness-meta Skill 起票時に skill-creator が rubric 評価する。
+- **dry-run 必須 / 不要の判定は `harness-meta-criteria.md` §dry-run 必須条件 を SoT とする**: 本 Skill 内で重複定義しない (重複時は rule 側を優先、本 Skill 側は誘導のみ)。
+- **dry-run 結果記録ファイルは `docs/harness/dry-runs/YYYY-MM-DD-pr-NNN.md`**: テンプレ / 索引は同ディレクトリの `template.md` / `INDEX.md` を参照。
 
 ## 関連
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@
 | `docs/harness/roadmap.md`, `docs/epics/**/roadmap.md` | roadmap.md |
 | `docs/requirements/**`, `docs/specifications/**` (実装中の仕様変更) | spec-living-sync.md, docs-structure.md |
 | `docs/harness/learnings/**/*.md` | retrospective-format.md |
+| `docs/harness/dry-runs/**/*.md` | harness-meta-criteria.md (§dry-run 必須条件) |
 | `docs/harness/evolution-proposals/**` | harness-evolution.md |
 | `data/users.db*` の追跡 | **禁止** (db-protection.md / pii.md / secrets.md / `.gitignore`) |
 | `data/idols.db` 関連 | sqlite-data-file.md |

--- a/docs/harness/dry-runs/INDEX.md
+++ b/docs/harness/dry-runs/INDEX.md
@@ -1,0 +1,36 @@
+---
+id: dry-runs-index
+title: ハーネス改善提案 dry-run 索引
+status: skeleton
+last_updated: 2026-05-17
+---
+
+# ハーネス改善提案 dry-run 索引
+
+> **5 行以内 summary**: `harness-meta` / `harness-bootstrap` (retro 集約改善モード) が
+> ハーネス改善提案を commit + push する前に実施する dry-run 結果の索引。
+> 1 PR (or 1 改善提案バッチ) = 1 ファイル (`YYYY-MM-DD-pr-NNN.md`)、Single Source of Truth。
+> ファイルフォーマットは `docs/harness/dry-runs/template.md` 参照、必須条件は
+> `.claude/rules/harness-meta-criteria.md` §dry-run 必須条件 を参照。
+
+## 索引 (起票時に追記)
+
+| 日付 | PR # | 関連 retrospective | 対象提案数 | 採用 / 破棄 / エスカレーション | 備考 |
+|---|---|---|---|---|---|
+
+## ファイル運用
+
+- 1 PR (or 1 改善提案バッチ) = 1 ファイル (`YYYY-MM-DD-pr-<n>.md`)
+- 必須条件: `.claude/rules/harness-meta-criteria.md` §dry-run 必須条件 §dry-run 必須 表に該当する提案が対象
+- 不要条件: 同 §dry-run 不要 表に該当する提案は本ディレクトリ非対象 (`📝 harness-meta フィードバック` に skip 理由明示)
+- 自動生成: `harness-meta` Skill 本格化 (A3/A4) で `harness-bootstrap` (skeleton) から移行
+- 集約 push: 通常は retro 集約消化 PR と同一ブランチで push、独立 PR が必要な場合は `harness/dry-run-<purpose>` ブランチ
+- 索引追記タイミング: dry-run ファイル生成時 (commit + push 前) に本 INDEX.md に 1 行追加
+
+## 関連
+
+- `.claude/rules/harness-meta-criteria.md` §dry-run 必須条件
+- `.claude/rules/retrospective-format.md` (元 retrospective フォーマット)
+- `.claude/skills/{harness-bootstrap,harness-meta}/SKILL.md` (harness-meta は A3/A4 で本格化予定)
+- `docs/harness/learnings/INDEX.md` (元 retrospective 索引)
+- `docs/harness/plan.md` §5.4.5 (harness-meta Skill 責務)

--- a/docs/harness/dry-runs/template.md
+++ b/docs/harness/dry-runs/template.md
@@ -1,0 +1,119 @@
+---
+id: dry-run-pr-NNN
+title: PR #NNN ハーネス改善提案 dry-run 結果 (<改善対象の簡潔な要約>)
+type: dry-run
+status: draft
+related_pr: NNN
+related_learning: docs/harness/learnings/YYYY-MM-DD-pr-NNN.md
+related_proposals:
+  - "[skill] <提案 1>"
+  - "[rule] <提案 2>"
+  - "[template] <提案 3>"
+generated_at: YYYY-MM-DDTHH:MM:SSZ
+generator: harness-meta Skill (vX.Y.Z) | harness-bootstrap (skeleton、本ペインで手動代替実行)
+verdict: adopt | discard | escalate
+---
+
+# PR #NNN ハーネス改善提案 dry-run 結果
+
+> 生成: harness-meta / harness-bootstrap Skill (vX.Y.Z) at YYYY-MM-DDTHH:MM:SSZ
+> 関連 retrospective: [`YYYY-MM-DD-pr-NNN.md`](../learnings/YYYY-MM-DD-pr-NNN.md)
+> 対象提案: <提案 N 件、各提案のプレフィックス [rule] / [skill] / [template] と該当ファイルパス>
+> 判定基準: 適用版が未適用版より明らかに望ましい出力 (誤検知減 / 規約遵守率向上 / 提案精度向上) を出す場合のみ採用
+
+## 改善提案の概要
+
+<!-- 対象提案を要約。元 retrospective `🤖 ハーネス改善提案` セクションへのリンクを含む。 -->
+
+- **提案 1 (`[skill]` / `[rule]` / `[template]`)**: <提案内容の 1-2 文要約> (元 retrospective: `docs/harness/learnings/YYYY-MM-DD-pr-NNN.md` `🤖 ハーネス改善提案`)
+- **提案 2**: ...
+- **提案 3**: ...
+
+## dry-run 入力 (適用版 / 未適用版の境界)
+
+<!-- 改善提案を適用した版と未適用の既存版をどう用意したか。両 commit / branch / worktree のどれを使ったか明示。 -->
+
+| 区分 | commit / branch / worktree | 該当ファイル |
+|---|---|---|
+| 未適用版 (Before) | `<base-branch>` / `<commit-sha>` | `<改善対象ファイル>` |
+| 適用版 (After) | `<feature-branch>` / `<commit-sha>` | 同上 (改善提案適用後) |
+
+## dry-run シナリオ (`⚠️ Problem` 抽出)
+
+<!-- 過去 retrospective の `⚠️ Problem` セクションから抽出した、改善効果を判定できるシナリオ。 -->
+
+| シナリオ ID | 抽出元 retrospective | Problem 内容 (要約) | 期待される改善 |
+|---|---|---|---|
+| S1 | PR #NNN | <Problem 要約> | <改善されるべき AI 出力の特性> |
+| S2 | PR #NNN | ... | ... |
+
+## dry-run 実行 (subagent 並列)
+
+<!-- Generator 独立性 (R-13) を保つため、適用版 / 未適用版それぞれに別 system prompt の subagent を立てて、上記シナリオを投げる。 -->
+
+### Subagent 構成
+
+- **適用版 subagent**: `Agent(subagent_type="general-purpose", prompt=<シナリオ + 適用版ファイル>)`
+- **未適用版 subagent**: `Agent(subagent_type="general-purpose", prompt=<シナリオ + 未適用版ファイル>)`
+- **system prompt 独立性**: 両 subagent の system prompt は本セッションの context を含まない、Generator-Evaluator 独立性 (R-13) と整合
+
+### Subagent 実行ログ (要約、PII / Secrets redaction 済)
+
+- 適用版 subagent 出力: `<要約 or リンク>`
+- 未適用版 subagent 出力: `<要約 or リンク>`
+
+## before/after AI 出力差分
+
+<!-- シナリオごとに適用版 / 未適用版の AI 出力を並列比較。差分 hunk または要約形式。 -->
+
+### S1: <シナリオ要約>
+
+**未適用版 (Before)**:
+
+```text
+<AI 出力のサンプル>
+```
+
+**適用版 (After)**:
+
+```text
+<AI 出力のサンプル>
+```
+
+**差分のポイント**: <誤検知減 / 規約遵守率向上 / 提案精度向上 のどれが観測されたか、定量 or 定性で記述>
+
+### S2: ...
+
+...
+
+## 判定理由
+
+<!-- 各シナリオの判定を集約し、最終的な採用 / 破棄 / エスカレーションの根拠を記述。 -->
+
+| シナリオ | 適用版優位 | 同等 | 適用版劣位 | コメント |
+|---|---|---|---|---|
+| S1 | ✅ | | | <観測結果> |
+| S2 | | ✅ | | <観測結果> |
+
+### 最終判定 (frontmatter `verdict` と整合)
+
+- **adopt (採用)**: 全シナリオで適用版が同等以上 + 過半で適用版優位 → commit + push に進む
+- **discard (破棄)**: 1 シナリオでも適用版劣位 (退化) → 変更を破棄、retro `📝 harness-meta フィードバック` の「保留 (要再評価)」表に記録、別案検討
+- **escalate (エスカレーション)**: 判定が拮抗 / dry-run コスト > 効果と判断 → orchestrator (subroh0508) に判定委任 (`harness-meta-criteria.md` §dry-run 必須条件 §必須条件不一致時のフォールバック)
+
+## 採用 / 破棄判定の反映
+
+<!-- 判定結果を retro / PR にどう反映したかの実施記録。 -->
+
+- 対象 retrospective `📝 harness-meta フィードバック` セクションの追記内容:
+  - 「採用」表: <該当提案 + 反映 PR 番号>
+  - 「見送り」表: <該当提案 + 移行先>
+  - 「保留」表: <該当提案 + 再評価条件>
+- 反映 PR: [<PR title> #NNN](https://github.com/subroh0508/colormaster/pull/NNN) (該当時)
+
+## 関連
+
+- 元 retrospective: [`docs/harness/learnings/YYYY-MM-DD-pr-NNN.md`](../learnings/YYYY-MM-DD-pr-NNN.md)
+- 関連 rule: `.claude/rules/{harness-meta-criteria,retrospective-format}.md`
+- 関連 Skill: `.claude/skills/{harness-bootstrap,harness-meta}/SKILL.md` (harness-meta は A3/A4 で本格化予定)
+- 索引: `docs/harness/dry-runs/INDEX.md`

--- a/docs/harness/learnings/2026-05-17-pr-139.md
+++ b/docs/harness/learnings/2026-05-17-pr-139.md
@@ -140,10 +140,13 @@ PR #139 + #140 は実装コード差分ゼロ (`.claude/rules/` + template + `do
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-17 PR #142 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #142 での消化内容 |
 |---|---|
+| `[skill]` `harness-meta` / `harness-bootstrap` (retro 集約改善モード) に dry-run フェーズを追加 (人間からの追加、最優先) | `.claude/skills/harness-bootstrap/SKILL.md` に retro 集約改善モード + 5 ステップ dry-run フェーズを記載 (配置のみ、本格実装は A3/A4 harness-meta Skill に委任) |
+| `[rule]` `.claude/rules/harness-meta-criteria.md` に dry-run 必須条件 を追記 (人間からの追加、最優先) | `harness-meta-criteria.md` に §dry-run 必須条件 セクション追加 (必須 / 不要の閾値表 + 結果記録先 + 必須条件不一致時のフォールバック) |
+| `[template]` `docs/harness/dry-runs/template.md` を新規追加 (人間からの追加、最優先) | `docs/harness/dry-runs/{template.md,INDEX.md}` 新規作成 + CLAUDE.md lookup table に `docs/harness/dry-runs/**/*.md` 行追加 |
 
 ### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
 

--- a/docs/harness/learnings/2026-05-17-pr-140.md
+++ b/docs/harness/learnings/2026-05-17-pr-140.md
@@ -102,10 +102,15 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-17 PR #142 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+> **PR #140 cross-reference**: PR #139 retro と同一の人間追加 3 件を両 retro に明示記録 (orchestrator 指示準拠)、消化先 PR も同一 (#142)
+
+| 提案 | PR #142 での消化内容 |
 |---|---|
+| `[skill]` `harness-meta` / `harness-bootstrap` (retro 集約改善モード) に dry-run フェーズを追加 (人間からの追加、最優先) | `.claude/skills/harness-bootstrap/SKILL.md` に retro 集約改善モード + 5 ステップ dry-run フェーズを記載 (配置のみ、本格実装は A3/A4 harness-meta Skill に委任) |
+| `[rule]` `.claude/rules/harness-meta-criteria.md` に dry-run 必須条件 を追記 (人間からの追加、最優先) | `harness-meta-criteria.md` に §dry-run 必須条件 セクション追加 (必須 / 不要の閾値表 + 結果記録先 + 必須条件不一致時のフォールバック) |
+| `[template]` `docs/harness/dry-runs/template.md` を新規追加 (人間からの追加、最優先) | `docs/harness/dry-runs/{template.md,INDEX.md}` 新規作成 + CLAUDE.md lookup table に `docs/harness/dry-runs/**/*.md` 行追加 |
 
 ### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
 


### PR DESCRIPTION
## 概要

PR #141 (8 retro 集約消化) 起票後に orchestrator (subroh0508) が両 retro (PR #139 / #140) に追加した **人間追加 3 件 (最優先)** を「配置のみ」実装する。本格的な dry-run 実行 (subagent 並列 + 出力比較 + 判定の自動化) は A3/A4 harness-meta Skill 本格化に委任し、本 PR は SoT 配置に留める。

## 採用根拠

`.claude/rules/harness-meta-criteria.md` §採用判定基準:

- **基準 4 (Critical 派生、無効提案リスク回避)**: AI 出力品質改善の事前検証不在 (PR #139 / #140 retro `⚠️ Problem (人間からの追加)`) を解消、Generator-Evaluator 独立性 (R-13) と整合
- **基準 5 (orchestrator 明示)**: 人間追加 3 件は両 retro `🤖 ハーネス改善提案` で `(人間からの追加、最優先)` と明示

## 変更内容 (7 ファイル)

### 新規 (`docs/harness/dry-runs/`)

- `docs/harness/dry-runs/template.md`: dry-run 結果記録テンプレ (frontmatter / 入力定義 / before-after AI 出力 / 判定基準 / 採用or破棄)
- `docs/harness/dry-runs/INDEX.md`: dry-run 索引 (`learnings/INDEX.md` パターン)

### 改修 (rule)

- `.claude/rules/harness-meta-criteria.md`: §dry-run 必須条件 セクション追加 (§採用判定基準 と §即時消化 vs 持ち越し の間に挿入)
  - 必須: rule 全文書き換え / Skill 新規追加 / Skill フロー追加削除 / template 構造変更 / rule 間 SoT 反転 / 採用判定基準改修
  - 不要: typo 修正 / リンク追加 / 既存セクション例示追加 / frontmatter 値更新 / rules-index 索引行追加 / 撤回コスト低 + scope 限定 + 既存 rule 本体改定なし
  - 必須条件不一致時のフォールバック: orchestrator 判定委任 + skip 理由明示

### 改修 (skill)

- `.claude/skills/harness-bootstrap/SKILL.md`: retro 集約改善モード + 5 ステップ dry-run フェーズ記載
  - description / related_rules 更新
  - 自動判定表に retro 集約改善モード追加
  - §retro 集約改善モード セクション新規 (4 ステップ: parse / dedupe / dry-run / PR 起票)
  - ステップ 3 が dry-run フェーズ (5 ステップ): 入力 / 実行 / 判定基準 / 結果記録 / 必須条件参照
  - 配置のみ (本格実装は A3/A4 harness-meta に委任)、SoT は harness-meta-criteria.md
  - Gotchas に 3 項目追加

### 改修 (索引 / 配信)

- `CLAUDE.md`: lookup table に `docs/harness/dry-runs/**/*.md` 行追加

### 改修 (retro 📝)

- `docs/harness/learnings/2026-05-17-pr-139.md`: `📝 harness-meta フィードバック` 「採用」表に人間追加 3 件記録 (PR #142 で消化)
- `docs/harness/learnings/2026-05-17-pr-140.md`: 同上 (cross-reference 形式、両 retro に同一内容)

## レビュー観点

- **spec-conformance**: 人間追加 3 件の retro 記載と本 PR の実装内容が整合 (skill / rule / template の 3 軸網羅)、`harness-meta-criteria.md` の既存採用判定基準との非矛盾
- **architecture**: dry-run 配置と本格実装 (A3/A4) の責務分離が明確、SoT (rule = `harness-meta-criteria.md`) と参照 (skill = `harness-bootstrap`) の役割分担、`learnings/{template,INDEX}.md` パターン継承の妥当性
- **security**: PII / Secrets redaction (dry-run subagent 実行ログを記録する際の規約) が `pii.md` / `secrets.md` redaction と整合、subagent 実行時の system prompt 独立性 (R-13) が認証情報伝播を防ぐ
- **code-quality**: Markdown 日本語見出し / frontmatter block 形式 / 5 行 summary / 識別子参照 / lookup table 表記の規範遵守、placeholder 残存ゼロ (PR 番号 #142 確定後の整合性)

test-quality / performance / visual-regression / design-tokens は Markdown only PR のため skip 妥当 (`code-reviewer-aspects.md` §aspect 動的選択ルール)。

## merge readiness

- CI green (markdown lint 未導入のため CI 待ち不要、`./gradlew check` は skeleton)
- code-reviewer 4 aspect Critical 0
- orchestrator 事前承認: 本 PR は orchestrator (subroh0508) が **Phase 1-9 含む self-merge を本指示で明示的に事前承認 (R-15 該当)** 済 (`merge-readiness.md` §orchestrator 明示承認パス 該当)

## 関連

- 元 retro: [PR #139 retrospective](https://github.com/subroh0508/colormaster/blob/master/docs/harness/learnings/2026-05-17-pr-139.md) / [PR #140 retrospective](https://github.com/subroh0508/colormaster/blob/master/docs/harness/learnings/2026-05-17-pr-140.md)
- 起票元 PR: [#141 (pr-139 + pr-140 retrospective 起票)](https://github.com/subroh0508/colormaster/pull/141)
- 関連 rule: `.claude/rules/{harness-meta-criteria,retrospective-format,skill-authoring}.md`
- 関連 Skill: `.claude/skills/{harness-bootstrap,harness-meta}/SKILL.md` (harness-meta は A3/A4 で本格化予定)
- Generator-Evaluator 独立性: R-13 (`docs/harness/plan.md` §3.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)