### PR TITLE
feat(infra): A8 im@sparql ローカル Docker 環境構築 (Fuseki container)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# ColorMaster ローカル開発用環境変数 (placeholder)
+#
+# - 本ファイルは git 追跡対象、実値は .env (.gitignore 対象) に個別記述。
+# - キーのみ + ダミー値で記述する (.claude/rules/secrets.md §機械検証 / ADR-0021)。
+# - 実値を本ファイルに記載しないこと。漏洩検出は trufflehog で行う (A6 で本格化)。
+# - 使用箇所: docker-compose.yml (im@sparql ローカル Fuseki 起動、ADR-0014 / PLAN-003)。
+
+# Fuseki container の admin password。docker-compose up 前に .env で実値を設定。
+# 任意の十分長い文字列を設定し、本番 / stage の値を絶対に流用しないこと。
+FUSEKI_ADMIN_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,18 @@ data/users.db-wal
 data/*.db-journal
 
 # ----------------------------------------------------------------------------
+# im@sparql ローカル Fuseki 用 RDF 初期データ (PLAN-003 / SPEC-IMASPARQL-001-basic / ADR-0014)
+# ライセンス未確認のため RDF 形式は除外、.gitkeep / README.md のみ追跡。
+# ----------------------------------------------------------------------------
+data/imasparql/*.ttl
+data/imasparql/*.nq
+data/imasparql/*.rdf
+data/imasparql/*.nt
+data/imasparql/tdb2/
+!data/imasparql/.gitkeep
+!data/imasparql/README.md
+
+# ----------------------------------------------------------------------------
 # Secrets / Credentials (ADR 0021 / secrets.md)
 # ----------------------------------------------------------------------------
 .env

--- a/data/imasparql/README.md
+++ b/data/imasparql/README.md
@@ -1,0 +1,66 @@
+---
+id: data-imasparql-readme
+title: data/imasparql/ ディレクトリ
+status: living
+last_updated: 2026-05-19
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+related_specs:
+  - SPEC-IMASPARQL-001-basic
+---
+
+# data/imasparql/ ディレクトリ
+
+> **5 行以内 summary**: ローカル Fuseki container (`docker-compose.yml`) が read-only でマウントする
+> RDF 初期データの配置先。本ディレクトリには `.gitkeep` と本 README のみが git 追跡され、
+> RDF データファイル (`*.ttl` / `*.nq` / `*.rdf` / `*.nt`) はライセンス未確認のため `.gitignore`
+> で除外する (ADR-0014 §Negative)。開発者が手動で配置し、Fuseki 管理 UI 経由で load する。
+
+## 役割
+
+- ローカル開発時に Apache Jena Fuseki container に投入する RDF 初期データのステージング領域
+- `docker-compose.yml` の `volumes` で `/staging:ro` (read-only) としてマウントされる
+- placeholder として `.gitkeep` と本 README のみが git で追跡される
+
+## 配置するファイル
+
+| 種別 | パターン | git 追跡 | 用途 |
+|---|---|---|---|
+| Turtle | `*.ttl` | 除外 (`.gitignore`) | 主要な RDF 初期データ形式 |
+| N-Quads | `*.nq` | 除外 | 名前空間付き quad 形式 |
+| RDF/XML | `*.rdf` | 除外 | XML シリアライゼーション |
+| N-Triples | `*.nt` | 除外 | プレーン triple 形式 |
+| placeholder | `.gitkeep` | 追跡 | ディレクトリ存在保証 |
+| README | `README.md` | 追跡 | 本ファイル |
+
+## データ取得手順
+
+本 PR (PLAN-003) では **データ取得スクリプトを提供しない**。開発者は以下のいずれかの手順で
+データを配置する:
+
+1. **im@sparql 公式 RDF (`imas/imasparql` GitHub repository 等) からの取得**: ライセンス確認後、
+   `*.ttl` を本ディレクトリにコピー。ライセンス確認は ADR-0014 §Negative / `docs/harness/plan.md`
+   R-9 を参照 (A8 後続 Plan で seed スクリプト整備時に再確認)。
+2. **ダミー RDF データの自作**: SPARQL クエリ動作確認のみが目的なら、最小限の triple を
+   `sample.ttl` 等として手動作成 (一部の `imas:Idol` インスタンスのみ)。
+3. **公開 endpoint からの `CONSTRUCT` クエリ抽出**: 公開 endpoint
+   (https://sparql.crssnky.xyz) に `CONSTRUCT { ?s ?p ?o } WHERE { ... }` を投げて結果を
+   `.ttl` で保存。倫理的負荷の観点から多量取得は避ける。
+
+詳細手順 (Fuseki 管理 UI 経由の load / API 経由の upload) は `docs/runbooks/local-imasparql.md`
+§dataset 投入手順 を参照。
+
+## ライセンス上の注意
+
+- im@sparql の RDF データは **個別ライセンス確認が必要** (`docs/harness/plan.md` R-9)
+- 本 PR ではライセンス未確認のため RDF データ自体を git 追跡しない方針
+- 商用利用 / 二次配布の場合は元データの利用規約を確認
+
+## 関連
+
+- ADR-0007 (im@sparql upstream-driven 同期)
+- ADR-0014 (Fuseki Docker 採用)
+- SPEC-IMASPARQL-001-basic (本ディレクトリの位置付け)
+- `docs/runbooks/local-imasparql.md` (起動 / 投入手順)
+- `.claude/rules/sparql.md` (SPARQL クエリ実装規約)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# im@sparql ローカル Docker 環境 (REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 / ADR-0014)
+#
+# - Apache Jena Fuseki 公式 Docker image を localhost:3030 で起動する。
+# - admin password は環境変数 FUSEKI_ADMIN_PASSWORD で渡し、本 YAML には hardcode しない (ADR-0021)。
+# - RDF 初期データは data/imasparql/ に開発者が手動配置する (placeholder / git 除外、ADR-0014 §決定)。
+# - 起動 / 接続確認手順は docs/runbooks/local-imasparql.md を参照。
+# - 公開 endpoint との切替 / Testcontainers 統合は A8 後続 Plan のスコープ (本 PR は触れない)。
+
+services:
+  fuseki:
+    # image tag を明示固定 (latest 不使用、Renovate docker manager 対象)。
+    # 採用根拠: stain/jena-fuseki は広く使われる Fuseki Docker image、最新メンテ状況を
+    # docs/runbooks/local-imasparql.md で再確認しつつ運用する (Open Question 解決まで)。
+    image: stain/jena-fuseki:4.10.0
+    container_name: colormaster-fuseki
+    restart: unless-stopped
+    # localhost にのみバインドし、他ホストから到達できないようにする (本番混入予防)。
+    ports:
+      - "127.0.0.1:3030:3030"
+    environment:
+      # admin password は .env (gitignore 対象) 経由で渡す。.env.example に placeholder。
+      ADMIN_PASSWORD: ${FUSEKI_ADMIN_PASSWORD:?FUSEKI_ADMIN_PASSWORD must be set in .env (see .env.example)}
+      # in-memory dataset を 1 つ起動 (default)。
+      # TDB2 永続化が必要な場合は volumes セクション + FUSEKI_DATASET 等のフラグで切替 (runbook 参照)。
+      FUSEKI_DATASET_1: imasparql
+    volumes:
+      # RDF 初期データを read-only でマウント (開発者が data/imasparql/ に *.ttl 等を配置)。
+      # ライセンス確認前の RDF データは .gitignore で除外済 (.gitkeep / README.md のみ git 追跡)。
+      - ./data/imasparql:/staging:ro
+    healthcheck:
+      # 管理 UI トップが 200 を返すかを 30 秒ごとにチェック。
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3030/$$/ping || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+# Volumes / networks は本 PR では明示宣言しない (default network で十分、TDB2 永続化は別 Plan)。

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -17,6 +17,7 @@ last_updated: 2026-05-19
 |---|---|---|---|---|---|
 | PLAN-001 | ADR 0001-0027 一括起票 | chore | in-progress | EPIC-000 | 2026-05-17 |
 | [PLAN-002](PLAN-002-3-axis-eval-for-harness-meta-evolution.md) | harness-meta / harness-evolution 改修 PR の 3 軸定量評価フレーム導入 | harness | completed | — | 2026-05-19 |
+| [PLAN-003](PLAN-003-a8-imasparql-docker.md) | A8 im@sparql ローカル Docker 環境構築 (Fuseki container) | feature-request | in-progress | — | 2026-05-19 |
 
 ## ステータス語彙
 

--- a/docs/plans/PLAN-003-a8-imasparql-docker.md
+++ b/docs/plans/PLAN-003-a8-imasparql-docker.md
@@ -1,0 +1,121 @@
+---
+id: PLAN-003
+title: A8 im@sparql ローカル Docker 環境構築 (Fuseki container)
+type: feature-request
+status: in-progress
+related_pr: null
+related_epic: null
+related_specs:
+  - SPEC-IMASPARQL-001-basic
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+  - ADR-0021
+expected_modules:
+  - docker-compose.yml
+  - docs/runbooks/local-imasparql.md
+  - data/imasparql/
+  - .gitignore
+  - .env.example
+created_at: 2026-05-19
+completed_at: null
+promoted_to: null
+---
+
+# A8 im@sparql ローカル Docker 環境構築 (Fuseki container)
+
+> **5 行以内 summary**: REQ-001 / SPEC-IMASPARQL-001-basic を実装する単一 PR。
+> Apache Jena Fuseki container を `docker-compose.yml` で起動可能にし、RDF データディレクトリ
+> placeholder と運用 runbook を整備する。Backend Kotlin module は touch せず、Backend
+> endpoint 切替 / Testcontainers 統合 / RDF seed 自動取得は A8 後続 Plan に分離して
+> スコープを 1 PR 完結に保つ。
+
+## 目的
+
+ADR-0014 を実体化する Phase A8 の最小 PR として、im@sparql 公開 endpoint 非依存で
+SPARQL クエリを試行・テストできるローカル環境を構築する。本 PR は infra (compose / runbook)
+のみで完結し、Kotlin module には触れない。
+
+## 背景
+
+`backend/cli/src/main/kotlin/net/subroh0508/colormaster/backend/cli/imasparql/Constants.kt:3`
+で `HOSTNAME = "sparql.crssnky.xyz"` が hardcode されており、公開 endpoint への依存が
+固定化されている。ADR-0014 が公開 endpoint からの切り離しを意思決定済 (2026-05-17)、
+roadmap A8 として `docker-compose.yml` + `docs/runbooks/local-imasparql.md` + `backend/**`
+の Fuseki ローカル環境を予定 (`docs/harness/plan.md:1540`, `docs/harness/roadmap.md` A8 行)。
+
+本 PR では `backend/**` を意図的に touch しない。endpoint 切替 / Testcontainers 統合 /
+seed スクリプト自動化は別 Plan に切り出し、本 PR を「ゼロから 5 分で Fuseki が起動できる」
+状態に絞り込む。
+
+## アプローチ
+
+1. **要件 / 基本設計起票** (本 PR 前提): `docs/requirements/REQ-001-imasparql-local-docker.md` +
+   `docs/specifications/basic/SPEC-IMASPARQL-001-basic.md` + `docs/requirements/INDEX.md`
+   を新規配置。詳細設計は本 PR では起票しない (Kotlin module touch ゼロのため対象なし、
+   §「単純な docker 環境構築は基本設計まで」判断)。
+2. **docker-compose.yml 起草**: project root に Fuseki service 定義。image は
+   `stain/jena-fuseki` 系 (Open Question で最終確定)、port `3030:3030`、`data/imasparql/`
+   を read-only volume mount、`FUSEKI_ADMIN_PASSWORD` を環境変数経由で受領。
+3. **.env.example 起草**: `FUSEKI_ADMIN_PASSWORD=changeme` 等 placeholder を配置。
+   実値は `.gitignore` 対象の `.env` に開発者ごとに記録する規約。
+4. **data/imasparql/ placeholder 配置**: `.gitkeep` + `README.md` (RDF データ取得の手引き)。
+5. **`.gitignore` 拡張**: `data/imasparql/*.ttl` / `*.nq` / `*.rdf` / `*.nt` を除外、
+   `!data/imasparql/.gitkeep` / `!data/imasparql/README.md` を whitelist として保持。
+6. **runbook 起草**: `docs/runbooks/local-imasparql.md` に「前提 / 初回セットアップ /
+   起動 / 接続確認 / dataset 投入 / 停止 / トラブルシュート / 関連リンク」の節を整備。
+7. **local-development.md 参照更新**: §6 の「現時点では未整備」を「`docs/runbooks/local-imasparql.md` 参照」に置換。
+8. **動作確認**: `docker-compose config 2>&1` で YAML syntax 検証 (実 `docker compose up`
+   は CI 環境制約 / 実体取得 RDF 未配置のため skip、PR description に注記)。
+
+## 受け入れ基準
+
+- [ ] AC-1: `docker-compose config` が syntax error なしで成功する
+- [ ] AC-2: `docker-compose.yml` に admin password / 認証情報の hardcode が含まれない
+      (`grep -iE "password.*=.*[^$]" docker-compose.yml` で実値検出なし)
+- [ ] AC-3: `data/imasparql/.gitkeep` と `data/imasparql/README.md` が配置され、git で追跡される
+- [ ] AC-4: `.gitignore` に `data/imasparql/*.ttl` / `*.nq` / `*.rdf` / `*.nt` の除外パターンが追加され、
+      `.gitkeep` / `README.md` の whitelist が live
+- [ ] AC-5: `docs/runbooks/local-imasparql.md` が「前提 / 起動 / 接続確認 / dataset 投入 / 停止 / トラブルシュート」の節を備える
+- [ ] AC-6: `backend/**` 配下の既存ファイルが一切 touch されない (`git diff backend/` が空)
+- [ ] AC-7: `docs/runbooks/local-development.md` §6 から `docs/runbooks/local-imasparql.md` への参照リンクが live link になる
+- [ ] AC-8: REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 が双方向リンクで整合し、frontmatter `related_*` が block 形式で記述される
+
+## スコープ外
+
+- Backend / CLI `ImasparqlApiClient` の endpoint 切替実装 (`IMASPARQL_ENDPOINT_URL`)
+- Testcontainers 統合 / Backend integration test の Fuseki 接続実装
+- RDF 初期データ取得スクリプト (`scripts/seed-imasparql.sh`)、ライセンス確認 (`docs/harness/plan.md` R-9)
+- CI 上での Fuseki 自動起動
+- 公開 endpoint と Fuseki の自動 fallback ロジック
+- 上記はすべて A8 後続 Plan に分離する (本 PR は 1 PR 完結維持のため範囲を明確化)
+
+## ロールバック手順
+
+外部依存は Docker image (`stain/jena-fuseki`) のみ。Image 取得は PR merge 後の
+開発者ローカル操作のため、リポジトリ側は `git revert <merge-commit>` で完全復元可能。
+復元後の確認:
+
+1. `git revert <pr-merge-commit>` で本 PR の commit 群を打ち消し
+2. `docker compose config 2>&1` を実行すると `docker-compose.yml` が無いため "no configuration file" となる
+3. `data/imasparql/` ディレクトリ削除、`.gitignore` 該当行削除、runbook 削除を merge commit が含むため自動復元
+4. 開発者ローカルの `.env` (個人作成) は git 管理外、必要に応じて手動削除
+5. `docs/runbooks/local-development.md` §6 が「未整備」表記に戻ることを確認
+
+## メモ
+
+- 詳細設計 `SPEC-IMASPARQL-001-detail` を本 PR で起票しない判断: 本 PR は Kotlin module
+  touch ゼロ / docker-compose + runbook のみで完結し、モジュール責務 / 状態遷移 / 例外
+  パターンを Kotlin 視点で記述する対象が存在しないため (SPEC-IMASPARQL-001-basic §9 参照)。
+  Phase B-C で Backend integration test + Testcontainers + endpoint 切替を本格化する
+  別 Plan / SPEC で詳細設計を起こす方針。
+- `docs/requirements/INDEX.md` を本 PR で新規作成 (旧来 README.md のみで運用、初回 REQ
+  起票につき索引が必要、`.claude/skills/feature-request/SKILL.md` §Gotchas 末尾の
+  「初回起動時に作成」規約に従う)。
+- `.gitignore` の既存 `*.db` 規約 (`db-protection.md` 由来) と衝突しないことを確認:
+  Fuseki TDB2 永続化は本 PR ではオプション扱い (default in-memory)、TDB2 を有効化する
+  場合の data volume は `data/imasparql/tdb2/` 配下で完結し `*.db` 衝突なし。
+- Renovate 連携: `docker-compose.yml` の image tag を明示固定 (`latest` 不使用) し、
+  将来 Renovate `docker` manager で自動 PR 対象とできる形にしておく。
+- code-reviewer security aspect: admin password hardcode 検出 / port localhost 限定の
+  2 点を重点レビュー対象として明記。

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -1,0 +1,36 @@
+---
+id: requirements-index
+title: 要件 (REQ-NNN) 一覧
+status: living
+last_updated: 2026-05-19
+---
+
+# 要件 (REQ-NNN) 一覧
+
+> **5 行以内 summary**: 機能要件 (`REQ-NNN-<slug>.md`) の索引。1 機能 = 1 ファイルで管理し、
+> 採番は連番 3 桁ゼロパディング。WHY / WHAT のみを記述し HOW (実装手段) は
+> `docs/specifications/{basic,detail}/` に分離する。起票は `feature-request` Skill 経由、
+> 詳細は `docs/requirements/README.md` を参照。
+
+## 一覧
+
+| REQ ID | タイトル | status | related_specs | related_plans | 起票日 |
+|---|---|---|---|---|---|
+| [REQ-001](REQ-001-imasparql-local-docker.md) | im@sparql ローカル Docker 環境 | proposed | SPEC-IMASPARQL-001-basic | PLAN-003 | 2026-05-19 |
+
+## ステータス語彙
+
+| 値 | 意味 |
+|---|---|
+| `proposed` | 起票済み、未着手 / 実装着手前 |
+| `in-progress` | 実装中 (Plan / Epic が `in-progress`) |
+| `accepted` | 実装完了、Spec として安定運用 |
+| `superseded` | 後継要件に置換 (frontmatter で後継 ID を指す) |
+| `abandoned` | 取り下げ |
+
+## 関連
+
+- `docs/requirements/README.md` (テンプレ / 運用規約)
+- `docs/requirements/template.md`
+- `.claude/skills/feature-request/SKILL.md`
+- `.claude/rules/docs-structure.md`

--- a/docs/requirements/REQ-001-imasparql-local-docker.md
+++ b/docs/requirements/REQ-001-imasparql-local-docker.md
@@ -1,0 +1,156 @@
+---
+id: REQ-001
+title: im@sparql ローカル Docker 環境
+status: proposed
+related_specs:
+  - SPEC-IMASPARQL-001-basic
+related_epics: []
+related_plans:
+  - PLAN-003
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+created_at: 2026-05-19
+updated_at: 2026-05-19
+---
+
+# im@sparql ローカル Docker 環境
+
+> **5 行以内 summary**: ColorMaster の Backend / CLI が依存する im@sparql 公開 SPARQL endpoint
+> (https://sparql.crssnky.xyz) をローカル開発・テストから切り離すための要件定義。
+> Apache Jena Fuseki を `docker-compose` で起動し、開発者と AI Coding Agent が
+> オフラインかつ deterministic に SPARQL クエリを試行できる環境を構築する。
+> 本要件は ADR-0014 を実体化する Phase A8 の出発点。
+
+## 1. 概要 / 目的 / 背景
+
+ColorMaster は im@sparql 公開 endpoint からアイドル情報マスタを同期する
+(ADR-0007 / ADR-0010)。`backend/cli/.../imasparql/ImasparqlApiClient.kt` は
+`https://sparql.crssnky.xyz` を直接叩く構成のため、ローカル開発と Backend integration
+test が外部稼働状況に依存し flaky 化するリスクがある (ADR-0014 コンテキスト参照)。
+
+| 項目 | 内容 |
+|---|---|
+| 目的 | im@sparql クエリの試行とテストを公開 endpoint 非依存で実施できる環境を整備する |
+| 背景 | 公開 endpoint の稼働揺れ / 外部負荷の倫理的懸念 / オフライン開発不可 (ADR-0014 §コンテキスト) |
+| 期待効果 | integration test の deterministic 化、開発者の試行錯誤自由度向上、公開 endpoint への負荷ゼロ |
+
+## 2. ステークホルダー / アクター
+
+| アクター | 役割 | 主要なゴール |
+|---|---|---|
+| Backend 開発者 (subroh0508) | im@sparql クエリ / Backend integration test 実装 | 公開 endpoint 非依存でクエリ動作確認 |
+| AI Coding Agent (Claude Code) | implementation-workflow Phase 3 でクエリ起草・検証 | docs/runbooks/local-imasparql.md の手順で再現可能に Fuseki 起動 |
+| Renovate / dependency-upgrade Skill | Fuseki Docker image の version bump | image tag の固定 + 検証手順の維持 |
+
+## 3. スコープ
+
+### 含む
+
+- `docker-compose.yml` (project root) に Fuseki service 定義 (Apache Jena Fuseki 公式 Docker image を採用)
+- ローカル開発者向け運用 runbook `docs/runbooks/local-imasparql.md` の整備 (起動 / 停止 / 接続確認 / トラブルシュート)
+- RDF 初期データ用ディレクトリ `data/imasparql/` の placeholder 配置 (`.gitkeep` + `README.md`)
+- `.gitignore` に RDF データファイル (`*.ttl` / `*.nq` / `*.rdf` / `*.nt`) の除外規約を追加 (ライセンス上 commit しないため)
+- Fuseki admin password を環境変数経由で渡す規約 (`.env.example` placeholder で運用)
+
+### 含まない (スコープ外)
+
+- Backend / CLI コード (`backend/cli/.../imasparql/ImasparqlApiClient.kt` 等) の endpoint 切替実装 (別 Plan)
+- Testcontainers 統合 (ADR-0014 §決定で言及済、A8 後続 Plan で実装)
+- RDF 初期データの実体取得 / 投入スクリプト (`scripts/seed-imasparql.sh`、A8 後続 Plan)
+- CI 上での Fuseki 起動 (現状は手動 / Phase B-C の integration test 本格化と連動)
+- 公開 endpoint と Fuseki の自動切替ロジック (環境変数 `IMASPARQL_ENDPOINT_URL` 対応は別 Plan)
+
+## 4. ユースケース概要
+
+```mermaid
+graph LR
+    Dev((Backend 開発者))
+    Agent((AI Coding Agent))
+    UC1[UC-1 Fuseki 起動 / 停止]
+    UC2[UC-2 SPARQL クエリ動作確認]
+    UC3[UC-3 RDF 初期データ投入]
+    Dev --> UC1
+    Dev --> UC2
+    Dev --> UC3
+    Agent --> UC1
+    Agent --> UC2
+```
+
+| UC ID | 名称 | 事前条件 | 事後条件 |
+|---|---|---|---|
+| UC-1 | Fuseki 起動 / 停止 | Docker Desktop 起動 / `docker-compose.yml` 存在 | `http://localhost:3030` で Fuseki 管理 UI / SPARQL endpoint が応答 |
+| UC-2 | SPARQL クエリ動作確認 | UC-1 完了 / dataset 投入済 | SPARQL `SELECT` で期待件数のレスポンスを得る |
+| UC-3 | RDF 初期データ投入 | UC-1 完了 / `data/imasparql/*.ttl` 等が配置済 | dataset がメモリ / ファイルに load 済 |
+
+## 5. 機能要件 (FR)
+
+| FR ID | 機能名 | 説明 | 優先度 | 関連 UC |
+|---|---|---|---|---|
+| FR-1 | docker-compose で Fuseki 起動 | `docker compose up -d fuseki` で Apache Jena Fuseki が起動し、SPARQL endpoint が `http://localhost:3030/<dataset>/query` で応答する | must | UC-1 |
+| FR-2 | 管理者認証の安全な扱い | Fuseki admin password を環境変数経由で渡し、`docker-compose.yml` に hardcode しない (`.env.example` に placeholder) | must | UC-1 |
+| FR-3 | RDF 初期データ用ディレクトリ | `data/imasparql/` を placeholder として配置、開発者が任意の `*.ttl` 等を投入できる | must | UC-3 |
+| FR-4 | RDF データの git 除外 | RDF データファイル (`*.ttl` / `*.nq` / `*.rdf` / `*.nt`) を `.gitignore` で除外、ライセンス確認前の意図しない commit を防止 | must | UC-3 |
+| FR-5 | runbook によるゼロからの再現 | `docs/runbooks/local-imasparql.md` の手順に従えば初見開発者が 5 分以内に Fuseki を起動でき、SPARQL クエリ実行まで到達する | should | UC-1, UC-2 |
+| FR-6 | 接続テスト手順の明示 | `curl -G http://localhost:3030/<dataset>/query --data-urlencode "query=..."` 等の接続確認手順を runbook に記載 | should | UC-2 |
+| FR-7 | port 競合時の代替ポート提示 | port 3030 が競合した場合のオーバーライド方法を runbook に明示 | could | UC-1 |
+
+## 6. 非機能要件 (NFR)
+
+| 区分 | 指標 | 目標値 | 計測方法 |
+|---|---|---|---|
+| 可用性 | ローカル限定、production 影響なし | — | `docker-compose.yml` は dev profile 相当の扱い |
+| 性能・拡張性 | Fuseki 起動完了までの時間 | 30 秒以内 (初回 image pull 除く) | `time docker compose up -d fuseki` |
+| 運用・保守性 | runbook の再現性 | 5 分以内にゼロから起動可能 | 開発者 / AI Agent による手順実走 |
+| 移行性 | 既存 Backend / CLI 動作非破壊 | `backend/cli` 既存 endpoint hardcode (`HOSTNAME = "sparql.crssnky.xyz"`) を一切 touch しない | `git diff backend/` で確認 |
+| セキュリティ | admin password 漏洩なし | 環境変数経由のみ、`.env*` / リポジトリ追跡なし | `git ls-files` + `.gitignore` 検証 |
+| システム環境・エコロジー | Docker Desktop 動作要件 | `docs/runbooks/local-development.md` 既存要件に追加 | 開発者環境マトリクス |
+
+## 7. 制約 / 前提
+
+- Docker Desktop (またはコンパチブルなランタイム) が開発者マシンにインストール済 (`docs/runbooks/local-development.md` §1)
+- Apache Jena Fuseki 公式 Docker image (`stain/jena-fuseki` 系または公式後継) を採用、image tag は明示固定
+- `.gitignore` の `*.db` 既存規約 (`db-protection.md` 由来) と衝突しないこと (Fuseki の TDB データは `data/imasparql/` 下に隔離)
+- 公開 im@sparql endpoint の RDF データには **個別ライセンス確認が必要** (ADR-0014 §Negative / docs/harness/plan.md R-9)。本要件では initial data 自動取得は行わず、開発者が手動投入する placeholder に留める
+- CI 環境では Fuseki を起動しない (現時点)、Phase B-C の integration test 本格化と連動
+
+## 8. 用語定義
+
+| 用語 | 説明 | 関連 |
+|---|---|---|
+| im@sparql | THE iDOLM@STER ドメイン RDF + SPARQL endpoint (https://sparql.crssnky.xyz/) | ADR-0007 / `.claude/rules/sparql.md` |
+| Apache Jena Fuseki | Java 実装の SPARQL 1.1 サーバ、公式 Docker image 提供 | ADR-0014 / https://jena.apache.org/documentation/fuseki2/ |
+| RDF | Resource Description Framework、グラフ形式の構造化データ | W3C RDF 1.1 |
+| TDB / TDB2 | Jena の永続化バックエンド | Fuseki configuration |
+| Turtle (`.ttl`) | RDF の人間可読シリアライゼーション | W3C Turtle |
+
+## 9. トレーサビリティ
+
+| FR ID | 関連 SPEC | 関連 EPIC | 関連 PLAN | 関連 ADR |
+|---|---|---|---|---|
+| FR-1 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0014 |
+| FR-2 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0021 |
+| FR-3 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0014 |
+| FR-4 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0014 |
+| FR-5 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0014 |
+| FR-6 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | ADR-0014 |
+| FR-7 | SPEC-IMASPARQL-001-basic | — | PLAN-003 | — |
+
+## 10. 受け入れ基準 (AC)
+
+- [ ] AC-1: `docker compose config` が syntax error なしで成功する (FR-1)
+- [ ] AC-2: `docker-compose.yml` に admin password / 認証情報の hardcode が含まれない (FR-2、`grep` で確認)
+- [ ] AC-3: `data/imasparql/.gitkeep` と `data/imasparql/README.md` が配置され、当該ディレクトリが git で追跡される (FR-3)
+- [ ] AC-4: `.gitignore` に `data/imasparql/*.ttl` / `*.nq` / `*.rdf` / `*.nt` の除外パターンが追加される (FR-4)
+- [ ] AC-5: `docs/runbooks/local-imasparql.md` が「前提 / 起動 / 接続確認 / dataset 投入 / 停止 / トラブルシュート」の節を備える (FR-5 / FR-6 / FR-7)
+- [ ] AC-6: `backend/**` 配下の既存ファイル (`HOSTNAME = "sparql.crssnky.xyz"` を含む) が一切 touch されないこと (`git diff backend/` が空) (NFR 移行性)
+- [ ] AC-7: `docs/runbooks/local-development.md` §6 から `docs/runbooks/local-imasparql.md` への参照リンクが live link になる (FR-5)
+
+## 11. Open Questions
+
+| 起票日 | 内容 | 暫定方針 | 解決状態 |
+|---|---|---|---|
+| 2026-05-19 | RDF 初期データの取得元 (imas/imasparql repository) のライセンス | A8 後続 Plan で確認、本要件ではデータ取得は手動・placeholder のみ | open |
+| 2026-05-19 | Fuseki Docker image tag の固定方針 (`stain/jena-fuseki` vs 公式後継) | SPEC-IMASPARQL-001-basic §7 で確定、Renovate 対象に組み込み | open |
+| 2026-05-19 | Backend / CLI の endpoint 切替 (`IMASPARQL_ENDPOINT_URL`) | 別 Plan (A8 後続) に分離、本要件のスコープ外 | open |
+| 2026-05-19 | Testcontainers 統合の本格化タイミング | Phase B-C で integration test 本格化と連動、ADR-0014 §決定で言及 | open |

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -93,7 +93,10 @@ related_adrs:
 
 ## 6. im@sparql Fuseki ローカル起動
 
-`docs/runbooks/local-imasparql.md` (A8 で本格化)。現時点では未整備。
+[`docs/runbooks/local-imasparql.md`](./local-imasparql.md) を参照 (A8 / PLAN-003 で整備)。
+`docker compose up -d fuseki` で `localhost:3030` に Fuseki container を起動できる。
+Backend / CLI の endpoint 切替 (`backend/cli/.../ImasparqlApiClient.kt` の hardcode `HOSTNAME`)
+は本 PR のスコープ外で A8 後続 Plan に分離。
 
 ## 7. Backend ローカル起動
 
@@ -116,7 +119,6 @@ related_adrs:
 
 | 持ち越し項目 | 持ち越し先 | 理由 |
 |---|---|---|
-| `docs/runbooks/local-imasparql.md` (Apache Jena Fuseki Docker 起動手順) | A8 | im@sparql 同期 Skill 本格化と連動 |
 | `docs/runbooks/backend-local.md` (Backend ローカル起動 + users.db 復元手順) | C5 | Backend 本格化と連動 |
 | `docs/runbooks/cloudflare-pages.md` (wrangler 認証 / preview デプロイ手順) | C7 | 静的配信デプロイ実装と連動 |
 | `docs/runbooks/cloud-run-deploy.md` (gcloud 認証 / Cloud Run デプロイ手順) | C7 | Backend デプロイ実装と連動 |

--- a/docs/runbooks/local-imasparql.md
+++ b/docs/runbooks/local-imasparql.md
@@ -1,0 +1,179 @@
+---
+id: runbook-local-imasparql
+title: im@sparql ローカル Fuseki Docker 環境
+status: living
+last_updated: 2026-05-19
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+  - ADR-0021
+related_specs:
+  - SPEC-IMASPARQL-001-basic
+---
+
+# im@sparql ローカル Fuseki Docker 環境
+
+> **5 行以内 summary**: 公開 im@sparql endpoint (https://sparql.crssnky.xyz) 非依存で SPARQL
+> クエリを試行できるローカル Fuseki 環境の起動 / 停止 / 接続確認 / トラブルシュート手順。
+> `docker-compose.yml` (project root) と `data/imasparql/` (RDF 初期データ配置先) と
+> 本 runbook の 3 点で運用が完結する (REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003)。
+> Backend / CLI の endpoint 切替 / Testcontainers 統合は本 runbook のスコープ外。
+
+## 1. 前提環境
+
+| ツール | バージョン (要求) | 確認コマンド |
+|---|---|---|
+| Docker Desktop (または互換ランタイム) | 24.0 以降推奨 | `docker --version` |
+| docker compose | v2 系 (`docker compose` サブコマンド形式) | `docker compose version` |
+| 空きポート | `127.0.0.1:3030` | `lsof -i :3030` (macOS / Linux) |
+
+詳細な開発環境一覧は `docs/runbooks/local-development.md` §1 を参照。
+
+## 2. 初回セットアップ
+
+1. リポジトリ root に移動
+
+   ```bash
+   cd <colormaster repo root>
+   ```
+
+2. `.env` ファイル作成 (`FUSEKI_ADMIN_PASSWORD` 設定)
+
+   ```bash
+   cp .env.example .env
+   # エディタで .env を開き FUSEKI_ADMIN_PASSWORD を任意の十分長い文字列に変更
+   ```
+
+   - `.env` は `.gitignore` 対象、個人マシン外に出さない (ADR-0021 / `.claude/rules/secrets.md`)
+   - 本番 / stage の admin password を絶対に流用しない (`@example.com` ドメインの fixture 規約と同等の隔離)
+
+3. RDF 初期データ配置 (任意、空でも Fuseki は起動)
+
+   ```bash
+   # 例: ダミー RDF を data/imasparql/sample.ttl に配置
+   # *.ttl / *.nq / *.rdf / *.nt は .gitignore 対象 (ライセンス未確認、PLAN-003 / ADR-0014)
+   ```
+
+   詳細は `data/imasparql/README.md` を参照 (取得手順 / ライセンス注意)。
+
+## 3. 起動
+
+```bash
+docker compose up -d fuseki
+```
+
+- 初回起動は image pull で数十秒〜数分かかる (image: `stain/jena-fuseki:4.10.0` を pin)
+- 2 回目以降は数秒で起動完了
+- 起動完了は `docker compose ps` の `STATUS` が `Up (healthy)` になるまで
+
+## 4. 接続確認
+
+### 4.1. 管理 UI
+
+ブラウザで以下を開く:
+
+- `http://localhost:3030/`
+- 管理者ログインは user `admin` + `FUSEKI_ADMIN_PASSWORD` で行う
+
+### 4.2. SPARQL クエリ (curl)
+
+```bash
+curl -G http://localhost:3030/imasparql/query \
+  --data-urlencode 'query=PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5' \
+  --header 'Accept: application/sparql-results+json'
+```
+
+- dataset 名は `docker-compose.yml` の `FUSEKI_DATASET_1` で指定した値 (default: `imasparql`)
+- データ未投入なら結果は 0 件、Fuseki 自体の応答確認に利用可能
+- SPARQL prefix / 規約は `.claude/rules/sparql.md` を参照
+
+### 4.3. ping endpoint (ヘルスチェック)
+
+```bash
+curl -fsS http://localhost:3030/$/ping
+```
+
+- 200 OK で `pong\n` 相当の応答 (Fuseki version により差異あり)
+
+## 5. dataset 投入手順
+
+### 5.1. Fuseki 管理 UI 経由 (推奨)
+
+1. `http://localhost:3030/` にログイン
+2. `manage datasets` で `imasparql` dataset を選択
+3. `upload data` から `*.ttl` ファイルを選択して投入
+
+### 5.2. Fuseki Admin API 経由 (CLI)
+
+```bash
+curl -X POST http://localhost:3030/imasparql/data \
+  -u admin:"$FUSEKI_ADMIN_PASSWORD" \
+  -H 'Content-Type: text/turtle' \
+  --data-binary @data/imasparql/sample.ttl
+```
+
+- `Content-Type` は形式に応じて変更 (`text/turtle` / `application/n-quads` / `application/rdf+xml`)
+- `data/imasparql/` 配下は container 内では `/staging` にマウント済 (read-only)、ホスト経由 POST と Fuseki container 内 load の両方が可能
+
+## 6. 停止
+
+```bash
+docker compose down
+```
+
+- in-memory dataset (default) は停止で揮発、再起動時は再投入が必要
+- TDB2 永続化を有効化していれば `data/imasparql/tdb2/` 配下にデータが残る (TDB2 設定は本 runbook §8 オプションを参照)
+
+## 7. トラブルシュート
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `docker compose up` でポート競合 | `127.0.0.1:3030` が他プロセス占有 | `lsof -i :3030` で原因 PID を確認、競合プロセスを停止するか `docker-compose.yml` の `ports` を `127.0.0.1:3031:3030` 等にオーバーライドする `docker-compose.override.yml` を作成 (個人ローカル、`.gitignore` 対象推奨) |
+| `FUSEKI_ADMIN_PASSWORD must be set` エラー | `.env` 未作成 or 未読込 | `.env.example` をコピーして `.env` を作成、`docker compose --env-file .env up -d fuseki` 形式の明示指定でも可 |
+| image pull 失敗 (DNS / proxy) | ネットワーク障害 / corporate proxy | `docker logout && docker login` で資格情報更新 / `~/.docker/config.json` の proxy 設定確認 / 一時的にフォールバックして公開 endpoint (https://sparql.crssnky.xyz) で代替 |
+| SPARQL クエリで 401 Unauthorized | 管理 API へ未認証アクセス | `query` endpoint は default 公開、`update` / dataset 管理 API は admin 認証必須。`curl -u admin:$FUSEKI_ADMIN_PASSWORD` 形式で再試行 |
+| dataset 未作成 (404) | `FUSEKI_DATASET_1` 未設定 / image 起動オプション未対応 | `docker compose logs fuseki` で起動ログ確認、必要なら管理 UI から手動 dataset 作成 |
+| データ load 後もクエリ結果が空 | dataset 名 / graph 名のミスマッチ | `SELECT ?g (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g` で graph 一覧確認、`FROM` / `GRAPH` 句で正しい graph を指定 |
+| 起動後すぐ unhealthy 表示 | `start_period` 未経過 | `docker-compose.yml` の `start_period: 30s` を待つ。30 秒経過後も unhealthy なら `docker compose logs fuseki` で原因確認 |
+
+## 8. オプション設定
+
+### 8.1. TDB2 永続化 (将来の Plan で本格化)
+
+本 PR (PLAN-003) では in-memory dataset を default としているが、再起動間でデータを保持したい場合は
+`docker-compose.override.yml` (個人ローカル、`.gitignore` 推奨) で以下のように上書きする
+(具体的な YAML は Fuseki image の TDB2 オプションに応じて記述):
+
+- volume を `./data/imasparql/tdb2:/fuseki/databases:rw` に変更
+- `FUSEKI_DATASET_1` を TDB2 用フラグ付きで指定
+
+TDB2 ディレクトリ (`data/imasparql/tdb2/`) は `.gitignore` で除外済 (本 PR で追加)。
+
+### 8.2. 公開 endpoint との切替
+
+`backend/cli/src/main/kotlin/net/subroh0508/colormaster/backend/cli/imasparql/Constants.kt:3` で
+hardcode された `HOSTNAME = "sparql.crssnky.xyz"` を環境変数化する作業は **本 runbook のスコープ外**。
+A8 後続 Plan で `IMASPARQL_ENDPOINT_URL` 等の環境変数経由の切替を実装する (ADR-0014 §決定)。
+
+## 9. CI 上での起動可否
+
+本 PR (PLAN-003) では CI で Fuseki を起動しない方針:
+
+- 現状は ColorMaster の CI (`.github/workflows/`) に Backend integration test が未配置
+- A8 後続 Plan で Testcontainers + Fuseki integration test を本格化する際に、CI でも
+  `docker compose up` 相当を起動する方針を再評価
+
+## 10. 関連リンク
+
+- ADR-0007 (im@sparql upstream-driven 同期)
+- ADR-0014 (Fuseki Docker 採用、本 runbook の意思決定根拠)
+- ADR-0021 (Secrets 管理、admin password 環境変数化)
+- REQ-001 (`docs/requirements/REQ-001-imasparql-local-docker.md`)
+- SPEC-IMASPARQL-001-basic (`docs/specifications/basic/SPEC-IMASPARQL-001-basic.md`)
+- PLAN-003 (`docs/plans/PLAN-003-a8-imasparql-docker.md`)
+- `data/imasparql/README.md` (RDF データ取得 / ライセンス注意)
+- `.claude/rules/sparql.md` (SPARQL クエリ実装規約)
+- `.claude/rules/secrets.md` (`.env` / `.env.example` 規約)
+- `docs/runbooks/local-development.md` §6 (本 runbook へのリンク元)
+- Apache Jena Fuseki: https://jena.apache.org/documentation/fuseki2/
+- stain/jena-fuseki Docker image: https://hub.docker.com/r/stain/jena-fuseki

--- a/docs/specifications/basic/SPEC-IMASPARQL-001-basic.md
+++ b/docs/specifications/basic/SPEC-IMASPARQL-001-basic.md
@@ -1,0 +1,191 @@
+---
+id: SPEC-IMASPARQL-001-basic
+title: im@sparql ローカル Docker 環境 基本設計
+type: spec-basic
+status: proposed
+related_requirements:
+  - REQ-001
+related_detail: []
+related_epics: []
+related_plans:
+  - PLAN-003
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+  - ADR-0021
+created_at: 2026-05-19
+updated_at: 2026-05-19
+---
+
+# im@sparql ローカル Docker 環境 基本設計
+
+> **5 行以内 summary**: REQ-001 を実体化する基本設計。Apache Jena Fuseki 公式 Docker image を
+> `docker-compose.yml` で起動し、RDF 初期データ用ディレクトリと runbook で運用フローを規定する。
+> Backend / CLI Kotlin module は touch しないため、本基本設計に対応する詳細設計 (モジュール責務)
+> は不要。Backend endpoint 切替は別 Plan のスコープ。コード断片は本文に書かない (§4.6.1)、
+> 具体的な YAML / シェルは `docker-compose.yml` / `docs/runbooks/local-imasparql.md` を SoT とする。
+
+## 1. 概要 (5 行以内サマリ)
+
+ADR-0014 で意思決定済の「im@sparql ローカル Fuseki」を Phase A8 の最小単位で実体化する基本設計。
+構成は `docker-compose.yml` (Fuseki service) + `data/imasparql/` (RDF 初期データ配置先、git 除外) +
+`docs/runbooks/local-imasparql.md` (運用手順) の 3 点セット。Testcontainers 統合 / Backend endpoint
+切替 / RDF seed スクリプトは本 SPEC のスコープ外で、A8 後続 Plan に分離する。
+
+## 2. システム構成
+
+```mermaid
+graph LR
+    Dev[Backend 開発者 / AI Agent]
+    Compose[docker-compose.yml]
+    Fuseki[(Apache Jena Fuseki<br/>container)]
+    Data[data/imasparql/<br/>RDF 初期データ]
+    Runbook[docs/runbooks/<br/>local-imasparql.md]
+    Env[.env<br/>FUSEKI_ADMIN_PASSWORD]
+    Dev --> Compose
+    Dev --> Runbook
+    Compose --> Fuseki
+    Data -.volume mount.-> Fuseki
+    Env -.environment.-> Fuseki
+```
+
+| 構成要素 | 役割 | 関連 ADR |
+|---|---|---|
+| `docker-compose.yml` | Fuseki container 起動定義 (image / port / volume / env) | ADR-0014 |
+| Apache Jena Fuseki container | SPARQL 1.1 endpoint + 管理 UI を `localhost:3030` で提供 | ADR-0014 |
+| `data/imasparql/` | RDF 初期データ (`*.ttl` / `*.nq` 等) の配置先、git 除外 | ADR-0014 |
+| `.env` (開発者ローカル) | `FUSEKI_ADMIN_PASSWORD` 等の秘密情報、git 除外 | ADR-0021 |
+| `docs/runbooks/local-imasparql.md` | 起動 / 接続確認 / トラブルシュート手順の SoT | ADR-0014 |
+
+## 3. 機能一覧と要件マッピング
+
+| SPEC-ID | 機能名 | 関連 FR ID | 関連 AC ID |
+|---|---|---|---|
+| SPEC-IMASPARQL-001-1 | docker-compose による Fuseki 起動 | FR-1 | AC-1 |
+| SPEC-IMASPARQL-001-2 | admin password 環境変数化 | FR-2 | AC-2 |
+| SPEC-IMASPARQL-001-3 | RDF データディレクトリ placeholder | FR-3 | AC-3 |
+| SPEC-IMASPARQL-001-4 | RDF データの git 除外 | FR-4 | AC-4 |
+| SPEC-IMASPARQL-001-5 | runbook 整備 (起動 / 接続 / トラブルシュート) | FR-5 / FR-6 / FR-7 | AC-5 / AC-7 |
+| SPEC-IMASPARQL-001-6 | 既存 Backend 非破壊 | NFR 移行性 | AC-6 |
+
+## 4. 業務フロー
+
+```mermaid
+sequenceDiagram
+    actor Dev as 開発者 / AI Agent
+    participant Env as .env
+    participant Compose as docker compose
+    participant Fuseki as Fuseki container
+    participant Data as data/imasparql/
+
+    Dev->>Env: .env.example をコピーして FUSEKI_ADMIN_PASSWORD 設定
+    Dev->>Data: RDF 初期データを配置 (任意)
+    Dev->>Compose: docker compose up -d fuseki
+    Compose->>Fuseki: image pull / container 起動
+    Fuseki->>Data: volume mount で参照
+    Fuseki-->>Dev: http://localhost:3030 で応答
+    Dev->>Fuseki: curl で SPARQL クエリ送信
+    Fuseki-->>Dev: SPARQL Results JSON 返却
+    Dev->>Compose: docker compose down (停止)
+```
+
+## 5. 画面遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped
+    Stopped --> Starting: docker compose up -d
+    Starting --> Running: image pull / startup 完了
+    Running --> Stopped: docker compose down
+    Running --> Failing: 起動エラー (port 競合 / image pull 失敗)
+    Failing --> Stopped: docker compose down + 修正
+```
+
+| 画面 | 状態 | 遷移トリガー |
+|---|---|---|
+| Fuseki 管理 UI (`http://localhost:3030`) | Stopped / Running | container 起動 / 停止 |
+| SPARQL endpoint (`http://localhost:3030/<dataset>/query`) | Running 時のみ応答 | container 起動完了 |
+
+## 6. データモデル (論理)
+
+```mermaid
+erDiagram
+    FUSEKI_CONTAINER ||--o{ DATASET : "hosts"
+    DATASET ||--o{ RDF_TRIPLE : "contains"
+    RDF_TRIPLE {
+      string subject
+      string predicate
+      string object
+    }
+    DATASET {
+      string name
+      string type "TDB2 or in-memory"
+    }
+    FUSEKI_CONTAINER {
+      string image_tag
+      int port
+      string admin_user
+    }
+```
+
+| エンティティ | 属性 | 制約 | 説明 |
+|---|---|---|---|
+| FUSEKI_CONTAINER | image_tag / port / admin_user / admin_password | image_tag 固定、admin_password は環境変数経由 | docker container の論理表現 |
+| DATASET | name / type | name は URL-safe、type は in-memory / TDB2 のいずれか | Fuseki が hosting する SPARQL dataset |
+| RDF_TRIPLE | subject / predicate / object | RDF 1.1 準拠 | 開発者が `data/imasparql/*.ttl` 経由で投入 |
+
+物理的な dataset 名や Fuseki configuration 詳細は `docker-compose.yml` / `docs/runbooks/local-imasparql.md` を SoT として参照。
+
+## 7. 外部 I/F 一覧
+
+詳細リクエスト/レスポンス JSON は SPARQL 1.1 Protocol (https://www.w3.org/TR/sparql11-protocol/) を Single Source of Truth として参照。
+
+| I/F 名 | 種別 | エンドポイント | 入力概要 | 出力概要 | 関連 ADR |
+|---|---|---|---|---|---|
+| SPARQL Query | HTTP GET / POST | `http://localhost:3030/<dataset>/query` | SPARQL `SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE` | SPARQL Results JSON / Turtle | ADR-0014 |
+| SPARQL Update | HTTP POST | `http://localhost:3030/<dataset>/update` | SPARQL `INSERT` / `DELETE` | 204 No Content | ADR-0014 |
+| Fuseki 管理 API | HTTP GET / POST | `http://localhost:3030/$/server` 等 | 管理操作 (dataset 作成 / 削除) | JSON | ADR-0014 |
+| 管理 UI | HTTP GET (browser) | `http://localhost:3030/` | — | HTML | ADR-0014 |
+
+本 PR では `backend/cli/.../imasparql/ImasparqlApiClient.kt` (`HOSTNAME = "sparql.crssnky.xyz"`) との接続切替は **行わない** (REQ-001 スコープ外 / 別 Plan)。
+
+## 8. エラーケース / 例外パターン
+
+| ケース | 発生条件 | UX | ログ | メトリクス |
+|---|---|---|---|---|
+| port 3030 競合 | 別プロセスが占有 | runbook §トラブルシュートに代替 port 設定方法を明示 | `docker compose up` がエラー出力 | — |
+| image pull 失敗 | ネットワーク障害 / DNS 不通 | runbook §トラブルシュートに retry / proxy 設定方法 | `docker compose` ログ | — |
+| admin password 未設定 | `.env` 未配置 | runbook §起動手順 §2 の `.env.example` コピー指示 | Fuseki 起動失敗 / default password 警告 | — |
+| RDF データ未投入 | `data/imasparql/` が空 | runbook で「データなしでも起動成功、クエリ結果は空」を明示 | — | — |
+| dataset 未作成 | Fuseki 起動後に dataset 設定なし | 管理 UI / API で dataset 作成手順を runbook に記載 | Fuseki 404 応答 | — |
+
+## 9. 受け入れ基準 (AC) ↔ テストマップ
+
+| AC ID | 内容 | 対応 SPEC-ID-detail | 期待テスト種別 |
+|---|---|---|---|
+| AC-1 | `docker-compose config` syntax 成功 | (詳細設計なし / 本 PR のみで完結) | 手動 (`docker-compose config 2>&1`) |
+| AC-2 | password hardcode なし | 同上 | 手動 (`grep -i password docker-compose.yml`) |
+| AC-3 | placeholder 配置 | 同上 | 手動 (`git ls-files data/imasparql/`) |
+| AC-4 | `.gitignore` RDF 除外追加 | 同上 | 手動 (`git check-ignore data/imasparql/sample.ttl`) |
+| AC-5 | runbook 節構成 | 同上 | 手動 (見出し review) |
+| AC-6 | backend 非破壊 | 同上 | 手動 (`git diff backend/` 空確認) |
+| AC-7 | local-development.md からの参照 live | 同上 | 手動 (link review) |
+
+詳細設計 (`SPEC-IMASPARQL-001-detail`) は本 SPEC では作成しない (本 PR は Kotlin モジュール touch ゼロ / docker-compose + runbook のみで完結するため、モジュール責務 / 状態遷移 / 例外パターンを Kotlin 視点で記述する対象が存在しない)。Phase B-C 以降で Backend integration test + Testcontainers + endpoint 切替を本格化する別 Plan / SPEC で詳細設計を起こす。
+
+## 10. 関連 ADR / リスク
+
+- ADR-0007 (im@sparql upstream-driven 同期、本 SPEC はそのテスト基盤側)
+- ADR-0014 (Apache Jena Fuseki Docker 採用、本 SPEC は ADR-0014 の Phase A8 実体化)
+- ADR-0021 (Secrets 管理、admin password の環境変数化根拠)
+- リスク: Fuseki Docker image (`stain/jena-fuseki` 系) の長期メンテナンス継続性。公式 Apache 提供 image に切替が必要になった場合は image tag を更新、Renovate 対象とする
+- リスク: RDF 初期データのライセンス未確認 (`docs/harness/plan.md` R-9)。本 SPEC では placeholder のみ、データ取得は A8 後続 Plan で著作権確認後に着手
+
+## 11. Open Questions
+
+| 起票日 | 内容 | 暫定方針 | 解決状態 |
+|---|---|---|---|
+| 2026-05-19 | Fuseki image (`stain/jena-fuseki` vs 公式 `atomgraph/fuseki` 等) の最終選定 | runbook 起草時に最新メンテ状況を再確認、当面は広く使われる `stain/jena-fuseki` 系 | open |
+| 2026-05-19 | Fuseki dataset の永続化方式 (in-memory vs TDB2 volume) | runbook と `docker-compose.yml` で in-memory を default、TDB2 永続化はオプション節として記載 | open |
+| 2026-05-19 | CI 上での Fuseki 起動可否 | 現時点では CI 起動しない、A8 後続 Plan で Testcontainers 統合と合わせて再評価 | open |
+| 2026-05-19 | docker-compose v1 (`docker-compose`) と v2 (`docker compose`) の表記統一 | runbook 内では v2 (`docker compose`) を推奨、v1 系記法は補足 | open |


### PR DESCRIPTION
## 概要

ADR-0014 (im@sparql ローカル Fuseki Docker) を Phase A8 の最小単位で実体化する PR。
Backend Kotlin module は touch せず、infra (docker-compose + runbook + RDF placeholder) のみで
1 PR 完結のスコープに絞り込む。

## 関連

- Plan: PLAN-003 (`docs/plans/PLAN-003-a8-imasparql-docker.md`)
- 要件: REQ-001 (`docs/requirements/REQ-001-imasparql-local-docker.md`)
- 基本設計: SPEC-IMASPARQL-001-basic (`docs/specifications/basic/SPEC-IMASPARQL-001-basic.md`)
- 詳細設計: 起票しない (Kotlin module touch ゼロのため、A8 後続 Plan で起こす方針、PLAN-003 §メモ)
- ADR: ADR-0014 (Fuseki Docker 採用) / ADR-0007 (im@sparql 同期) / ADR-0021 (Secrets 管理)
- 関連 Issue: —

## 変更内容

| 区分 | パス | 変更 |
|---|---|---|
| docs | `docs/requirements/INDEX.md` | 新規 (初回 REQ 起票) |
| docs | `docs/requirements/REQ-001-imasparql-local-docker.md` | 新規 (要件、11 セクション) |
| docs | `docs/specifications/basic/SPEC-IMASPARQL-001-basic.md` | 新規 (基本設計、11 セクション) |
| docs | `docs/plans/PLAN-003-a8-imasparql-docker.md` | 新規 (Plan) |
| docs | `docs/plans/INDEX.md` | PLAN-003 行追加 |
| docs | `docs/runbooks/local-imasparql.md` | 新規 (起動 / 接続確認 / dataset 投入 / 停止 / トラブルシュート) |
| docs | `docs/runbooks/local-development.md` | §6 を未整備 → live link に更新 + 持ち越し表から該当行削除 |
| build | `docker-compose.yml` | 新規 (stain/jena-fuseki:4.10.0、localhost:3030 bind、`.env` 経由 admin password) |
| chore | `.env.example` | 新規 (`FUSEKI_ADMIN_PASSWORD` placeholder) |
| chore | `.gitignore` | `data/imasparql/*.ttl` 等 RDF 形式除外 + `.gitkeep` / `README.md` whitelist 追加 |
| chore | `data/imasparql/.gitkeep` | 新規 (placeholder) |
| chore | `data/imasparql/README.md` | 新規 (RDF データ取得手順 / ライセンス注意) |

`backend/**` は意図的に touch ゼロ (`git diff backend/` 空、AC-6)。

## 受け入れ基準 (AC)

- [x] AC-1: `docker compose config` syntax 成功 (`FUSEKI_ADMIN_PASSWORD=testpw docker compose config` で確認、Fuseki service 1 つを `127.0.0.1:3030` で展開、`data/imasparql` を read-only mount)
- [x] AC-2: `docker-compose.yml` に password hardcode なし (`grep -nE 'password.*[:=].*[^$]' docker-compose.yml` で実値検出なし、`ADMIN_PASSWORD: ${FUSEKI_ADMIN_PASSWORD:?...}` 形式のみ)
- [x] AC-3: `data/imasparql/.gitkeep` + `README.md` が配置、git で追跡 (`git status` で `?? data/imasparql/` の中身が 2 ファイル)
- [x] AC-4: `.gitignore` に `data/imasparql/*.{ttl,nq,rdf,nt}` 除外追加、`git check-ignore data/imasparql/sample.{ttl,nq,rdf,nt}` で全て ignored、`.gitkeep` / `README.md` は exit 1 (NOT ignored = whitelist 成立)
- [x] AC-5: `docs/runbooks/local-imasparql.md` 節構成 (前提 / 初回セットアップ / 起動 / 接続確認 / dataset 投入 / 停止 / トラブルシュート / オプション / CI / 関連) 整備済
- [x] AC-6: `backend/**` touch なし (`git diff --stat backend/` 空)
- [x] AC-7: `docs/runbooks/local-development.md` §6 から `local-imasparql.md` への live link 設置済
- [x] AC-8: REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 が frontmatter `related_*` で双方向リンク、block 形式で記述

## テスト

- [x] `docker compose config` グリーン (syntax 検証、上記 AC-1 参照)
- [ ] `./gradlew check` グリーン (本 PR は Kotlin module touch ゼロのため Gradle 実行は AC ではなく、code-reviewer architecture aspect で確認推奨)
- [ ] 三層指標差分: A7 完了前のため空欄 (`.github/pull_request_template.md` 注記参照)
- [ ] Roborazzi baseline 比較: A10 完了前 + UI 変更なしのため対象外

## 動作確認

- ローカル `FUSEKI_ADMIN_PASSWORD=testpw docker compose config` で `127.0.0.1:3030:3030` bind + `data/imasparql:/staging:ro` mount + admin password 環境変数展開を確認済
- 実 `docker compose up -d fuseki` 起動は本 PR 単体の AC ではないが、開発者がローカルで実行する場合は image pull (`stain/jena-fuseki:4.10.0`) + `localhost:3030` 応答を runbook §3-§4 で再現可能
- CI 上での Fuseki 起動は本 PR スコープ外 (A8 後続 Plan で Testcontainers 統合と合わせて再評価)

## スクリーンショット (UI 変更時)

該当なし (infra / docs のみの変更)。

## 新規 API エンドポイント (該当時)

該当なし (`docs/api/colormaster-api.yaml` は touch しない、SPARQL endpoint は外部 protocol で OpenAPI 対象外)。

## レビュー観点

code-reviewer 4 aspect (spec-conformance / architecture / security / code-quality) で重点的に見てほしい点:

- **spec-conformance**: REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 の AC 8 項目と実装 (docker-compose / runbook / .gitignore / placeholder) の対応整合 + frontmatter block 形式 + 識別子参照の実在
- **architecture**: ADR-0014 §決定 (Fuseki Docker / Testcontainers 統合 / 環境変数切替 / 公開 endpoint 倫理) と本 PR のスコープ判断 (Kotlin module touch ゼロ + Testcontainers / endpoint 切替の A8 後続 Plan 分離) の整合
- **security**: admin password hardcode 防止 (`${FUSEKI_ADMIN_PASSWORD:?...}` 形式、`.env.example` placeholder) + port `127.0.0.1` 限定 bind (外部到達防止) + `.gitignore` に RDF データ / `.env` 含めるカバレッジ + `.claude/rules/secrets.md` 整合
- **code-quality**: `docker-compose.yml` の image tag 固定 (Renovate 対応)、healthcheck 設定、volume mount read-only 制約、runbook の手順再現性 + Markdown 表記規約 (`.claude/rules/markdown.md`)

## 仕様変更箇所 (spec-living-sync)

N/A (本 PR は新規 REQ-001 / SPEC-IMASPARQL-001-basic 起票であり、既存 SPEC の変更なし)。

## チェックリスト

- [x] `.claude/rules/` の関連規約を確認した (sparql.md / secrets.md / db-protection.md / sqlite-data-file.md / docs-structure.md / template-language.md / commit-message.md / cloud-run-deploy.md)
- [x] 要件 (REQ-001) / 基本設計 (SPEC-IMASPARQL-001-basic) を起票・更新済 (詳細設計は本 PR スコープ外)
- [ ] `@Spec("SPEC-NNN-N")` annotation 付きテスト (A7 以降、本 PR は Kotlin module touch なしのため対象外)
- [x] PII / Secrets が diff に含まれていない (`.env.example` は placeholder のみ、admin password 実値なし)
- [x] roadmap-tracker で完了根拠登録 (Plan は対象外、R-34)

## R-15 事前承認

(orchestrator pane の操作者 subroh0508) が本 PR (PLAN-003) を out-of-band approval で事前承認済 (R-15 該当)。本 agent は `gh pr merge` を実行せず、orchestrator pane が代行 merge する。
