### PR TITLE
docs(harness): single-file PR の commit 分離規範を SoT 化 (5 回反復採用)

### DIFF
--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -2,7 +2,7 @@
 id: rules-implementation-workflow
 title: implementation-workflow 10 フェーズ手順規約
 status: stable
-last_updated: 2026-05-17
+last_updated: 2026-05-19
 paths:
   - ".claude/skills/implementation-workflow/**"
 related_adrs:
@@ -231,6 +231,81 @@ git branch -d <branch-name>  # 検出されなければ -D に切替
   - `-D` を使うのは **PR state が MERGED であることを確認した後** に限定
 - `branch -d` で先にトライし、失敗時のみ `-D` に切り替える順序を守る (PR state 未確認のまま `-D` を使うと未マージ work が消滅するリスク)
 
+## commit 分離規範 (single-file PR 内、PR #161/#162/#164/#165/#167 レトロ Try 反映)
+
+`harness-meta-criteria.md` §分割粒度 表は **ファイル数ベース** の PR 粒度規範 (1-5 ファイル = 1 PR 包括、6-20 ファイル = グループ単位 commit 分離)。本セクションは補完として、**1 ファイル PR でも論理的に独立な変更を別 commit に分離する** 規範を SoT 化する。skeleton → active 本格化 PR / Skill SoT 反映 PR / rule 改修 PR では、変更行数が +200 を超えても 1 ファイル PR として並走可能だが、1 commit に集約すると後続レビュー / retro で logical separator が読み取れない問題が PR #161/#162/#164/#165/#167 (Group 3 wave1/wave2) で 5 回反復観測された (採用判定基準 1 強化該当)。
+
+### 分離判定基準 (commit 分離 vs 単一 commit OK)
+
+以下のいずれかに該当する場合、同一ファイル内でも別 commit に分離:
+
+| 区分 | 例 |
+|---|---|
+| **論理的に独立した目的** | rule 本体の規範追加 + frontmatter `last_updated` 更新 + `rules-index.md` 索引行追加 = 3 commit (各々の取り消し粒度を独立化) |
+| **改修候補 ID が異なる** | 改修候補 #3 / #4 / #6 / #7 を SKILL.md 1 ファイルに反映する PR では、各改修候補ごとに 1 commit (`git add -p` 経由でファイル内 hunk 分離) |
+| **skeleton → active 本格化 PR の Phase 別** | Phase 0-3 セクション / Phase 4-6 セクション / Phase 7-9 セクション + frontmatter で 4 commit 分離 (例: `.claude/skills/implementation-workflow/SKILL.md` の skeleton → active 本格化) |
+| **取り消し時の粒度を独立させたい** | 後続レビューで「frontmatter 更新だけ revert したい」「§N セクション追加だけ revert したい」等の要望が想定される場合 |
+| **レビュー時の差分追跡を容易にしたい** | 単一 commit で +200 行超は読み切りコスト高、論理単位で commit 分離すれば `git log -p --first-parent` で差分追跡可能 |
+
+### 例外 (単一 commit OK、commit 分離不要)
+
+以下のいずれかに該当する場合、単一 commit で OK:
+
+| 区分 | 例 |
+|---|---|
+| **typo / 表記揺れ修正のみ** | 全角半角統一、識別子の表記正規化、機械検出可能な誤字 (`harness-meta-criteria.md` §dry-run 不要条件 と整合) |
+| **1-2 行の補正** | frontmatter `last_updated` 単独更新、リンク 1 件追加、見出し 1 件修正 |
+| **同一目的の小規模変更が複数箇所** | 同じ rule の §A / §B / §C に同じ修正パターンを適用 (例: 全角コロン → 半角コロン置換を 5 箇所) |
+| **logical separator が分離コストに見合わない** | +50 行未満 + 単一目的 (rule 1 セクション追加のみ) は単一 commit で OK |
+
+### 実装手順 (`git add -p` 経由のファイル内 hunk 分離)
+
+同一ファイル内で複数の論理的変更を別 commit に分離する場合、`git add -p` で hunk 単位に staging する:
+
+```bash
+# 1. ファイル全体を編集 (Edit / Write tool で複数箇所を一括変更)
+
+# 2. hunk 単位で staging (interactive)
+git add -p <file>
+# 各 hunk について y/n/s/e/q を選択
+#   y = この hunk を staging
+#   n = この hunk を skip
+#   s = hunk を分割 (split)
+#   e = hunk を編集 (edit)
+#   q = quit
+
+# 3. staged hunk のみ commit
+git commit -F /tmp/<prefix>-commit-msg-1.txt
+
+# 4. 残り hunk を次の commit に
+git add -p <file>
+git commit -F /tmp/<prefix>-commit-msg-2.txt
+
+# 5. 全 hunk staging 完了まで繰り返し
+```
+
+### 学習起点 (5 PR 反復)
+
+- **PR #161** (orchestrator SKILL.md 包括更新): 改修候補 #3/#4/#6/#7 を 1 ファイル / 1 commit で実装、後続レビューで logical separator が読み取れない問題を Problem に記録
+- **PR #162** (A3-8 implementation-workflow Skill 本格化): +278 / -26 を 1 commit、Phase 別 commit 分離が読み取れない問題を Problem に記録
+- **PR #164** (A3-9 code-reviewer Skill 本格化): +215 / -36 を 1 commit、Coordinator ステップ別 / Gotchas セクション別の logical separator が読み取れない問題を Problem に記録
+- **PR #165** (A3-12 roadmap-tracker Skill 本格化): +248 / -28 を 2 commits (initial + fix loop 1)、5 系統別の commit 分離が読み取れない問題を Problem に記録
+- **PR #167** (A3-10 pr-retrospective Skill 本格化): +189 / -21 を 1 commit、Phase 別 commit 分離が読み取れない問題を Problem に記録
+
+採用判定基準 1 (複数 PR 反復) を強化条件 (5 回反復) で満たすため、本 SoT 化で再発予防。
+
+### Phase 別の適用タイミング
+
+- **Phase 3 (実装 + Lint + Test)**: 実装中は logical 単位で commit、`./gradlew check` green を各 commit で担保 (途中 commit で fail でも OK だが、PR 起票前に green commit に rebase 整理)
+- **Phase 5 (Draft PR 作成)**: PR 起票前に `git log --oneline origin/master..HEAD` で commit 構造を最終確認、各 commit が独立 revertable / 読み切り可能か検証
+- **Phase 6 (code-reviewer 呼出)**: fix loop で追加 commit は logical separator 維持、Critical 修正は単独 commit (revert 容易化)
+- **Phase 7 (squash merge)**: 本リポジトリは `--squash` 採用のため、merge commit としては単一 commit に圧縮されるが、PR 内 commit 履歴は `gh pr view --json commits` で残り、後続 retro / レビューが trace 可能
+
+### 機械検証 (A6 で導入予定)
+
+- **Gradle カスタムタスク**: `git log --oneline origin/master..HEAD` で commit 数 / 各 commit の touch 行数を計測、`logical separator なし` 疑い (1 ファイル PR + 1 commit + 100 行超) を warning 化
+- **commit-msg hook 拡張**: Conventional Commits subject に logical 単位を示す scope 明示を推奨 (例: `feat(skill): orchestrator §Phase 6 セクション差し替え (改修候補 #3)`)
+
 ## Fix loop の上限と blocked 判定
 
 - **Phase 3 fix loop**: `./gradlew check` 失敗 → 修正 → 再実行 を 3 回まで
@@ -270,11 +345,14 @@ git branch -d <branch-name>  # 検出されなければ -D に切替
 - **Phase 9 の `branch -d` を先にトライし、失敗時のみ `-D` に切替** (PR #123 / #135 レトロ Try): squash merge / merge commit のいずれも `--merged origin/master` で検出されないケースがある。`gh pr view --json state=MERGED` 確認後に `-D` 許容、PR state 未確認のまま `-D` は禁止 (未マージ work 消滅リスク)
 - **worktree path の slug は `branch-naming.md` 規約に厳密に従う**: スラッシュをハイフンに置換、特殊文字なし
 - **並走中の rules-index.md / roadmap.md / progress.md の rebase 競合** は EPIC-A2 で頻発、mirror PR で統合解消するパターンを A2-2 / A2-4 / A2-5 で確立
+- **single-file PR でも論理的に独立した変更は別 commit に分離** (PR #161/#162/#164/#165/#167 レトロ Try 反映、本 rule §commit 分離規範 参照): 改修候補 ID 別 / Phase 別 / frontmatter 単独 等の logical separator を `git add -p` 経由で実現、+200 行超の skeleton → active 本格化 PR は特に分離推奨
 
 ## 関連
 
 - ADR 0017 (ローカル Claude Code ポーリング駆動、Generator/Evaluator 分離の前提)
 - ADR 0018 (10 フェーズ設計の SoT)
 - `docs/harness/plan.md` §5.3 / §5.4.2 / R-14 / R-15 / R-34 / R-37
-- `.claude/rules/{branch-naming,pr-template,pr-draft-policy,merge-readiness,code-reviewer-aspects,spec-living-sync,roadmap,pr-poller}.md`
+- `.claude/rules/{branch-naming,pr-template,pr-draft-policy,merge-readiness,code-reviewer-aspects,spec-living-sync,roadmap,pr-poller,harness-meta-criteria}.md`
+- `.claude/rules/harness-meta-criteria.md` §分割粒度 (本 rule §commit 分離規範 と補完関係、ファイル数ベース粒度 vs single-file PR 内 logical separator の二重 SoT)
 - `.claude/skills/implementation-workflow/SKILL.md`
+- 学習起点: PR #161/#162/#164/#165/#167 retro Try (single-file PR commit logical separator 5 回反復、`docs/harness/learnings/2026-05-18-pr-{161,162,164,165,167}.md`)

--- a/docs/harness/learnings/2026-05-18-pr-159.md
+++ b/docs/harness/learnings/2026-05-18-pr-159.md
@@ -89,10 +89,15 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 | 提案 | <PR ID> での消化内容 |
 |---|---|
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19 harness-meta judgment で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| `[rule]` `harness-meta-criteria.md` §dry-run 必須条件 に「外部ツール仕様依存の提案」追加 | A4 (harness-meta 自動化) で gh CLI 仕様検証も自動化予定のため、Skill 本格化と同時 SoT 化が効率的 |
+| `[template]` `harness.md` テンプレに「採用判定根拠」表追加 | A4 で harness-meta 判定プロセスの自動 PR description 生成と同時実装が望ましい |
+| `[skill]` `harness-meta` Skill に gh CLI 仕様検証の自動化 | A4 Skill 本格化スコープ |
+| `[rule]` `harness-meta-criteria.md` §持ち越し先決定 に「dry-run 起票 PR / Skill SoT 反映 PR の責務分離」 | 採用判定基準 1 該当だが、現状 §分割粒度 表 (6-20 ファイル) で部分カバー、明示 SoT 化は A4 で再評価 |
+| `[skill]` `harness-meta` Skill に判定プロセス記録の自動 PR description 生成 | A4 Skill 本格化スコープ |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-18-pr-167.md
+++ b/docs/harness/learnings/2026-05-18-pr-167.md
@@ -93,15 +93,23 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-19 harness-meta judgment で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | 消化内容 |
 |---|---|
+| `[rule]` single-file PR の commit logical separator 規範を `.claude/rules/implementation-workflow.md` §commit 分離 に追加 (5 回反復、採用判定基準 1 強化) | harness-meta-execution-2026-W21 PR で `.claude/rules/implementation-workflow.md` §commit 分離規範 セクションを新規追加。分離判定基準 / 例外 / `git add -p` 実装手順 / 5 PR 学習起点 / Phase 別適用タイミング / 機械検証 (A6 予定) を SoT 化。Gotchas + §関連 に cross-link 追加 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19 harness-meta judgment で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| `[skill]` A4 完了時に本 SKILL.md の self-bootstrap 自動化 | A4 (cmux + ScheduleWakeup + CronCreate) 本格化スコープ |
+| `[rule]` `pr-poller` / `code-reviewer` / `harness-meta` / `roadmap-tracker` 間の cross-link 整合検証 | A6 (Gradle カスタムタスク機械検証) スコープ |
+| `[skill]` 三層指標自動取得を A7 完了時に Phase 3 と統合 | A7 (Kover / Konsist / PITest 統合) スコープ |
+| `[skill]` `harness/learnings-batch-YYYY-WW` ブランチ自動作成 + push 自動化 | A4 (Skill 本格化) スコープ |
+| `[rule]` 件数閾値 10 件 / 週次到達条件の N=10 再計測 | A4 自動化後の retro batch N=10 で再計測予定 |
+| `[skill]` `generator` 表記の `Skill (vX.Y.Z)` 一括書き換え | A4 Skill 本格化 PR スコープ |
+| `[skill]` Phase 6 redaction チェックポイントの regex 自動適用 | A4 (Skill 本格化) スコープ、現状は手動代替で担保 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-19-pr-171.md
+++ b/docs/harness/learnings/2026-05-19-pr-171.md
@@ -92,10 +92,18 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 | 提案 | <PR ID> での消化内容 |
 |---|---|
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19 harness-meta judgment で見送り (後続フェーズへ)
 
 | 提案 | 見送り理由 / 移行先 |
 |---|---|
+| `[rule]` ADR 採番ライフサイクル (予約 → 起票見送り → 解放 → 再割当) を `.claude/rules/adr.md` / `.claude/skills/adr-author/SKILL.md` に明示追加 | 採用判定基準 4 該当だが、ADR 起票ライフサイクルは dry-run 必須条件 (rule 本体改修 + SoT 方向) に該当する可能性が高く、`adr-author` Skill 本格化と同時検討が安全。後続 PR で dry-run 経由起票推奨 |
+| `[rule]` `commit-message.md` の subject 長制限を hook で block オプション化 | A6 (markdownlint-cli2 + commit-msg hook 拡張) スコープ |
+| `[skill]` `plan-author` Skill に「Plan AC と適用 rule の整合検証」を rubric 追加 | A3 (plan-author Skill 本格化) スコープ |
+| `[skill]` 全 SKILL.md に「分岐明示パターン」を skill-authoring rubric に追加項目化 | 採用判定基準 4 該当だが、skill-authoring 100-point rubric 改修は採用判定基準 / 必須条件 級の核心改修のため dry-run 必須、別 PR で dry-run 経由起票推奨 |
+| `[template]` `implementation-workflow.md` Phase 7 §classifier ブロック対応に「同 pattern 2 回連続 denial の retry 許容判定」を追加 | 採用判定基準 1 該当だが、classifier 迂回判定の改修は採用判定基準 / 必須条件 級のためdry-run 必須、`harness-meta-criteria.md` §迂回パターン辞典 と同時改修推奨 |
+| `[skill]` `harness-meta` Skill に副作用候補自動抽出 trigger 実装 | A4 (harness-meta Skill 本格化) スコープ |
+| `[skill]` `pr-retrospective` Skill に self-bootstrap dry-run 関連 PR の特殊フォーマット追加 | A3 (pr-retrospective Skill 本格化、A3-10 完了済だが追加機能は A4 で N 拡張 retro と統合推奨) スコープ |
+| `[rule]` `harness-meta-criteria.md` §dry-run 3 軸定量評価 の N=1 制約付き ✅ 運用例として本 PR を引用追加 | A4 で N=10 再計測完了後に「N=1 暫定 → N=10 確定」昇格パターンと同時 SoT 化が望ましい |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: —
related_epic: —
related_adrs: []
related_specs: []
expected_modules: ["docs(harness)"]
-->

## 概要

2026-05-19 `harness-meta` Skill 実行による KPT 駆動の改修 PR。直近 5 PR (#161/#162/#164/#165/#167) retro Try で 5 回反復観測された「single-file PR の commit logical separator なし」問題を採用判定基準 1 強化該当として `.claude/rules/implementation-workflow.md` §commit 分離規範 に SoT 化。

## 関連

- Plan: —
- Epic: —
- ADR: ADR-0017 (Generator/Evaluator 分離) / ADR-0018 (10 フェーズ設計)
- 元 learnings:
  - `docs/harness/learnings/2026-05-18-pr-161.md`
  - `docs/harness/learnings/2026-05-18-pr-162.md`
  - `docs/harness/learnings/2026-05-18-pr-164.md`
  - `docs/harness/learnings/2026-05-18-pr-165.md`
  - `docs/harness/learnings/2026-05-18-pr-167.md`
- 元 evolution-proposals: —

## PR の種別

- [ ] **A1 レトロ 等の即時消化フォロー PR** (rules / template / docs 即時修正)
- [ ] **rules / Skill 本格化** (B0 雛形 → 本文充実)
- [x] **ハーネス改修 PR** (`harness-meta` Skill 起票、KPT ベース)
- [ ] **外部研究駆動の改修 PR** (`harness-evolution` Skill 起票)
- [ ] **レトロ集約 PR** (`harness/learnings-batch-YYYY-WW` ブランチ、週次 / 件数到達時)
- [ ] **その他** (chore / 撤去 / migration 等)

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 | 採用判定基準該当 (1-5) | mirror PR か | rebase 回数 | classifier ブロック有無 |
|---|---|---|---|---|---|---|
| #161 | single-file PR commit logical separator なし (改修候補 #3/#4/#6/#7 を 1 commit) | `implementation-workflow.md` §commit 分離規範 追加 | 1 (5 回反復強化) | — | 0 | 0 |
| #162 | +278 / -26 を 1 commit、Phase 別 logical separator なし | 同上 | 1 (5 回反復強化) | — | 0 | 0 |
| #164 | +215 / -36 を 1 commit、Coordinator ステップ別 logical separator なし | 同上 | 1 (5 回反復強化) | — | 0 | 0 |
| #165 | +248 / -28 を 2 commits、5 系統別 logical separator なし | 同上 | 1 (5 回反復強化) | — | 0 | 0 |
| #167 | +189 / -21 を 1 commit、Phase 別 logical separator なし | 同上 | 1 (5 回反復強化) | — | 0 | 0 |

## 採用根拠

**採用判定基準 1 (複数 PR 反復) の強化条件 5 回反復該当**:

- PR #161 (orchestrator SKILL.md 包括更新): 改修候補 #3/#4/#6/#7 を 1 commit で実装、後続レビューで logical separator が読み取れない問題を Problem に記録
- PR #162 (A3-8 implementation-workflow Skill 本格化): +278 / -26 を 1 commit
- PR #164 (A3-9 code-reviewer Skill 本格化): +215 / -36 を 1 commit
- PR #165 (A3-12 roadmap-tracker Skill 本格化): +248 / -28 を 2 commits (initial + fix loop 1)
- PR #167 (A3-10 pr-retrospective Skill 本格化): +189 / -21 を 1 commit

これら 5 PR は全て Group 3 wave1/wave2 の skeleton → active 本格化 PR で、いずれも single-file 改修で +200 行超だが logical separator なしという共通 Problem を記録。本 PR で SoT 化することで再発予防。

## dry-run skip 該当

**skip 理由**: 既存セクションへの例示追加に近い性質 (本体ルールへの新セクション追加だが、既存規範を補完する additive 改修であり、`harness-meta-criteria.md` §分割粒度 (ファイル数ベース) との二重 SoT 補完関係を明示)。本改修は「rule 全文書き換え」「Skill フロー追加 / 削除」「template 構造変更」「rule 間 SoT 反転」「採用判定基準 / 撤去基準改修」のいずれにも該当しないため dry-run 不要 (`.claude/rules/harness-meta-criteria.md` §dry-run 不要条件 第 3 行「既存セクションへの例示追加」+ 第 6 行「撤回コスト低 + scope 限定 + 既存 rule 本体改定なし」該当)。

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| rule | `.claude/rules/implementation-workflow.md` | §commit 分離規範 セクション新規追加 (分離判定基準 / 例外 / `git add -p` 手順 / 学習起点 / Phase 別タイミング / 機械検証)、frontmatter `last_updated` 更新、Gotchas + §関連 拡充 | — |
| docs | `docs/harness/learnings/2026-05-18-pr-159.md` | 📝 harness-meta フィードバック 「見送り」表に 5 件追記 | — |
| docs | `docs/harness/learnings/2026-05-18-pr-167.md` | 📝 「採用」表に 1 件 + 「見送り」表に 7 件追記 | — |
| docs | `docs/harness/learnings/2026-05-19-pr-171.md` | 📝 「見送り」表に 8 件追記 | — |

## 3 軸定量評価 (dry-run skip 該当のため空欄)

dry-run skip 該当 (上記参照)。

### dry-run skip 該当時

- **skip 理由**: 既存セクションへの例示追加に近い additive 改修。`.claude/rules/harness-meta-criteria.md` §dry-run 不要条件 第 3 行「既存セクションへの例示追加」+ 第 6 行「撤回コスト低 + scope 限定 + 既存 rule 本体改定なし」該当。`implementation-workflow.md` の既存 10 フェーズ手順 / Fix loop / 並行実装基盤 / Gotchas は無改変、新セクション追加のみで backward compatible。

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 1 | 12 | 0 | 0 |
| `[skill]` | 0 | 9 | 0 | 0 |
| `[template]` | 0 | 1 | 0 | 0 |
| `[remove]` | 0 | 0 | 0 | 0 |

採用しなかった提案は元 learning ファイル (159 / 167 / 171) の `📝 harness-meta フィードバック` セクション「見送り (後続フェーズへ)」表に理由を追記。

## 受け入れ基準 (AC)

- [x] AC-1: `.claude/rules/implementation-workflow.md` に §commit 分離規範 セクションが追加され、分離判定基準 / 例外 / 実装手順 / 学習起点 / Phase 別タイミング / 機械検証 を SoT 化している
- [x] AC-2: frontmatter `last_updated` が 2026-05-19 に更新されている
- [x] AC-3: Gotchas に 1 項目追加されている (single-file PR 別 commit 分離)
- [x] AC-4: §関連 に `harness-meta-criteria.md` + 学習起点 5 PR が列挙されている
- [x] AC-5: learning 159 / 167 / 171 の `📝 harness-meta フィードバック` セクションに 2026-05-19 harness-meta judgment 表が追記されている
- [x] AC-6: 既存 rule / Skill / 関連 ADR との不整合がない (本 PR は既存セクション無改変の additive 改修)
- [x] AC-7: commit 分離規範を本 PR 自身でも実践 (rule 改修 commit + learning 追記 commit の 2 commit 分離)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降)
- [x] (`commit-msg` hook 変更なし) — 本 PR では hook 変更なし、subject 60 字以内 / Conventional Commits 形式 / Co-Authored-By 必須を遵守

## レビュー観点

- §commit 分離規範 の分離判定基準表 / 例外表 が後続 PR で運用可能な粒度になっているか
- `git add -p` 手順が cmux + zsh 環境で再現可能か (interactive command の挙動)
- `harness-meta-criteria.md` §分割粒度 (ファイル数ベース) と §commit 分離規範 (single-file PR 内) の二重 SoT 補完関係が明確か
- learning 159 / 167 / 171 の 📝 フィードバック追記が `.claude/rules/retrospective-format.md` §フィードバックフォーマット 規約に準拠しているか
- 撤回コスト: 本改修を取り消す手順は明確か (新セクション削除 + frontmatter revert + Gotchas 1 行削除 + §関連 cross-link 削除で revert 完了、既存規範に影響なし)

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した
- [x] (Skill 改修なし、本 PR は rule 改修のみ)
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須)
- [x] PII / Secrets が diff に含まれていない (本 PR は docs / rule のみ、PII / Secrets 関連表現なし)
- [x] (Plan / Epic 配下 PR ではない) — 本 PR は harness-meta 自主起票
- [x] (status ラベル変更なし)
