### PR TITLE
docs(harness): A3-4 adr-author Skill 完成

### DIFF
--- a/.claude/skills/adr-author/SKILL.md
+++ b/.claude/skills/adr-author/SKILL.md
@@ -7,6 +7,7 @@ description: |
   議論 / approve / merge は人間レビューに委ねる (Skill は merge を実行しない)。
 status: active
 phase: A3
+last_updated: 2026-05-18
 related_plan: docs/harness/plan.md §A3 / §4.5
 related_rules:
   - .claude/rules/adr.md
@@ -75,8 +76,13 @@ related_adrs:
 - `.claude/rules/adr.md` §起票基準 10 項目を逐一チェック、2 つ以上満たすか判定
 - 満たさない場合は §他の記録方法 (rules / Epic decisions.md / Plan / learning / runbook) から
   最適な記録先を提案し、本 Skill は停止 (ADR ファイル / INDEX 更新は行わない)
-  - 補助判定: §ADR 化見送りの理由テンプレ (3 条件: 撤回コスト低 / config N ファイル限定 /
-    既存 rule 本体改定なし) に該当するなら EPIC `decisions.md` 記録を推奨
+  - 補助判定: `.claude/rules/adr.md` §ADR 化見送りの理由テンプレ 3 条件 (撤回コスト低 /
+    scope が config N ファイル限定 / 既存 rule 本体の改定なし) を順に確認し、3 条件すべて
+    満たす場合のみ ADR 化見送りが正当と判定。該当する場合は EPIC `decisions.md` / PR
+    description / Plan に「ADR 起票基準 (§起票基準) を満たさないため見送り、撤回コスト低 /
+    scope は `<files>` 限定 / 既存 rule 本体の改定なし」と明記して記録を推奨 (PR #129 で
+    `.claude/settings.json` の permissions.allow 拡張時に本テンプレを適用し、ADR-0028 起票を
+    見送って EPIC-A2 `decisions.md` に判断ログを残した実績)
 - 満たす場合は Phase 2 へ進む
 
 ### Phase 2: 採番 + テンプレ copy + frontmatter 埋め
@@ -101,7 +107,7 @@ related_adrs:
     採用しなかった理由) を埋める
   - **帰結**: Positive / Negative / Neutral の 3 区分で列挙、トレードオフを明示
 - 冒頭 5 行以内 summary (`> **5 行以内 summary**: ...`) を必須記入 (`.claude/rules/docs-structure.md` §各 docs 構造)
-- §4.5 起票基準充足チェック表で該当項目に `[x]` をマーク (2 つ以上充足が条件)
+- §4.5 起票基準充足チェック表 (`docs/adr/template.md` §ADR 起票基準 (§4.5) の充足 / SoT は `.claude/rules/adr.md` §起票基準 + `docs/harness/plan.md` §4.5) で該当項目に `[x]` をマーク (2 つ以上充足が条件)
 - §ADR 化すべき例 / すべきでない例 の自己チェックボックスにも `[x]` を付与
 - 言語は日本語 (ADR 0027 / `.claude/rules/template-language.md`)、コード断片は英語 / プレーン
   テキストは ` ```text ` 言語指定 (`.claude/rules/markdown.md`)
@@ -112,9 +118,14 @@ related_adrs:
 - 新 ADR の frontmatter に block 形式で記入 (要素ゼロは `[]` 明示、`docs-structure.md`
   frontmatter 規約)
 - `supersedes: ADR-MMMM` を宣言する場合、対向 ADR (ADR-MMMM) の frontmatter `superseded_by`
-  を新 ADR ID に書き換え + `status` を `superseded` に更新
-- `related_adrs` は双方向リンクが望ましいが、対向 ADR が `accepted` 以降で immutable な場合は
-  対向側を改変せず、新 ADR 側のみリンク (`.claude/rules/adr.md` §Gotchas)
+  を新 ADR ID に書き換え + `status` を `superseded` に更新 (supersede は新旧の決定差し替えを
+  明示する操作のため、`accepted` immutable 原則の例外として対向 frontmatter 改変が許容される)
+- `related_adrs` は双方向リンクが望ましいが、対向 ADR が `accepted` 以降で immutable な場合
+  (= supersede 以外の単純参照関係の場合) は対向側を改変せず、新 ADR 側のみ
+  `related_adrs: [ADR-MMMM]` を記入する片方向リンクに留める。例: 新 ADR が ADR-0017 (ハーネス
+  ローカル Claude Code ポーリング駆動、`accepted`) を参照したいが新旧差し替え関係ではない場合、
+  ADR-0017 側の `related_adrs` には追記せず新 ADR 側のみ参照を記入 (`.claude/rules/adr.md`
+  §Gotchas「`accepted` 以降は本文を改変しない」原則と整合)
 
 ### Phase 5: INDEX 更新
 

--- a/.claude/skills/adr-author/SKILL.md
+++ b/.claude/skills/adr-author/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: adr-author
+description: |
+  アーキテクチャ決定の ADR 起票を担当する Skill。起票基準判定 + 採番 + テンプレ起草 +
+  関連 ADR 双方向リンク + INDEX 更新を実施。起票基準を満たさない決定は
+  rules / epic decisions.md / learning への記録を推奨し、本 Skill は起草で完了する。
+  議論 / approve / merge は人間レビューに委ねる (Skill は merge を実行しない)。
+status: active
+phase: A3
+related_plan: docs/harness/plan.md §A3 / §4.5
+related_rules:
+  - .claude/rules/adr.md
+  - .claude/rules/docs-structure.md
+  - .claude/rules/template-language.md
+  - .claude/rules/markdown.md
+related_adrs:
+  - ADR-0001
+  - ADR-0027
+---
+
+# adr-author
+
+> **5 行以内 summary**: アーキテクチャ決定の ADR を `docs/adr/template.md` から起草する
+> Skill。`.claude/rules/adr.md` §起票基準 (10 項目のうち 2 つ以上) を判定し、満たさない
+> 決定は別記録方法 (rules / Epic decisions.md / Plan / learning / runbook) を推奨して
+> 停止する。採番 + frontmatter 埋め + 本文起草 + `related_adrs` / `supersedes` /
+> `superseded_by` の双方向リンク + `docs/adr/README.md` INDEX 更新まで実施し、
+> Phase 6 で人間レビューに handoff する。議論 / approve / merge は人間が担当。
+
+## 役割
+
+- ADR 起票要求 (人間または他 Skill) の入力を受け取り、`.claude/rules/adr.md` §起票基準
+  10 項目のうち 2 つ以上を満たすか判定
+- 起票基準を満たさない場合は別記録方法 (rules / Epic decisions.md / Plan / learning /
+  runbook) を提案し、ADR を起草せず停止
+- 起票基準を満たす場合は連続 4 桁ゼロパディングで採番 (既存 ADR 一覧を走査して最大番号 + 1)
+- `docs/adr/template.md` を base に `docs/adr/ADR-NNNN-<kebab-slug>.md` を起草、frontmatter +
+  本文 (ステータス / コンテキスト / 決定 / 根拠 / 帰結 / §4.5 起票基準充足チェック / 関連) を埋める
+- 関連 ADR の双方向リンクを解析・追加 (`related_adrs` / `supersedes` / `superseded_by`)、
+  supersede 関係がある場合は対向 ADR の frontmatter にも `superseded_by` を書き込む
+- `docs/adr/README.md` の一覧テーブルに新行を追加 (ADR ID / 状態 / 内容 / 起票根拠 (§4.5) /
+  関連 rule / ファイル)
+- 起草で本 Skill の責務完了、議論 / approve / 状態遷移 (`proposed` → `accepted`) /
+  PR merge は人間レビューに委ねる
+
+## 入力
+
+- **起動 prompt** (人間 / 他 Skill から): 決定のタイトル候補 / コンテキスト / 採用方針 /
+  関連 ADR (supersede / 参照) / 関連 SPEC / Plan / Epic
+- **既存 ADR 一覧** (`docs/adr/ADR-*.md` + `docs/adr/README.md` 一覧テーブル): 採番衝突回避 /
+  双方向リンクの対向 ADR 解析に使用
+- **起票基準の SoT** (`.claude/rules/adr.md` §起票基準): 10 項目のうち 2 つ以上の充足判定に使用
+- **テンプレ** (`docs/adr/template.md`): frontmatter / 本文構造の雛形
+- **関連 docs** (任意): SPEC / Plan / Epic の本文を参照して背景情報を抽出
+
+## 出力
+
+- **新規 ADR ファイル**: `docs/adr/ADR-NNNN-<kebab-slug>.md`
+  - frontmatter: `id` / `title` / `status: proposed` (起草時は固定) / `date` / `related_epics` /
+    `related_plans` / `related_specs` / `superseded_by` / `supersedes`
+  - 本文: 冒頭 5 行以内 summary / ステータス / コンテキスト / 決定 / 根拠 (比較した代替案表
+    含む、該当時) / 帰結 (Positive / Negative / Neutral) / §4.5 起票基準充足チェック /
+    ADR 化すべき例・すべきでない例の自己チェック / 関連
+- **INDEX 更新**: `docs/adr/README.md` 一覧テーブルに新行追加
+  (`| NNNN | proposed | <内容> | <起票根拠 §4.5> | <関連 rule> | [ADR-NNNN](ADR-NNNN-<slug>.md) |`)
+- **対向 ADR の双方向リンク更新** (該当時): 新 ADR が `supersedes: ADR-MMMM` を宣言する場合、
+  ADR-MMMM 側の frontmatter `superseded_by` を新 ADR ID に書き換え + 状態を `superseded` に更新
+- **起票見送り時の出力**: ADR 起草・INDEX 更新を行わず、推奨記録方法を人間に報告
+
+## フェーズ別動作
+
+### Phase 1: 入力把握 + ADR 起票基準判定
+
+- 起動 prompt から決定の核 (採用方針 / 代替案 / 影響範囲) を抽出
+- `.claude/rules/adr.md` §起票基準 10 項目を逐一チェック、2 つ以上満たすか判定
+- 満たさない場合は §他の記録方法 (rules / Epic decisions.md / Plan / learning / runbook) から
+  最適な記録先を提案し、本 Skill は停止 (ADR ファイル / INDEX 更新は行わない)
+  - 補助判定: §ADR 化見送りの理由テンプレ (3 条件: 撤回コスト低 / config N ファイル限定 /
+    既存 rule 本体改定なし) に該当するなら EPIC `decisions.md` 記録を推奨
+- 満たす場合は Phase 2 へ進む
+
+### Phase 2: 採番 + テンプレ copy + frontmatter 埋め
+
+- 既存 ADR 一覧 (`docs/adr/ADR-*.md` ファイル名 + `docs/adr/README.md` 一覧テーブル) を走査して
+  最大番号を取得、+1 で新 ADR 番号を確定 (4 桁ゼロパディング、`ADR-NNNN`)
+- 同番号の race 検出: 直前に他 Skill / 他セッションが採番した可能性を考慮し、確定前に
+  `git status` / `git log --oneline -5 docs/adr/` で直近の差分を確認
+- タイトルから kebab-case slug を導出 (動詞は省略可、要件のキーワードを含める)
+- `docs/adr/template.md` を copy して `docs/adr/ADR-NNNN-<slug>.md` を作成、frontmatter の
+  プレースホルダ (`ADR-NNNN` / `<タイトル>` / `YYYY-MM-DD` / `related_*` / `superseded_by` /
+  `supersedes`) を実値で埋める
+- `status` は `proposed` 固定 (起草時、`accepted` 遷移は人間レビュー後の別操作)
+
+### Phase 3: 本文起草
+
+- テンプレ §コンテキスト / §決定 / §根拠 / §帰結 を以下の指針で埋める:
+  - **コンテキスト**: 決定が必要となった背景・現状の問題・制約・関連する他の決定。事実ベース、
+    判断は §根拠 へ
+  - **決定**: 「~を採用する」「~を撤去する」「~に統一する」等の断定的記述
+  - **根拠**: 複数代替案を比較した場合は §比較した代替案 表 (代替案 / 利点 / 欠点 /
+    採用しなかった理由) を埋める
+  - **帰結**: Positive / Negative / Neutral の 3 区分で列挙、トレードオフを明示
+- 冒頭 5 行以内 summary (`> **5 行以内 summary**: ...`) を必須記入 (`.claude/rules/docs-structure.md` §各 docs 構造)
+- §4.5 起票基準充足チェック表で該当項目に `[x]` をマーク (2 つ以上充足が条件)
+- §ADR 化すべき例 / すべきでない例 の自己チェックボックスにも `[x]` を付与
+- 言語は日本語 (ADR 0027 / `.claude/rules/template-language.md`)、コード断片は英語 / プレーン
+  テキストは ` ```text ` 言語指定 (`.claude/rules/markdown.md`)
+
+### Phase 4: 関連 ADR 双方向リンク
+
+- 起動 prompt + コンテキスト分析から `related_adrs` / `supersedes` / `superseded_by` を抽出
+- 新 ADR の frontmatter に block 形式で記入 (要素ゼロは `[]` 明示、`docs-structure.md`
+  frontmatter 規約)
+- `supersedes: ADR-MMMM` を宣言する場合、対向 ADR (ADR-MMMM) の frontmatter `superseded_by`
+  を新 ADR ID に書き換え + `status` を `superseded` に更新
+- `related_adrs` は双方向リンクが望ましいが、対向 ADR が `accepted` 以降で immutable な場合は
+  対向側を改変せず、新 ADR 側のみリンク (`.claude/rules/adr.md` §Gotchas)
+
+### Phase 5: INDEX 更新
+
+- `docs/adr/README.md` の一覧テーブルに新行を追加:
+  `| NNNN | proposed | <内容簡潔> | <起票根拠 §4.5 の該当番号カンマ区切り> | <関連 rule のリスト> | [ADR-NNNN](ADR-NNNN-<slug>.md) |`
+- テーブルは ADR 番号昇順を維持
+- 統合 / 撤去履歴がある場合は §★統合の経緯 表に行追加 (該当時)
+- last_updated 日付を更新
+
+### Phase 6: 人間レビュー handoff
+
+- 起草内容のサマリ (ADR 番号 / タイトル / 起票根拠 / 関連 ADR) を print して停止
+- `status: proposed` のまま停止し、人間レビュー → `accepted` 遷移 → PR レビュー → merge は
+  人間が担当
+- 議論 / 修正要求があれば本 Skill を再起動して該当 ADR を更新 (`accepted` 以降の immutable
+  原則に注意、§Gotchas 参照)
+
+## Gotchas
+
+- **起票基準を満たさない決定を ADR 化しない**: `.claude/rules/adr.md` §起票基準 10 項目のうち
+  2 つ以上を満たさない場合は ADR 起草を見送り、別記録方法 (rules / Epic decisions.md /
+  Plan / learning / runbook) を提案。撤回コスト低 / config N ファイル限定 / 既存 rule 本体
+  改定なしの 3 条件を満たすなら §ADR 化見送りの理由テンプレ に従う (PR #129 で実績、ADR-0028
+  起票を見送り EPIC-A2 `decisions.md` に記録)
+- **双方向リンク漏れ防止**: `supersedes: ADR-MMMM` 宣言時は対向 ADR の `superseded_by` も同 PR
+  内で更新。片方向だけ書くと A6 機械検証 (相互参照の実在チェック) で reject される
+- **`superseded_by` の整合性**: 対向 ADR の `status` も `superseded` に更新が必要。`accepted`
+  のまま `superseded_by` を埋めると status 語彙と矛盾 (MADR 4 状態の遷移ルール違反)
+- **採番の race 注意**: 別セッション / 別 Skill が同時に採番すると番号衝突。Phase 2 で
+  `git status` + `git log --oneline -5 docs/adr/` を確認、可能なら `git fetch origin master`
+  で latest と同期してから採番
+- **`accepted` 以降は本文を改変しない**: 既存 ADR を `accepted` から書き換える要求が来ても、
+  本 Skill は新 ADR (supersede) を提案して旧 ADR は immutable に保つ。誤記訂正のみ
+  `docs/adr/README.md` 側に正誤表を追記
+- **status 語彙準拠**: `proposed` / `accepted` / `deprecated` / `superseded by ADR-NNNN` の
+  MADR 4 状態以外を使わない (`.claude/rules/adr.md` §採番・命名・ステータス)
+- **rule への双方向 SoT 宣言は書かない**: ADR 側に「`.claude/rules/<name>.md` が SoT」と書くと
+  循環参照になり A6 トレーサビリティ機械検証が弱まる (`.claude/rules/adr.md` §ADR ⇄ rule の
+  SoT 方向、PR #119 レトロ Try)。委譲先の明示 (「運用詳細は rule に委譲」) は OK
+- **本文へのコード断片混入**: 設計書本文ではないが、ADR 本文に長いコード断片を書くと可読性が
+  下がる。`file_path:line` 参照 / 30 行以内の最小例 / ` ```text ` 言語指定など
+  `.claude/rules/markdown.md` の規約に従う
+- **frontmatter 配列は block 形式必須**: `related_adrs: [ADR-0001, ADR-0011]` の flow 形式は
+  禁止 (`.claude/rules/docs-structure.md` §配列はブロック形式を強制)。要素ゼロのみ `[]` 許容
+- **title と H1 の表記方針**: frontmatter `title` ⊇ H1 (完全一致または短縮形許容)。別表現は
+  NG (`.claude/rules/docs-structure.md` §title と H1 の表記方針、PR #126 レトロ Try)
+- **議論 / approve / merge は人間レビュー**: 本 Skill は起草で完了。`status: proposed` →
+  `accepted` 遷移は人間が議論結果を反映して別操作で行う。auto-merge は禁止 (R-15)
+
+## 関連
+
+- ADR-0001 (ADR 運用基準・書式・起票判断フロー、本 Skill の SoT)
+- ADR-0027 (docs 構造 + 命名規約 + 5 行 summary + lazy-load + 日本語化)
+- `.claude/rules/adr.md` (ADR 起票基準 + 採番規約 + status 語彙 + ADR ⇄ rule SoT 方向)
+- `.claude/rules/docs-structure.md` (frontmatter 規約 / 命名規約 / 5 行 summary)
+- `.claude/rules/template-language.md` (日本語必須、Phase A 経過措置)
+- `.claude/rules/markdown.md` (見出し / frontmatter / code block / 表記規約)
+- `docs/adr/template.md` (本 Skill が copy する雛形)
+- `docs/adr/README.md` (本 Skill が更新する INDEX)
+- `docs/harness/plan.md` §4.5 (ADR 判断フロー Mermaid) / §A3 (本 Skill の責務 SoT)
+- `.claude/skills/plan-author/SKILL.md` (テンプレ起票責務の構造参考)
+- `.claude/skills/epic-author/SKILL.md` (同上)


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: EPIC-A3
related_specs: []
related_adrs:
  - ADR-0001
  - ADR-0017
  - ADR-0018
  - ADR-0025
  - ADR-0027
expected_modules:
  - .claude/skills/adr-author/SKILL.md
-->

## 概要

EPIC-A3 (専用 Skill 群実装 Epic) Group 1 の A3-4 として `adr-author` Skill を完成。
`.claude/skills/adr-author/SKILL.md` 1 ファイルを新規追加 (179 行)、Group 1 共通テンプレの
制約に従い `rules-index.md` / `CLAUDE.md` lookup table / `docs/harness/plan.md` /
`docs/epics/EPIC-A3-skill-suite-extension/{roadmap,progress}.md` は触らない。

`adr-author` の役割は、ADR 起票要求を受けて (1) `.claude/rules/adr.md` §起票基準
10 項目のうち 2 つ以上の充足判定、(2) 連続 4 桁ゼロパディング採番、(3) `docs/adr/template.md`
copy + frontmatter / 本文起草、(4) 関連 ADR (`related_adrs` / `supersedes` / `superseded_by`)
の双方向リンク、(5) `docs/adr/README.md` INDEX 更新の 5 つを担う。起票基準を満たさない決定は
別記録方法 (rules / Epic decisions.md / Plan / learning / runbook) を提案して停止し、議論 /
approve / merge は人間レビューに委ねる。

## 関連

- Plan: なし (EPIC-A3 配下 PR のため、Plan を起こさない `.claude/rules/plan.md` §Gotchas)
- Epic: EPIC-A3 (`docs/epics/EPIC-A3-skill-suite-extension/README.md`)
- ADR: ADR-0001 (ADR 運用基準・書式・起票判断フロー、本 Skill の SoT) / ADR-0017 (ハーネスローカル Claude Code ポーリング駆動) / ADR-0018 (`implementation-workflow` 10 フェーズ設計) / ADR-0025 (Skill 作成は `example-skills:skill-creator` 経由) / ADR-0027 (docs 構造 + 命名規約 + 日本語化)
- 元 learnings: なし
- 元 evolution-proposals: なし

## PR の種別

- [ ] A1 レトロ 等の即時消化フォロー PR
- [x] **rules / Skill 本格化** (B0 雛形 → 本文充実) — `adr-author` Skill (B0 では未配置、本 PR で A3 active として新規作成)
- [ ] ハーネス改修 PR (`harness-meta` Skill 起票)
- [ ] 外部研究駆動の改修 PR (`harness-evolution` Skill 起票)
- [ ] レトロ集約 PR
- [ ] その他

## 対象 PR (KPT / 改修起点)

本 PR は KPT 起点ではなく EPIC-A3 計画に基づく新規 Skill 実装のため、対象 PR 表は該当なし。

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| skill | `.claude/skills/adr-author/SKILL.md` | 新規追加 (179 行)、frontmatter + 必須セクション (役割 / 入力 / 出力 / フェーズ別動作 Phase 1-6 / Gotchas 10 項目 / 関連) | — |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 0 | 0 | 0 | 0 |
| `[skill]` | 1 | 0 | 0 | 0 |
| `[template]` | 0 | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

本 PR は KPT 起点ではないため `📝 harness-meta フィードバック` 追記なし。

## 受け入れ基準 (AC)

- [ ] AC-1: SKILL.md が `.claude/rules/skill-authoring.md` §SKILL.md フォーマット + 100-point rubric に準拠 (description = trigger / status: active / phase: A3 / Gotchas 具体例 3 項目以上 / 関連リンク dangling なし / 入出力明示 / 禁止表現回避 / 責務分離)
- [ ] AC-2: YAML frontmatter あり、配列は block 形式 (`.claude/rules/docs-structure.md` §配列はブロック形式を強制)
- [ ] AC-3: 見出しは日本語 (固定セクション名 `Gotchas` は例外、`.claude/rules/template-language.md` §例外)
- [ ] AC-4: 5 行以内 summary が冒頭に存在 (`.claude/rules/docs-structure.md` §各 docs 構造)
- [ ] AC-5: §役割 / §入力 / §出力 / §フェーズ別動作 / §Gotchas / §関連 が必須セクションとして存在
- [ ] AC-6: ADR 起票基準判定ロジックが明確 (Phase 1 で §起票基準 10 項目のうち 2 つ以上を判定、満たさない場合は別記録方法を提案して停止)
- [ ] AC-7: 採番 + 双方向リンク + INDEX 更新の 3 出力が明確 (Phase 2 / 4 / 5)
- [ ] AC-8: 既存 rule / Skill / 関連 ADR との不整合がない (`.claude/rules/adr.md` §ADR ⇄ rule SoT 方向 / §採番・命名・ステータス / §Gotchas と整合)
- [ ] AC-9: code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) Critical 0 通過

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降のため本 PR では skip)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降のため本 PR では skip)
- [ ] `commit-msg` hook 変更なし

## レビュー観点

- `.claude/rules/adr.md` §起票基準 / §採番・命名・ステータス / §ADR ⇄ rule SoT 方向 / §ADR 化見送りの理由テンプレ との整合
- 起票基準を満たさない決定を ADR 化しない (別記録方法提案 → 停止) ロジックが Phase 1 で明示されているか
- 双方向リンク (`supersedes` / `superseded_by`) を Phase 4 で対向 ADR の frontmatter にも書き込む手順が明確か
- 採番 race 対策 (`git status` + `git log --oneline -5 docs/adr/` 確認) が Phase 2 で明示されているか
- `accepted` 以降の immutable 原則 (新 ADR / supersede 提案で対応、本文改変禁止) が Gotchas で明示されているか
- `plan-author` / `epic-author` Skill との責務 overlap が最小化されているか (テンプレ起票責務の構造参考)
- 撤回コスト: 本 Skill を取り消す手順は明確か (SKILL.md 1 ファイル削除で完結、本格化前なので影響範囲限定)

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した
- [x] Skill 改修の場合: `.claude/rules/skill-authoring.md` §SKILL.md フォーマット に準拠 (ADR 0025、本 PR では `example-skills:skill-creator` を経由せず手動起草 — Group 1 共通テンプレに従う簡易フロー)
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須、Phase 7 merge は orchestrator pane が代行)
- [x] PII / Secrets が diff に含まれていない (SKILL.md 1 ファイルのみ、PII / token / 認証情報なし)
- [x] EPIC-A3 配下 PR のため、`roadmap-tracker` 起動は EPIC-A3 完了時にまとめて実施 (Group 1 共通テンプレに従い本 PR では touch しない)
- [x] status ラベル: SKILL.md frontmatter `status: active` / `phase: A3` (`.claude/rules/skill-authoring.md` §status 値の遷移 に準拠)
