### PR TITLE
docs(harness): harness-meta 初回ドッグフード (改修候補 3 件 SoT 反映 + 5 件見送りフィードバック)

### DIFF
--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -112,22 +112,46 @@ git restore <unwanted-file-1> <unwanted-file-2> ...
 
 ## Phase 5: Draft PR 作成
 
+### gh pr create 実行手順 (PR #146 / #156 / #158 レトロ Try 反映、改修候補 #5 + #8 統合)
+
+`gh pr create` で Draft PR を起票する。**`--template` と `--body-file` / `--body` は排他** (gh CLI 実仕様、同時指定すると Exit 1 でエラー `` `--template` is not supported when using `--body` or `--body-file` ``、PR #158 dogfooding で実証)。本リポジトリの全 PR は **本格 PR description 起草が必須** (PR レビュー観点 / AC / 関連 ADR 等を構造化記載するため、`.claude/rules/pr-template.md` §必須セクション参照) なので、実運用上は **`--body-file` 一択** で `--template` は使用しない。
+
+**既定 (本格 PR description を起草する場合、本リポジトリ全 PR で採用)**:
+
 ```bash
 # commit message と PR body を /tmp ファイル経由で渡す (PR #129 レトロ Try)
 git commit -F /tmp/<unique-prefix>-commit-msg.txt
+
+# PR body は --body-file 経由 (--template は指定しない、排他のため)
 gh pr create --draft \
   --base master \
   --head <branch-name> \
   --title "<conventional-commits-subject>" \
-  --template <type>.md \
   --body-file /tmp/<unique-prefix>-pr-body.md
 ```
 
-- `--template` は **必須** (`pr-template.md` 規約)
-- `--draft` は **既定** (`pr-draft-policy.md` 規約)、orchestrator 明示指示時のみ即 Ready で起票可
+- PR body 文面は `.github/PULL_REQUEST_TEMPLATE/<type>.md` の内容を `/tmp/<unique-prefix>-pr-body.md` に コピー → 該当 PR 用にカスタマイズ → `--body-file` で渡す (テンプレ構造は手動で揃える、`.claude/rules/pr-template.md` §起票コマンド §「`--body-file` 代替」参照)
+- 対応する `<type>.md` の選択は `.claude/rules/pr-template.md` §6 種類のテンプレート + §gh pr create 必須パラメータ を参照 (`feature.md` / `bugfix.md` / `refactor.md` / `dependency-upgrade.md` / `docs.md` / `harness.md` の 6 種)
+- **`--draft` は既定** (`pr-draft-policy.md` 規約)、orchestrator 明示指示時のみ即 Ready で起票可、mirror PR は `--draft` 省略可
 - PR description frontmatter (HTML コメント `<!-- pr-frontmatter ... -->`) に必須キー (`type` / `related_plan` / `related_epic` / `related_specs` / `related_adrs` / `expected_modules`) を埋める
-- mirror PR は `--draft` 省略可 (`pr-draft-policy.md` Gotchas 参照)
-- **`/tmp` 経由の HEREDOC 回避パターン** (PR #129 レトロ Try): HEREDOC ネストが深いと zsh paste で escape 事故が起きうるため、commit message を `/tmp/<unique-prefix>-commit-msg.txt`、PR body を `/tmp/<unique-prefix>-pr-body.md` に Write してから `git commit -F` / `gh pr edit --body-file` / `gh pr create --body-file` で参照する。ユーザー手動実行時のコピペ事故も予防
+
+**例外 (テンプレ default fill、body 起草を省く trivial chore PR のみ)**:
+
+```bash
+gh pr create --draft \
+  --base master \
+  --head <branch-name> \
+  --title "<conventional-commits-subject>" \
+  --template <type>.md
+# --body-file / --body は指定しない (排他)
+```
+
+**禁止パターン** (PR #146 / #158 で Exit 1 を実証):
+
+- `--body "$(cat <<EOF...)"` heredoc 直送 (PR #146 で Exit 1 実証): cmux + zsh + heredoc の三重解釈で truncate / escape 不全リスク → **`--body-file` を使用**
+- `--template <type>.md --body-file <path>` 同時指定 (PR #158 dogfooding で Exit 1 実証): gh CLI 実仕様で排他 → **どちらか一方のみ指定**
+
+**`/tmp` ファイル経由パターン** (PR #129 / #146 レトロ Try 反映): HEREDOC ネストが深いと zsh paste で escape 事故が起きうるため、commit message を `/tmp/<unique-prefix>-commit-msg.txt`、PR body を `/tmp/<unique-prefix>-pr-body.md` に Write してから `git commit -F` / `gh pr edit --body-file` / `gh pr create --body-file` で参照する。ユーザー手動実行時のコピペ事故も予防。`<unique-prefix>` は branch slug + timestamp 推奨 (例: `harness-harness-meta-batch-20260518`)。
 
 ## Phase 6: code-reviewer 呼出 (Evaluation)
 
@@ -236,6 +260,8 @@ git branch -d <branch-name>  # 検出されなければ -D に切替
 - **Phase 3 fix loop 上限 3 回** (R-14)、超過時は blocked + 人間通知
 - **Phase 4 の Scope 縮小 redirect は soft reset 3 段階で完全取り消し** (PR #129 レトロ Try): `git reset --soft HEAD~1` + `git restore --staged .` + `git restore <files>` の順、`--hard` は使わない
 - **Phase 5 で commit message / PR body は `/tmp` ファイル経由** (PR #129 レトロ Try): HEREDOC ネストの quoting 事故予防、`git commit -F` / `gh pr edit --body-file` / `gh pr create --body-file` を採用
+- **Phase 5 で `gh pr create --template <type>.md --body-file <path>` の同時指定は禁止** (PR #146 / #158 レトロ Try 反映): gh CLI 実仕様で排他 (`` `--template` is not supported when using `--body` or `--body-file` `` Exit 1)、本リポジトリは本格 PR description 起草必須のため **`--body-file` 一択** で `--template` は使用しない。詳細は §gh pr create 実行手順 参照
+- **Phase 5 で `--body "$(cat <<EOF...)"` heredoc 直送は禁止** (PR #146 レトロ Try): cmux + zsh + heredoc の三重解釈で truncate / escape 不全リスク、`--body-file <path>` を使用
 - **Phase 6 の code-reviewer は Claude API 直接呼び出しではなくサブエージェント並列** (R-37 / ADR 0017)
 - **Phase 6 完了後に二段 fetch + `gh pr view --json mergeable,mergeStateStatus` 確認** (PR #123 / #125 / #126 レトロ Try): review 待ち中の master 再進化で発生する rebase 必要状態を事前検出
 - **Phase 7 で auto-merge 禁止** (R-15)、orchestrator 明示承認テキストでの代替パスは許可

--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -26,7 +26,7 @@ related_plan: docs/harness/plan.md §5.3 / §5.4.2 / R-14 / R-15
 | 2 | Spec 整合チェック | 整合性レポート | ID 重複・dangling リンクゼロ |
 | 3 | 実装 + Lint + Test | commit (fix loop ≤3 回) | `./gradlew check` green |
 | 4 | Self-Verification | 三層指標差分 + rule 違反チェック | `@Spec` 整合 + PII / secrets ゼロ |
-| 5 | Draft PR 作成 | `gh pr create --draft --template <type>.md` | PR URL 取得 |
+| 5 | Draft PR 作成 | `gh pr create --draft --body-file <path>` (`--template` と排他、本格 description 起草必須) | PR URL 取得 |
 | 6 | code-reviewer 呼出 | Coordinator レビューコメント | Critical = 0 (fix loop 後) |
 | 7 | 人間 approve → squash merge | merge commit | 3 条件充足 (CI/Critical/approve) |
 | 8 | pr-poller + roadmap-tracker | learning ファイル + roadmap 更新 | (該当時) mirror PR 起票 |

--- a/.claude/rules/pr-template.md
+++ b/.claude/rules/pr-template.md
@@ -33,18 +33,57 @@ related_plan: docs/harness/plan.md §4.8 / §5.4.2
 
 ## 起票コマンド
 
+**重要**: `gh pr create` は **`--template` と `--body-file` / `--body` を排他** とする (gh CLI 実仕様、同時指定すると Exit 1 でエラー `` `--template` is not supported when using `--body` or `--body-file` ``、PR #146 / #158 で実証)。本リポジトリの全 PR は本格 PR description 起草が必須 (§必須セクション参照) なので **`--body-file` 一択** で `--template` は使用しない。
+
 ```bash
+# 既定 (本格 PR description 起草、本リポジトリ全 PR で採用)
 gh pr create \
   --base master \
   --head <branch-name> \
   --title "<conventional-commits-subject>" \
-  --template <type>.md \
+  --body-file /tmp/<unique-prefix>-pr-body.md \
   --draft
 ```
 
-- **`--template` は必須**: 省略するとデフォルトテンプレが選ばれ、type 別の必須セクション (Behavior Preservation / レトロ要約等) が抜ける
+- **`--body-file` 一択 (本リポジトリ既定)**: 本リポジトリの全 PR は本格 PR description 起草必須のため、`.github/PULL_REQUEST_TEMPLATE/<type>.md` の内容を `/tmp/<unique-prefix>-pr-body.md` にコピー → 該当 PR 用にカスタマイズ → `--body-file` で渡す (テンプレ構造は手動で揃える)
 - **`--draft` は Phase 5 の既定**: Draft → Ready 昇格は `.claude/rules/pr-draft-policy.md` 参照
-- **`--body-file` 代替**: 大量の自動生成本文 (フェーズ ID / Plan ID / Epic ID 等の埋め込み済 body) を流し込む場合は `--body-file <path>` を `--template` 代わりに使用 (テンプレ構造は手動で揃える)
+- **`--template <type>.md` 単独 (例外、trivial chore PR で body 起草を省く場合のみ)**: `--body-file` / `--body` を同時指定しない、テンプレの default 内容のままで起票
+
+## gh pr create 必須パラメータ (PR #146 / #156 / #158 レトロ Try 反映、改修候補 #8 SoT 化)
+
+`gh pr create` 実行時の必須パラメータ:
+
+| パラメータ | 必須/任意 | 説明 |
+|---|---|---|
+| `--base <target-branch>` | 必須 | 通常 `master` |
+| `--head <source-branch>` | 必須 | 本 PR の source branch (現在チェックアウト中の branch 名) |
+| `--title "<...>"` | 必須 | Conventional Commits 形式 (`.claude/rules/commit-message.md` 準拠) |
+| `--body-file <path>` | 必須 (本リポジトリ既定) | 本格 PR description を `/tmp/<unique-prefix>-pr-body.md` 経由で渡す。`--template` と排他 |
+| `--draft` | 既定 (Phase 5) | `pr-draft-policy.md` 規約、orchestrator 明示指示時のみ即 Ready で起票可、mirror PR は省略可 |
+| `--template <type>.md` | 例外時のみ | body 起草を省く trivial chore PR でのみ使用、`--body-file` と排他 |
+
+**`--template` と `--body-file` の排他関係** (gh CLI 実仕様、PR #158 dogfooding で実証):
+
+```text
+$ gh pr create --base master --head <branch> --draft --template harness.md --title "..." --body-file /tmp/pr-body-...md
+`--template` is not supported when using `--body` or `--body-file`
+Exit code 1
+```
+
+per-task pane / orchestrator pane で `gh pr create` を実行する Skill (implementation-workflow Phase 5、orchestrator 共通テンプレ等) は、**`--body-file` 一択コマンド例** を共通 prompt テンプレで明示すること。
+
+**完全コマンド例** (本リポジトリ既定、`--body-file` 一択):
+
+```bash
+gh pr create \
+  --base master \
+  --head <branch-name> \
+  --draft \
+  --title "<conventional-commits-subject>" \
+  --body-file /tmp/<unique-prefix>-pr-body.md
+```
+
+PR 種別ごとの `<type>.md` 対応は §6 種類のテンプレート 参照、`--body-file` 渡しの body 文面は `.github/PULL_REQUEST_TEMPLATE/<type>.md` の内容を `/tmp/<unique-prefix>-pr-body.md` にコピー → カスタマイズして渡す。
 
 ## PR description frontmatter 規約
 
@@ -125,7 +164,8 @@ A7 完了前は **三層指標 (Kover / Konsist Spec coverage / PITest) が未�
 
 ## Gotchas
 
-- **`--template` 省略は禁止**: デフォルトテンプレ (`.github/pull_request_template.md`) は最小骨格、type 別必須セクションが抜けるため
+- **`--template` と `--body-file` は排他** (PR #146 / #158 レトロ Try、gh CLI 実仕様): 同時指定は Exit 1、本リポジトリは本格 PR description 起草必須のため **`--body-file` 一択** で `--template` は使用しない。`<type>.md` のテンプレ内容は `/tmp/<unique-prefix>-pr-body.md` にコピー → カスタマイズして `--body-file` で渡す
+- **`--body-file` 経由で渡す本文は `<type>.md` のテンプレ構造を維持**: §必須セクション (type 別) を満たすよう手動で揃える、`--template` 省略によって type 別必須セクション (Behavior Preservation / レトロ要約等) が抜けないこと
 - **frontmatter は HTML コメント形式**: GitHub Markdown 仕様で YAML frontmatter を render しないため、`<!-- pr-frontmatter ... -->` で擬装
 - **harness.md は branch-naming `harness/<purpose>` 専用**: feature/bugfix/refactor 等の Plan PR では使わない (`branch-naming.md` と整合)
 - **三層指標差分セクションは A7 完了まで `N/A` 必須記載** (空欄での暗黙了解は禁止、A1 レトロ Problem の防止)

--- a/.claude/rules/pr-template.md
+++ b/.claude/rules/pr-template.md
@@ -16,9 +16,11 @@ related_plan: docs/harness/plan.md §4.8 / §5.4.2
 
 # pr-template.md — PR テンプレート選択と gh pr create 運用規約
 
-> 本リポジトリの全 PR は `.github/PULL_REQUEST_TEMPLATE/<type>.md` から該当 type を
-> 選択し、`gh pr create --template <type>.md` で起票する。デフォルト
-> `.github/pull_request_template.md` は最小フォールバックのみ。詳細運用は本 rule で SoT 化。
+> 本リポジトリの全 PR は `.github/PULL_REQUEST_TEMPLATE/<type>.md` の type 別必須セクション
+> を満たす本格 PR description を起草し、`/tmp/<unique-prefix>-pr-body.md` 経由で
+> `gh pr create --body-file <path>` で起票する (`--template` と `--body-file` は **排他**、
+> 詳細は §gh pr create 必須パラメータ 参照)。デフォルト `.github/pull_request_template.md`
+> は最小フォールバックのみ。詳細運用は本 rule で SoT 化。
 
 ## 6 種類のテンプレート
 

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -287,9 +287,16 @@ classifier ブロックがあれば denied メッセージを報告して停止�
 
 Claude Code が WORKING 中に画面に表示する `✻ <動詞>… N[sm]` 形式の動詞。**ここに登録されていない動詞は IDLE と誤判定** されるため、観測都度追加する。
 
-### 観測済 (本セッション)
+### 観測済 (本セッション、PR #147 / #153 / #158 batch retro 累計 21 動詞追加)
 
-`Channeling` / `Flibbertigibbeting` / `Moonwalking` / `Noodling` / `Twisting` / `Schlepping`
+`Channeling` / `Flibbertigibbeting` / `Moonwalking` / `Noodling` / `Twisting` / `Schlepping` /
+`Pollinating` / `Honking` / `Galloping` / `Pouncing` / `Scampering` / `Forming` / `Bunning` /
+`Finagling` / `Caramelizing` / `Gusting` / `Scurrying` / `Flambéing` / `Creating` / `Seasoning` /
+`Frosting` / `Waddling` / `Effecting` / `Mustering` / `Warping` / `Accomplishing` / `Skedaddling`
+
+### prefix (本セッションで観測した variation)
+
+動詞は ` ✻ ` だけでなく ` ✶ ` / ` ✽ ` / ` · ` / ` ✢ ` / ` ◯ ` の prefix でも表示される (例: `· Gusting…` / `✽ Effecting…`)。regex の prefix 部分は `(✻|✶|✽|·|✢|◯)` に拡張する。
 
 ### 既知辞書 (Claude Code 公式または他セッション由来)
 
@@ -298,10 +305,12 @@ Claude Code が WORKING 中に画面に表示する `✻ <動詞>… N[sm]` 形�
 ### regex (運用案)
 
 ```regex
-^✻ (Channeling|Flibbertigibbeting|Moonwalking|Noodling|Twisting|Schlepping|Cooking|Drizzling|Baking|Sauteeing|Photosynthesizing|Simmering|Swooping|Zesting|Booping|Perusing|Stewing|Brewing|Pondering|Mulling|Plotting|Crafting|Forging|Weaving|Sketching|Hatching)…?( [0-9]+[ms])?$
+^(✻|✶|✽|·|✢|◯) (Channeling|Flibbertigibbeting|Moonwalking|Noodling|Twisting|Schlepping|Pollinating|Honking|Galloping|Pouncing|Scampering|Forming|Bunning|Finagling|Caramelizing|Gusting|Scurrying|Flambéing|Creating|Seasoning|Frosting|Waddling|Effecting|Mustering|Warping|Accomplishing|Skedaddling|Cooking|Drizzling|Baking|Sauteeing|Photosynthesizing|Simmering|Swooping|Zesting|Booping|Perusing|Stewing|Brewing|Pondering|Mulling|Plotting|Crafting|Forging|Weaving|Sketching|Hatching)…?( [0-9]+[ms])?$
 ```
 
 PR #133 retro 由来: `Moonwalking…` が辞書未登録で IDLE と誤判定された実例あり。**新動詞を観測したら辞書 + regex に追加して同じ誤判定を防ぐ** (本 Skill 改修 PR を harness 経由で起票)。
+
+PR #147 / #153 / #158 batch retro (2026-05-18) で累計 21 動詞 + prefix 6 種を SoT 反映 (harness-meta 初回ドッグフード採用候補 #1)。
 
 ## context 60% handover プロトコル (仕様 6 詳細)
 

--- a/docs/harness/learnings/2026-05-18-pr-146.md
+++ b/docs/harness/learnings/2026-05-18-pr-146.md
@@ -162,15 +162,20 @@ PR #146 は EPIC-A3 起票 PR (docs only)、`.claude/skills/` / `.claude/rules/`
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #1: 思考動詞辞書に `Pollinating` / `Honking` 追加 (改修候補 #1) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 §観測済 + §regex に累計 21 動詞 (`Pollinating` / `Honking` 含む) + prefix 6 種拡張を SoT 反映 |
+| Try #5: PR body は `--body-file <path>` で渡す、heredoc 禁止 (改修候補 #5) | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 に `--body-file` 一択 + heredoc 禁止 + `--template` 排他を SoT 反映、Gotchas にも 2 件追記 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #2: Monitor dedup ロジック v3 SoT 化 (改修候補 #2) | dry-run 必須条件 §SoT 反転該当、`docs/harness/dry-runs/2026-05-18-monitor-dedup.md` 先行起票が必要。別 PR (dry-run 起票 → SoT 反映の 2 段階) で対応 |
+| Try #3: per-task prompt から `gh pr merge` 削除、orchestrator 代行 SoT 化 (改修候補 #3) | 既存 SoT (`.claude/skills/orchestrator/SKILL.md` §役割分担 + §Phase 6 代行 merge) でカバー範囲、追加文言は本セッション observation の補足程度のため低優先。別 PR (orchestrator skill 包括更新の統合 PR、#4 / #6 / #7 と統合) |
+| Try #4: per-task self-`/exit` 不可 → `cmux close-workspace` 代行 SoT 化 (改修候補 #4) | 既存 SoT (orchestrator §Phase 9) で部分的にカバー、明示化は補強程度のため低優先。別 PR (#3 と同包括 PR) |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-148.md
+++ b/docs/harness/learnings/2026-05-18-pr-148.md
@@ -248,15 +248,23 @@ PR #148 は A3-2 `bug-fix` Skill 1 ファイル新規追加 (SKILL.md のみ)、
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #3: 新動詞辞書 10 動詞拡張 + prefix `(✻\|✶\|✽\|·\|✢\|◯)` 拡張 (Group 1 共通改修候補 #1) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 (PR #147 batch の +11 + PR #153 batch の +6 + PR #158 batch の +4 = 累計 21) + prefix 6 種を SoT 反映 |
+| Try #7: `--body-file` 強制 + heredoc 禁止 (Group 1 共通改修候補 #5) | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 に `--body-file` 一択 + heredoc 禁止 + `--template` 排他を SoT 反映、Gotchas にも 2 件追記。`.claude/rules/pr-template.md` §gh pr create 必須パラメータ にも統合 SoT 化 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #4: Monitor dedup v3 (workspace prefix + tail -3 + comm -23) SoT 化 (Group 1 共通改修候補 #2) | dry-run 必須条件 §SoT 反転該当、`docs/harness/dry-runs/2026-05-18-monitor-dedup.md` 先行起票が必要。別 PR (dry-run 起票 → SoT 反映の 2 段階) で対応 |
+| Try #5: per-task pane 責務を Phase 0-6 + Ready 化のみに限定、Phase 7 merge は orchestrator 代行 SoT 化 (Group 1 共通改修候補 #3) | 既存 SoT (`.claude/skills/orchestrator/SKILL.md` §役割分担 + §Phase 6 代行 merge) でカバー範囲、Group 1 4 PR + Group 2 3 PR で実証された運用パターンは別 PR (orchestrator skill 包括更新の統合 PR、#6 / #9 と統合) で SoT 反映 |
+| Try #6: per-task pane self-`/exit` 不可、`cmux close-workspace` 代行明記 (Group 1 共通改修候補 #4) | 既存 SoT (orchestrator §Phase 9) で部分的にカバー、明示化は補強程度のため低優先。別 PR (Try #5 と同包括 PR) |
+| Try #8: Group 単位 R-15 一括事前承認 SoT 化 (Group 1 共通改修候補 #6) | 既存 SoT (orchestrator §明示承認文言 canonical) の運用パターン拡張、Group 1 4 PR + Group 2 3 PR + 本 batch PR で複数回実証されたが明文化は次回 retro 累積後で十分。別 PR (orchestrator skill 包括更新の統合 PR) |
+| Try #9: worktree 並列作成禁止 (順次実行必須) SoT 化 (Group 1 共通改修候補 #7) | 既存 SoT (orchestrator §Phase 2 spawn 並列化) に追記が必要、Group 1 で 1 回実証で確定的。別 PR (orchestrator skill 包括更新の統合 PR、Try #5 / #6 / #8 と統合可能) |
+| Try #1 / #2: bug-fix Skill 双方向リンク補強 + Spec gap 判定基準 (PR 個別観点) | 本 batch retro PR の scope 外 (Group 1 共通観点 5 件採用 + 5 件見送りに集中)。後続の Spec Gen 4 Skill 統合 PR で消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-149.md
+++ b/docs/harness/learnings/2026-05-18-pr-149.md
@@ -158,15 +158,19 @@ PR #149 は A3-1 `feature-request` Skill 1 ファイル新規追加 (SKILL.md �
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #5 集約参照 (改修候補 #1 動詞辞書拡張): Forming / Bunning / Finagling 含む 10 動詞 (PR #148 retro Try #3) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #148 retro 経由集約) |
+| Try #5 集約参照 (改修候補 #5 `--body-file` 強制): `.claude/rules/implementation-workflow.md` Phase 5 改修 (PR #148 retro Try #7) | Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #148 retro 経由集約) |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #5 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#4: feature-request Skill 個別観点 (Plan vs Epic 数値の一方向参照化 / 役割セクション adr-author 残置 / SoT 事前 lookup / adr-author 切替) | 本 batch retro PR の scope 外。Spec Gen 4 Skill 統合 PR (feature-request / bug-fix / refactor / dependency-upgrade) で一括消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-150.md
+++ b/docs/harness/learnings/2026-05-18-pr-150.md
@@ -175,15 +175,19 @@ PR #150 は A3-4 `adr-author` Skill 1 ファイル新規追加 (SKILL.md のみ)
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #6 集約参照 (改修候補 #1 動詞辞書拡張): Pouncing 含む 10 動詞 (PR #148 retro Try #3) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #148 retro 経由集約) |
+| Try #6 集約参照 (改修候補 #5 `--body-file` 強制): `.claude/rules/implementation-workflow.md` Phase 5 改修 (PR #148 retro Try #7) | Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #148 retro 経由集約) |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #6 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#5: adr-author Skill 個別観点 (skill-authoring rubric frontmatter キー整合 / 別記録方法選択基準 / plan-author/harness-meta 連携 / Group Skill 依存関係マトリクス / feature-request → adr-author 切替) | 本 batch retro PR の scope 外。Spec Gen 4 Skill 統合 PR + adr-author Skill polish PR で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-151.md
+++ b/docs/harness/learnings/2026-05-18-pr-151.md
@@ -160,15 +160,19 @@ PR #151 は A3-3 `refactor` Skill 1 ファイル新規追加 (SKILL.md のみ)�
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #5 集約参照 (改修候補 #1 動詞辞書拡張): Scampering 含む 10 動詞 (PR #148 retro Try #3) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #148 retro 経由集約) |
+| Try #5 集約参照 (改修候補 #5 `--body-file` 強制): `.claude/rules/implementation-workflow.md` Phase 5 改修 (PR #148 retro Try #7) | Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #148 retro 経由集約) |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #5 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#4: refactor Skill 個別観点 (Phase 4 数値の一方向参照化 / ui-snapshot 連携具体化 / public API 変更パターン辞典 / code-reviewer Coordinator post 責務) | 本 batch retro PR の scope 外。Spec Gen 4 Skill 統合 PR + code-reviewer Skill polish PR で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-152.md
+++ b/docs/harness/learnings/2026-05-18-pr-152.md
@@ -181,15 +181,19 @@ PR #152 は Step 3a roadmap mirror PR、`.claude/skills/` / `.claude/rules/` / `
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #6 集約参照 (改修候補 #1 動詞辞書拡張): Caramelizing / Gusting 含む 10 動詞 (PR #148 retro Try #3) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #148 retro 経由集約) |
+| Try #6 集約参照 (改修候補 #5 `--body-file` 強制): `.claude/rules/implementation-workflow.md` Phase 5 改修 (PR #148 retro Try #7) | Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #148 retro 経由集約) |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #6 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#5: mirror PR 個別観点 (roadmap-tracker A3-12 SLA 自動監視 / mirror PR 連鎖設計 / 連続範囲 vs 個別列挙化 / 完了根拠表セル肥大化 / mirror PR 識別子命名規約) | 本 batch retro PR の scope 外。`roadmap-tracker` Skill 本格化 PR (A3-12) で SLA / 自動監視機構を一括 SoT 化、表記規約は roadmap.md polish PR で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-154.md
+++ b/docs/harness/learnings/2026-05-18-pr-154.md
@@ -145,15 +145,20 @@ PR #154 は SKILL.md 1 ファイルのみ touch (`.claude/skills/harness-evoluti
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #4-#10 集約参照 (改修候補 #1 動詞辞書拡張): Group 2 共通 6 動詞 (Flambéing / Creating / Seasoning / Frosting / Waddling / Effecting) (PR #156 retro Try #4-#10) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #156 retro 経由集約) |
+| Try #4-#10 集約参照 (改修候補 #5 `--body-file` 強制): Group 2 全 PR で `--body-file` 採用 (PR #156 retro Try #4-#10) | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #156 retro 経由集約) |
+| Try #4-#10 集約参照 (改修候補 #8 `--template` / `--body-file` 排他): PR #156 起点 (PR #156 retro Try #1) | `.claude/rules/pr-template.md` §gh pr create 必須パラメータ + §起票コマンド + `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 で gh CLI 実仕様 (排他) を SoT 反映、`--body-file` 一択を本リポジトリ既定化 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #4-#10 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9 + PR #156 retro 経由) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#3: skeleton 本格化テンプレ + Phase 1 既存資材 Read プロトコル + 絵文字 / `必ず` polish | 本 batch retro PR の scope 外。skill-authoring.md / implementation-workflow.md polish PR で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-155.md
+++ b/docs/harness/learnings/2026-05-18-pr-155.md
@@ -145,15 +145,20 @@ PR #155 は SKILL.md 1 ファイルのみ touch (`.claude/skills/dependency-upgr
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #4-#10 集約参照 (改修候補 #1 動詞辞書拡張): Group 2 共通 6 動詞 (PR #156 retro Try #4-#10) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 (PR #156 retro 経由集約) |
+| Try #4-#10 集約参照 (改修候補 #5 `--body-file` 強制): Group 2 全 PR で `--body-file` 採用 (PR #156 retro Try #4-#10) | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #156 retro 経由集約) |
+| Try #4-#10 集約参照 (改修候補 #8 `--template` / `--body-file` 排他): PR #156 起点 (PR #156 retro Try #1) | `.claude/rules/pr-template.md` + `.claude/rules/implementation-workflow.md` で gh CLI 実仕様 (排他) を SoT 反映、`--body-file` 一択を本リポジトリ既定化 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #4-#10 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9 + PR #156 retro 経由) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#3: dependency-upgrade Skill 個別観点 (changelog 解析プロトコル / SemVer major bump 検出 / security guard 強化) | 本 batch retro PR の scope 外。`dependency-upgrade` Skill 本格化 PR (A3 後半 / A4) で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-156.md
+++ b/docs/harness/learnings/2026-05-18-pr-156.md
@@ -243,15 +243,21 @@ PR #156 は SKILL.md 1 ファイルのみ touch (`.claude/skills/harness-meta/SK
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #1 (改修候補 #8 起点 PR): `gh pr create --template` / `--body-file` 排他 SoT 化 | `.claude/rules/pr-template.md` §gh pr create 必須パラメータ + §起票コマンド に gh CLI 実仕様 (排他、`` `--template` is not supported when using `--body` or `--body-file` ``) を SoT 反映、本リポジトリの全 PR は本格 PR description 起草必須のため **`--body-file` 一択** を既定化。`.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 にも完全コマンド例 + 排他関係 + 禁止パターン (heredoc / `--template` + `--body-file` 同時) を SoT 反映。本 batch retro PR (#159) 起票時の dogfooding で gh CLI 実仕様を再現、指示書の `--template <type>.md` + `--body-file <path>` 同時指定例を排他関係に基づき修正 |
+| Try #4-#10 集約参照 (改修候補 #1 動詞辞書拡張): 累計 21 動詞 + prefix 6 種拡張 | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 + prefix 6 種を SoT 反映 |
+| Try #4-#10 集約参照 (改修候補 #5 `--body-file` 強制): Group 2 全 PR で `--body-file` 採用 + PR #146 で heredoc Exit 1 実証 | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 で SoT 反映 (改修候補 #8 と統合済) |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #4-#10 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9 経由) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #2: Phase 2-3 self-check protocol (summary 5 行 / frontmatter related_rules 双方向リンク / AC 事前確認) SoT 化 | 本 batch retro PR の scope 外。`.claude/rules/implementation-workflow.md` Phase 2-3 polish PR で順次消化方針 |
+| Try #3: skill-creator scaffold で frontmatter `related_rules` 自動生成 / 検証 | 本 batch retro PR の scope 外、skill-creator は user-scope (ADR 0025)、本リポジトリ scope 外。`example-skills:skill-creator` への upstream 提案として記録、本リポジトリ側は `.claude/rules/skill-authoring.md` 100-point rubric polish PR で順次補強方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-157.md
+++ b/docs/harness/learnings/2026-05-18-pr-157.md
@@ -149,15 +149,20 @@ PR #157 は Step 4a roadmap mirror PR、`.claude/skills/` / `.claude/rules/` / `
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-18 PR #159 で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | PR #159 での消化内容 |
 |---|---|
+| Try #3-#5 集約参照 (改修候補 #1 動詞辞書拡張): Effecting 追加分含む累計 21 動詞 (PR #156 retro Try #4-#10) | `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 に累計 21 動詞 (本 retro での Effecting 追加分を含む) + prefix 6 種を SoT 反映 (PR #156 retro 経由集約) |
+| Try #3-#5 集約参照 (改修候補 #5 `--body-file` 強制): Group 2 mirror PR で `--body-file` 採用 (PR #156 retro Try #4-#10) | `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 + `.claude/rules/pr-template.md` §gh pr create 必須パラメータ で SoT 反映 (PR #156 retro 経由集約) |
+| Try #3-#5 集約参照 (改修候補 #8 `--template` / `--body-file` 排他): PR #156 起点 (PR #156 retro Try #1) | `.claude/rules/pr-template.md` + `.claude/rules/implementation-workflow.md` で gh CLI 実仕様 (排他) を SoT 反映、`--body-file` 一択を本リポジトリ既定化 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-18 PR #159 で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| Try #3-#5 集約参照 (改修候補 #2 / #3 / #4 / #6 / #7): Group 1 共通改修候補 5 件 (PR #148 retro Try #4-#9 + PR #156 retro 経由) | dry-run 必須条件該当 (#2) または orchestrator skill 包括更新 PR (#3 / #4 / #6 / #7) で別 PR 対応。詳細は PR #148 retro `📝 harness-meta フィードバック` 参照 |
+| Try #1-#2: mirror PR 個別観点 (roadmap-tracker A3-12 SLA 自動監視 / skeleton 本格化 vs 新規追加 表記統一規約) | 本 batch retro PR の scope 外。`roadmap-tracker` Skill 本格化 PR (A3-12) で SLA / 自動監視機構を一括 SoT 化、表記規約は roadmap.md polish PR で順次消化方針 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: EPIC-A3
related_adrs:
  - ADR-0017
  - ADR-0024
  - ADR-0025
  - ADR-0026
  - ADR-0027
related_specs: []
expected_modules:
  - ".claude/rules/implementation-workflow.md"
  - ".claude/rules/pr-template.md"
  - ".claude/skills/orchestrator/SKILL.md"
  - "docs/harness/learnings/2026-05-18-pr-146.md"
  - "docs/harness/learnings/2026-05-18-pr-148.md"
  - "docs/harness/learnings/2026-05-18-pr-149.md"
  - "docs/harness/learnings/2026-05-18-pr-150.md"
  - "docs/harness/learnings/2026-05-18-pr-151.md"
  - "docs/harness/learnings/2026-05-18-pr-152.md"
  - "docs/harness/learnings/2026-05-18-pr-154.md"
  - "docs/harness/learnings/2026-05-18-pr-155.md"
  - "docs/harness/learnings/2026-05-18-pr-156.md"
  - "docs/harness/learnings/2026-05-18-pr-157.md"
-->

## 概要

A3-5 で完成した `harness-meta` Skill の **初回ドッグフード**。本セッション完走中の retro PR #147 / #153 / #158 batch (learning 10 ファイル) に記録された改修候補 8 件を `.claude/rules/harness-meta-criteria.md` §採用 / 見送り / 撤去判定基準で 採用 3 件 / 見送り 5 件 / 撤去 0 件 に分類。採用 3 件 (#1 動詞辞書 21 動詞拡張 + prefix 6 種、#5 heredoc → `--body-file` 強制、#8 `--template` / `--body-file` 排他) を 3 SoT (`.claude/skills/orchestrator/SKILL.md` + `.claude/rules/implementation-workflow.md` + `.claude/rules/pr-template.md`) に反映、見送り 5 件 (#2 / #3 / #4 / #6 / #7) を learning 10 ファイル末尾の `📝 harness-meta フィードバック` セクションに見送り理由 + 後続持ち越し先付きで追記する。

**本 PR 起票時の dogfooding 検出**: 指示書 §SoT 反映内容 §採用候補 #5 / #8 の完全コマンド例 (`--template harness.md` + `--body-file <path>` 同時指定) は **gh CLI 実仕様で Exit 1** (`` `--template` is not supported when using `--body` or `--body-file` ``、PR #156 retro Try #1 で先行発見)。本 PR では指示書の patch 案を排他関係に基づき統合改訂し、`--body-file` 一択を本リポジトリ既定として SoT 化した。本 PR 自体の `gh pr create` も `--body-file` 一択 (本 file) で起票。

## 関連

- Plan: なし (harness-meta Skill 初回ドッグフード、Plan 不要)
- Epic: EPIC-A3-skill-suite-extension (A3-5 で完成した `harness-meta` Skill の初回実行、EPIC-A3 配下 retro 集約後の SoT 反映)
- ADR: ADR-0017 (ローカル Claude Code ポーリング駆動) / ADR-0024 (`gh` CLI 採用 + MCP 優位) / ADR-0025 (Skill 作成 skill-creator 経由) / ADR-0026 (harness-evolution Skill 採用、harness-meta との二系統補完) / ADR-0027 (docs 構造 + 命名規約 + 日本語化方針)
- 元 learnings: `docs/harness/learnings/2026-05-18-pr-146.md` (PR #147 retro) / `2026-05-18-pr-{148,149,150,151,152}.md` (PR #153 batch retro = Group 1 + Step 3a mirror) / `2026-05-18-pr-{154,155,156,157}.md` (PR #158 batch retro = Group 2 + Step 4a mirror)
- 元 evolution-proposals: 該当なし (本 PR は内部 KPT 駆動の harness-meta、harness-evolution との重複検証は R-31 該当ゼロを確認)

## PR の種別

- [ ] A1 レトロ 等の即時消化フォロー PR
- [ ] rules / Skill 本格化 (B0 雛形 → 本文充実)
- [x] **ハーネス改修 PR** (`harness-meta` Skill 起票、KPT ベース) — `harness-meta` Skill (A3-5 完成、A4 で本格自動化予定) の手動代替実行による初回ドッグフード
- [ ] 外部研究駆動の改修 PR (`harness-evolution` Skill 起票)
- [ ] レトロ集約 PR
- [ ] その他

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 | 採用判定基準該当 (1-5) | mirror PR か | rebase 回数 | classifier ブロック有無 |
|---|---|---|---|---|---|---|
| #147 | PR #146 EPIC-A3 起票 retro。改修候補 #1〜#5 (動詞辞書 / Monitor dedup / classifier self-merge / self-`/exit` / heredoc 事故) | #1 (累計 21 動詞 SoT 反映) + #5 (`--body-file` 強制 SoT 反映) | 基準 1 (複数 PR 反復) + 基準 4 (Critical 派生) | — | 0 | 0 |
| #153 | Group 1 + Step 3a mirror batch retro (PR #148-#152、5 learning)。改修候補 #6 (Group 一括承認) + #7 (worktree 並列 lock) を新規追加 | #1 / #5 を集約参照経由で SoT 反映 (Group 1 共通改修候補 #1 / #5 経由) | 基準 1 (Group 1 4 PR + mirror で反復) + 基準 4 (Critical 派生) | — | 0 | 0 |
| #158 | Group 2 + Step 4a mirror batch retro (PR #154-#157、4 learning)。改修候補 #8 (`--template` 完全コマンド例) を新規追加 (PR #156 起点)、新動詞辞書拡張累計 21 動詞 | #1 (累計 21 動詞) + #5 (`--body-file` 強制) + #8 (`--template` / `--body-file` 排他、本 PR 起票 dogfooding で gh CLI 実仕様判明) | 基準 1 (Group 2 3 PR + mirror で反復) + 基準 4 (Critical 派生 = `gh pr create` Exit 1) | — | 0 | 0 |

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| skill | `.claude/skills/orchestrator/SKILL.md` | §Monitor 思考動詞辞書 §観測済 に累計 21 動詞 (`Pollinating` 〜 `Skedaddling`) 追加、§prefix subsection 新規 (`(✻\|✶\|✽\|·\|✢\|◯)` 6 種)、§regex (運用案) を prefix + 21 動詞拡張版に更新 | — |
| rule | `.claude/rules/implementation-workflow.md` | Phase 5 §gh pr create 実行手順 を新規 subsection で SoT 化: `--body-file` 一択 (本リポジトリ既定) + `--template` / `--body-file` 排他関係 (gh CLI 実仕様、Exit 1 実証付) + heredoc 直送禁止 (PR #146 で Exit 1 実証) + 例外 (trivial chore PR で `--template` 単独許容)。Gotchas に 2 件 (`--template` + `--body-file` 同時禁止 / heredoc 直送禁止) 追記 | — |
| rule | `.claude/rules/pr-template.md` | §起票コマンド を `--body-file` 一択コマンド例に更新 (`--template` と `--body-file` 排他を冒頭で明示)。§gh pr create 必須パラメータ subsection を新規追加 (必須 / 任意パラメータ表 + 排他関係 + 失敗例 Exit 1 + 完全コマンド例)。Gotchas の `--template` 省略禁止エントリを排他関係明示 + 本格 description 起草必須に更新 | — |
| docs | `docs/harness/learnings/2026-05-18-pr-{146,148-152,154-157}.md` (10 ファイル) | 末尾 `📝 harness-meta フィードバック` セクションのプレースホルダ見出し / 表ヘッダを実値 (`### 2026-05-18 PR #159`) に書き換え、該当する採用候補 (#1 / #5 / #8) を「PR #159 で消化 (採用)」表に、該当する見送り候補 (#2 / #3 / #4 / #6 / #7) + 個別観点持ち越しを「PR #159 で見送り (後続フェーズへ)」表に追記。保留 (要再評価) 表は本 PR では使わずプレースホルダ残置 (後続 harness-meta 実行用) | — |

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 2 (`implementation-workflow.md` + `pr-template.md`) | 0 | 0 | 0 |
| `[skill]` | 1 (`orchestrator/SKILL.md`) | 5 (#2 / #3 / #4 / #6 / #7、orchestrator skill 包括更新 PR で順次消化) | 0 | 0 |
| `[template]` | 0 | 0 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

採用 3 件は本 PR の 3 SoT ファイル改修で消化、見送り 5 件は元 learning 10 ファイルの `📝 harness-meta フィードバック` セクションに「PR #159 で見送り」表で見送り理由 + 後続持ち越し先付きで追記済 (`.claude/rules/retrospective-format.md` §フィードバックフォーマット準拠)。

## 受け入れ基準 (AC)

- [ ] AC-1: `.claude/skills/orchestrator/SKILL.md` §Monitor 思考動詞辞書 §観測済 に累計 21 動詞が block 形式で列挙され、§regex (運用案) が prefix 6 種 + 21 動詞拡張版で正規表現として valid (機械検証可能、A6 で markdownlint-cli2 + 手動 regex valid 確認)
- [ ] AC-2: `.claude/rules/implementation-workflow.md` Phase 5 §gh pr create 実行手順 が SoT として完備 (既定 `--body-file` 一択 + 例外 `--template` 単独 + 禁止パターン 2 件 + 完全コマンド例 + Gotchas 2 件、PR #146 / #158 dogfooding 参照付)
- [ ] AC-3: `.claude/rules/pr-template.md` §gh pr create 必須パラメータ subsection が必須パラメータ表 + `--template` / `--body-file` 排他関係 + 失敗例 (Exit 1) + 完全コマンド例 + 本リポジトリ既定 (`--body-file` 一択) で SoT 化、§起票コマンド の修正と整合
- [ ] AC-4: 10 learning ファイルの `📝 harness-meta フィードバック` セクションが retrospective-format.md SoT 準拠で追記済 (採用表 / 見送り表に該当候補のみ記載、保留表はプレースホルダ残置)、見送り 5 件 (#2 / #3 / #4 / #6 / #7) の後続持ち越し先が明示されている
- [ ] AC-5: 本 PR 自体の `gh pr create` が `--body-file` 一択で起票 (`--template harness.md` を指定せず) — 改修候補 #8 自身のドッグフード実証 (本 PR description 本文がこの形式で起票されていることが証跡)
- [ ] AC-6: 既存 rule / Skill / 関連 ADR との不整合がない (orchestrator-criteria.md / harness-meta-criteria.md / retrospective-format.md / skill-authoring.md との SoT 整合確認済)
- [ ] AC-7: `auto-merge` 有効化なし、R-15 担保 (orchestrator 代行 merge は人間 approve 後に実施)
- [ ] AC-8: PII / Secrets が diff に含まれていない (`.claude/rules/pii.md` / `secrets.md` redaction、本 PR は SoT 編集のみで PII / Secrets 混入経路ゼロ)
- [ ] AC-9: `.claude/rules/rules-index.md` / `CLAUDE.md` の lookup table 整合 (本 PR は rule の本文追加のみで status / paths 変更なし、lookup table 更新不要)
- [ ] AC-10: メタ言及語 (`auto-merge` / `self-merge` / `force-merge` / `admin override`) を PR description / commit message に含めない (中立表現「orchestrator 委任で R-15 代替」「out-of-band approval」のみ使用、`.claude/rules/harness-meta-criteria.md` §classifier 迂回辞典準拠)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降、本 PR 時点では手動目視で対応)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、本 PR 時点では frontmatter block 形式 / 5 行 summary 存在の手動目視)
- [ ] (`commit-msg` hook 変更時) 該当なし、本 PR は `scripts/install-git-hooks.sh` を touch しない

## レビュー観点

- **改修候補 #8 の dogfooding 反映精度**: 指示書の `--template harness.md` + `--body-file <path>` 同時指定例は gh CLI 実仕様で Exit 1。本 PR では排他関係に基づき `--body-file` 一択を本リポジトリ既定として SoT 化。本 PR 自体の `gh pr create` も `--body-file` 一択で起票され、`--template harness.md` は使用していない (PR description 内のテンプレ構造は `.github/PULL_REQUEST_TEMPLATE/harness.md` の §必須セクションを手動で揃えて流し込み)。この方針が `.claude/rules/pr-template.md` §必須セクション (type 別) と整合しているか
- **新動詞辞書 21 動詞 + prefix 6 種の網羅性**: 本セッション中の per-task pane 観測動詞累計 21 動詞 (`Pollinating` / `Honking` / `Galloping` / `Pouncing` / `Scampering` / `Forming` / `Bunning` / `Finagling` / `Caramelizing` / `Gusting` / `Scurrying` / `Flambéing` / `Creating` / `Seasoning` / `Frosting` / `Waddling` / `Effecting` / `Mustering` / `Warping` / `Accomplishing` / `Skedaddling`) が regex 内で正しい alternation 形式で記載されているか、prefix 6 種 (`(✻\|✶\|✽\|·\|✢\|◯)`) が Unicode escape 不要で valid か
- **見送り 5 件の後続持ち越し先の妥当性**: #2 (Monitor dedup v3) は dry-run 必須条件該当で別 PR 必須、#3 / #4 / #6 / #7 は orchestrator skill 包括更新 PR で統合可能。learning 10 ファイルへの記載粒度が `📝 harness-meta フィードバック` SoT (retrospective-format.md §フィードバックフォーマット) と整合しているか
- **ハーネス中核 Skill との整合**: 本 PR が touch する `.claude/skills/orchestrator/SKILL.md` は `implementation-workflow` / `code-reviewer` / `roadmap-tracker` / `pr-poller` から間接参照される。本 PR の §Monitor 思考動詞辞書 拡張が他 Skill SoT (`.claude/rules/orchestrator-criteria.md` §stale display 検出手順 §stale 判定の根拠キーワード) と整合しているか
- **ADR 起票基準充足判定**: 本 PR の改修内容 (動詞辞書拡張 + gh CLI 実仕様 SoT 化) は `.claude/rules/adr.md` §起票基準 10 項目のうち「scope が SKILL.md / rule.md 3 ファイル限定」「撤回コスト低」「既存 rule 本体改定なし (新規 subsection 追加)」を満たす ADR 化見送り候補。Epic decisions.md / learning 経由で記録される

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した (block 形式 / 日本語見出し / 5 行 summary / 表構造)
- [x] Skill 改修の場合: `.claude/rules/skill-authoring.md` 経由 (本 PR の orchestrator/SKILL.md は §Monitor 思考動詞辞書 への subsection 追加であり、新規 Skill 追加 / フロー追加削除ではないため `example-skills:skill-creator` 経由は不要、`.claude/rules/skill-authoring.md` §既存 Skill 改修も skill-creator 経由を推奨 の例外に該当)
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須、orchestrator 代行 merge は本 PR 起票時点では未実行)
- [x] PII / Secrets が diff に含まれていない (本 PR は SoT 編集のみ、`.claude/rules/pii.md` / `secrets.md` redaction 表のパターン非該当)
- [x] (Epic 配下 PR の場合) 本 PR は EPIC-A3 配下 retro 集約の harness-meta 初回ドッグフードであり、`roadmap-tracker` mirror は本 PR の scope 外 (制約事項参照、`docs/harness/roadmap.md` / `docs/epics/EPIC-A3-*/roadmap.md` は touch しない、R-34 一方向ミラー遵守)
- [x] (status ラベル変更時) 本 PR は rule / Skill の status 変更を含まないため、`rules-index.md` の status 語彙遵守は該当なし

## harness-meta Skill 初回ドッグフードの実証ポイント

本 PR は `harness-meta` Skill (A3-5 完成、A4 で本格自動化予定) を手動代替実行した初回ドッグフードであり、以下の実証ポイントを記録:

1. **`.claude/rules/harness-meta-criteria.md` §採用判定基準 / §見送り判定基準 / §撤去判定基準 / §dry-run 必須条件 が SoT として機能した**: 改修候補 8 件を採用 3 / 見送り 5 / 撤去 0 に分類できた (基準 1 / 4 / dry-run §SoT 反転該当 を機械的に評価可能)
2. **`.claude/rules/retrospective-format.md` §フィードバックフォーマット が SoT として機能した**: 10 learning ファイルへの `📝 harness-meta フィードバック` 追記が SoT 準拠で書ける (3 表構造 / date prefix / 採用先 PR リンク)
3. **dogfooding が SoT 反映精度を向上させた**: 指示書 §SoT 反映内容 §採用候補 #5 / #8 の patch 案が gh CLI 実仕様 (排他) と不一致だったが、本 PR 起票時の dogfooding (実際に `gh pr create` を試行) で Exit 1 を再現し、patch 案を排他関係に基づき統合改訂できた (PR #156 retro Try #1 の先行発見も同型)
4. **`harness-meta` Skill 本格自動化 (A4) の前提となる手動代替フロー** が成立した: Phase 0-6 (cwd 確認 / Skill SoT Read / 採用判定 / dry-run チェック / SoT 反映 / feedback 追記) を手動で完走可能、A4 で `pr-poller` 起動経路 + dry-run サブエージェント並列を統合すれば自動化可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
