### PR TITLE
harness: A4 ローカルポーリング機構の本格化 (pr-poller 実運用稼働 + harness-meta 起動閾値 SoT)

### DIFF
--- a/.claude/rules/harness-meta-criteria.md
+++ b/.claude/rules/harness-meta-criteria.md
@@ -96,15 +96,42 @@ Step 1 と Step 2 を同一 PR に統合する 1 段階運用は **禁止** (誤
 | 前回 harness-meta 実行からの経過日数 | 7 日 | 同上で 3 日に下げる |
 | 連続実行間隔 | 24 時間 | 緊急時のみ 6 時間に下げる (debug / 手動) |
 
-上書きは `.claude/rules/harness-meta-criteria.md` 本ファイル末尾の「実行時パラメータ」セクション (placeholder、将来追加) または `pr-poller` 起動時の引数で指定。
+上書きは本ファイル §実行時パラメータ (本格化済、A4) または `pr-poller` 起動時の引数で指定。
 
-## 実行時パラメータ (placeholder、A4 Skill 本格化時に拡充予定)
+## 実行時パラメータ (A4 で本格化)
 
-> **注**: 本セクションは pr-poller / harness-meta Skill 本格化 (A4) 時に実行時パラメータを書き込む場所として確保している placeholder。A4 完了までは空のまま維持し、本文の `(将来追加)` 参照との整合を保つ (PR #135 レトロ Try 反映)。
+> **注**: 本セクションは `pr-poller` / `harness-meta` Skill 実運用稼働 (A4) のための実行時パラメータ SoT。`.claude/skills/pr-poller/SKILL.md` §入力 / §実運用稼働手順 と本 rule §pr-poller 起動閾値 が本表を参照する (R-31、SoT 一本化)。
 
-| パラメータ名 | 既定値 | 上書き例 |
-|---|---|---|
-| _(A4 で記入)_ | _(A4 で記入)_ | _(A4 で記入)_ |
+### 既定値 + 上書き例
+
+| パラメータ名 | 既定値 | 上書き条件 | 上書き例 |
+|---|---|---|---|
+| `unprocessed_learnings_threshold` (未処理 learning 件数) | 10 件 | 重要改修 PR が直近 merge された / フェーズ ID 切替時 (A2 → A3 → A4 等) / orchestrator 明示 | 一時的に **5 件**に下げて harness-meta を前倒し起動 (PR #135 / #156 直後タイミング) |
+| `harness_meta_interval_days` (前回 harness-meta 実行からの経過日数) | 7 日 | 同上 + 連休前の集約 | 一時的に **3 日**に下げる (週次 PR を月曜日 09:00 JST にまとめ起票したい場合) |
+| `harness_meta_min_interval_hours` (連続実行間隔の最小) | 24 時間 | 緊急 debug / 手動 dogfood | 一時的に **6 時間**に下げる (A4 PR merge 後の Skill 本格化直後 dogfood) |
+| `pr_poller_stale_threshold_minutes` (lock stale 判定) | 30 分 | 長時間 dispatch を想定 (キャッチアップ batch 30+ 件) | **60 分**に延長 (`pr-poller` 起動時引数 `stale_threshold_minutes=60`) |
+| `pr_poller_lookback_default` (lookback 既定) | 24h | `$LAST_RUN` 不在時のフォールバック (`now - 7d`) で取りこぼし懸念 | **48h** に延長 (連休後の初回起動、`pr-poller` 起動時引数 `lookback=48h`) |
+| `dry_run` | false | 本 A4 PR merge 後の初回 dogfood / debug | `pr-poller` 起動時引数 `dry_run=true` (副作用なし、dispatch + learning push + harness-meta 起動を skip) |
+
+上書きは以下の 2 経路:
+
+- **本 rule §既定値 + 上書き例 を直接編集する PR**: 恒久的な閾値変更 (例: 運用熟成で 10 件 → 7 件 に下げる judgment) は本 rule を改修する harness-meta 改修 PR として起票 (`harness/<purpose>` ブランチ + `harness.md` テンプレ)
+- **`pr-poller` 起動時引数で渡す**: 一時的な上書き (`pr-poller route=manual unprocessed_learnings_threshold=5 dry_run=true` 等)、本表を参照しつつ runtime で override
+
+### dogfood 観測値 (A4 PR merge 後に追記)
+
+A4 PR (本 PR) merge 後の初回稼働で観測した実値を以下の表に記録する。観測値は `.claude/skills/pr-poller/SKILL.md` §A4 dogfood 期待値 と差分比較して、閾値妥当性 (10 件 / 7 日 / 24h) の運用熟成材料化する。
+
+| 観測項目 | A4 PR merge 時点 | 期待値 (SKILL.md §A4 dogfood 期待値) | 差分 / 備考 |
+|---|---|---|---|
+| 未処理 learning 件数 (pr-poller 起動時点) | _(dogfood で記入)_ | 0-2 件 | _(差分理由を記入)_ |
+| 未処理 merged PR (直近 7 日) | _(dogfood で記入)_ | 0-3 件 | _(同上)_ |
+| 前回 harness-meta 実行からの経過日数 | _(dogfood で記入)_ | 7 日未満 (PR #156 = A3-5 起点) | _(同上)_ |
+| harness-meta 自動起動有無 | _(dogfood で記入)_ | 起動しない見込み | _(起動した場合は閾値が低すぎた / してない場合は妥当)_ |
+| Renovate open PR 検出件数 | _(dogfood で記入)_ | 0-2 件 | _(同上)_ |
+| lock 取得 / 解放経過秒 | _(dogfood で記入)_ | 1 分以内 | _(同上)_ |
+
+dogfood が複数サイクル (CronCreate 起動 / ScheduleWakeup 起動の差分検証含む) 走った場合は、本表を縦に拡張するのではなく **新たな表として 1 サイクルずつ追記** + 観測日時 JST を明示する。3 サイクル分の観測値が揃ったら閾値の運用熟成 PR (本 rule §既定値 + 上書き例 の直接編集) を起票する。
 
 ## 改修 PR の品質基準 (採用時)
 

--- a/.claude/rules/pr-poller.md
+++ b/.claude/rules/pr-poller.md
@@ -2,7 +2,7 @@
 id: rules-pr-poller
 title: pr-poller ローカルポーリング規約
 status: stable
-last_updated: 2026-05-17
+last_updated: 2026-05-19
 paths:
   - ".claude/skills/pr-poller/**"
   - ".claude/locks/**"
@@ -86,9 +86,74 @@ related_plan: docs/harness/plan.md §5.3 / §6.2 A4 / R-11 / R-12
 
 ## A3 / A4 で本格化する MVP
 
-- **A3**: Phase 1 (merged PR → pr-retrospective) を Skill 駆動で本格化、現状は手動代替 (PR #117 / #119 / #121 の learning は手動生成)
-- **A4**: Phase 2 (Renovate ラベル PR → dependency-upgrade) を Skill 駆動で本格化、CronCreate / ScheduleWakeup の自動起動経路を追加
-- **A4**: harness-meta 自動起動閾値の機械化 (本 rule の閾値表を parse)
+- **A3 (完了、PR #167 / #168)**: Phase 1 (merged PR → `pr-retrospective`) + Phase 2 (Renovate ラベル PR → `dependency-upgrade`) を Skill 駆動で本格化
+- **A4 (本 PR で本格化)**: 3 系統起動経路 (SessionStart hook / CronCreate / ScheduleWakeup) の実運用稼働 + harness-meta 自動起動閾値の runtime override + dogfood 観測値の記録枠 (`.claude/rules/harness-meta-criteria.md` §実行時パラメータ 参照)
+- **A6 (機械化予定)**: 本 rule の閾値表を parse + Gradle カスタムタスクで stale lock 検出 + GitHub Actions で learning 起票検証 (R-12 ロスト検出)
+
+## 実運用稼働 Q&A (A4 で本格化)
+
+A4 PR (本 PR) 以降の実運用で発生し得る well-known 失敗パターンと回避策。`.claude/skills/pr-poller/SKILL.md` §実運用稼働手順 / §Gotchas と整合 (SoT は本 rule、SKILL.md は手順書側)。
+
+### Q1. lock 二重取得 (`mkdir` が EEXIST で失敗する)
+
+**症状**: `mkdir .claude/locks/pr-poller.lock` が `mkdir: cannot create directory '.claude/locks/pr-poller.lock': File exists` で失敗、Phase 1 で skip 判定。
+
+**原因 (well-known)**:
+
+- 直前の `pr-poller` 異常終了で lock が残留 (`acquired_at` が 30 分以内なら正規 skip、超えてたら stale 回収対象)
+- 3 系統 (SessionStart / CronCreate / ScheduleWakeup) のいずれかが同時刻起動して片方が EEXIST 失敗
+- 別ペイン (orchestrator pane / per-task pane) が同時刻に手動起動
+
+**回避策**:
+
+1. `cat .claude/locks/pr-poller.lock/acquired_at` で取得時刻を確認、30 分以内なら正規 skip (二重起動防止が機能している)
+2. 30 分以上前なら stale 判定 → `rm -rf .claude/locks/pr-poller.lock` + `pr-poller` 再起動
+3. `cat .claude/locks/pr-poller.lock/route` で起動経路 (manual / cron / wakeup) を確認、想定外の経路なら orchestrator (subroh0508) に通知
+
+### Q2. CronCreate 起動で `gh auth status` 失敗 (環境ロード未済)
+
+**症状**: CronCreate で起動した `pr-poller` の Phase 2 で `gh pr list` が `gh: To get started with GitHub CLI, please run: gh auth login` で失敗、連続 5 件失敗で緊急停止。
+
+**原因 (well-known)**:
+
+- Claude Code routine の起動時に `gh` の token cache が読み込まれていない (親シェルの環境変数継承漏れ)
+- GitHub token が TTL 切れ (90 日ローテーション、`.claude/rules/secrets.md` §ローテーション 参照)
+
+**回避策**:
+
+1. Skill の Phase 2 冒頭で `gh auth status` を最初に走らせて token 有効性を確認 (失敗時は連続 5 件失敗扱いで緊急停止経路に乗せる)
+2. CronCreate routine の cron 式起動コマンドに `gh auth login` を前置せず、**ローカル Claude Code セッション内で 1 度認証を済ませる** (Claude Code 内 OAuth は `.claude/oauth-tokens*` に保存、`.gitignore` で除外)
+3. TTL 切れ検出時は `docs/runbooks/secrets-rotation.md` の手順で再認証 (A6 で本格運用)
+
+### Q3. dispatch 重複 (3 系統が同 lookback で重なる)
+
+**症状**: SessionStart hook で起動した直後に CronCreate routine が 09:00 JST 起動、同じ未処理 PR# を 2 回 `pr-retrospective` に dispatch して learning ファイルが重複生成される。
+
+**原因 (well-known)**:
+
+- `.claude/locks/pr-poller.last-run` が前者で更新される前に後者が起動 (lock 排他は機能していても last-run の前進判定が間に合わない)
+- `docs/harness/learnings/*.md` の dedup が「ファイル存在チェック」のみで、in-flight (生成中) ファイルを処理済 set に含めていない
+
+**回避策**:
+
+1. **Phase 1 lock 排他で防御**: 後発側が `mkdir` EEXIST で 30 分 no-op、Phase 5 で前者が last-run 更新するまで待つ
+2. **Phase 5 で `.claude/locks/pr-poller.last-run` を lock 解放前に書く** (`.claude/skills/pr-poller/SKILL.md` §Phase 5 順序が SoT)、次回起動時の lookback 起点を確実に前進させる
+3. **dedup を 2 経路で行う**: `docs/harness/learnings/*.md` ファイル列挙 + `.claude/locks/pr-poller.processed-cache` の直近 30 日分の処理済 PR# 記録 (`SKILL.md` §Phase 3 1-2)
+
+### Q4. harness-meta 二重起動 (pr-poller 自動起動 + 人間手動起動)
+
+**症状**: 未処理 learning が閾値 10 件を超えて `pr-poller` が `harness-meta` を自動起動した直後に、orchestrator (subroh0508) が手動で `harness-meta` を起動 → `harness-meta` の改修 PR 起票処理が衝突して二重 PR 起票や提案セクション parse の race condition が発生。
+
+**原因 (well-known)**:
+
+- `harness-meta` 側の lock 排他 (`.claude/locks/harness-meta.lock`) が pr-poller 側からは見えず、pr-poller が「閾値超過 → 即起動」した直後に人間が二重起動
+- `harness-meta-criteria.md` §実行時パラメータ の `harness_meta_min_interval_hours` (24h) が「pr-poller 自動起動」のみ参照、人間手動起動は無視
+
+**回避策**:
+
+1. **`harness-meta` Skill 側で `.claude/locks/harness-meta.lock` 排他制御を担う**: pr-poller は「起動を試みる」だけで成否を問わない (`.claude/skills/pr-poller/SKILL.md` §Phase 4-4)
+2. **人間手動起動時も `harness-meta-criteria.md` §連続実行間隔 (24h) を確認**: orchestrator (subroh0508) が手動起動する前に `git log -- .claude/rules/harness-meta-criteria.md | head` で前回実行時刻を確認、24h 未満なら起動見送り or `harness_meta_min_interval_hours=6` 等の上書きを明示
+3. **pr-poller が `harness-meta` 起動結果を handoff サマリに記録**: 「起動済」「skip (lock 競合)」「skip (閾値未到達)」の 3 値で出力、人間手動起動判断の材料化
 
 ## Gotchas
 

--- a/.claude/skills/pr-poller/SKILL.md
+++ b/.claude/skills/pr-poller/SKILL.md
@@ -7,8 +7,8 @@ description: |
   CronCreate + ScheduleWakeup) に対応するため .claude/locks/pr-poller.lock で排他制御し、
   pending-fetch 項目の再走査と harness-meta 自動起動の閾値判定も担当する。
 status: active
-phase: A3
-last_updated: 2026-05-18
+phase: A4
+last_updated: 2026-05-19
 related_plan: docs/harness/plan.md §5.3 / §5.4 / §6.2 A3 / §6.2 A4
 related_rules:
   - .claude/rules/pr-poller.md
@@ -154,6 +154,89 @@ dispatch は順次 / 直列 (並列起動は Phase 4 内では行わない、各
 - `rm -rf .claude/locks/pr-poller.lock` で lock 解放
 - handoff サマリを §出力 のフォーマットで標準出力に出す
 - 異常終了時 (Phase 1-4 のいずれかで unrecoverable error): lock を解放してから orchestrator 通知 + 当該 PR を次回再試行に回す (lock 残留は次回 stale 判定で自動回収されるため強制不要)
+
+## 実運用稼働手順 (A4 本格化)
+
+3 系統起動経路の具体的 setup と初回 dogfood 手順。`.claude/rules/pr-poller.md` §3 系統の起動経路 + `harness-meta-criteria.md` §pr-poller 起動閾値 と整合。
+
+### 経路 1: SessionStart hook (起動時 auto-invoke)
+
+`.claude/settings.json` の `hooks.SessionStart` で Bash command を登録し、Claude Code セッション開始時に **「pr-poller 起動候補」のヒントを context に注入** する (`.claude/rules/pr-poller.md` §3 系統 / `.claude/rules/harness-meta-criteria.md` §pr-poller 起動閾値 参照)。
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -d .claude/locks/pr-poller.lock 2>/dev/null && echo '[pr-poller] lock active - skip auto-invoke' || echo '[pr-poller] no active lock - 候補: /pr-poller を起動して未処理 PR の有無を確認 (R-15 / R-37、SessionStart hint)'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- **hook の責務は context 注入のみ**: Skill の自動起動は Claude が判断 (R-15 人間 approve の代替として、Claude が「起動候補」を提示する形)
+- **lock 既存時は skip**: `mkdir` が EEXIST で失敗する経路と整合、二重起動防止 (Phase 1 §stale 判定)
+- **PII / Secrets 漏洩経路なし**: hook の stdout は固定文字列、`gh pr` / `git log` などの外部コマンドを **呼ばない** (PR# / 著者名等が context に乗らない、R-26)
+
+### 経路 2: CronCreate (日次まとめ)
+
+ローカル Claude Code routine を `CronCreate` で登録し、日次まとめ起動。`harness-meta-criteria.md` §pr-poller 起動閾値 (7 日経過、10 件閾値) と組合せて週単位の取りこぼし防止。
+
+```text
+# 例: 毎日 22:00 JST (= 13:00 UTC) に pr-poller を起動
+/schedule "0 13 * * *" /pr-poller route=cron
+```
+
+- **cron 式は UTC で記述** (CronCreate の慣行)、JST 換算は手元計算で確認
+- **route=cron を渡す**: Skill 側で経路識別 (Phase 1 lock 内 `route` 平文ファイルへ記録)
+- **環境ロードのタイミング**: Claude Code routine は起動時に `.claude/mcp.json` / `.claude/settings.json` を再ロードするが、shell 環境変数は親プロセス継承前提なので **`gh auth status` を最初に走らせて token 有効性を確認** (失敗時は Phase 2 連続失敗 5 件で緊急停止経路に乗る)
+- **22:00 JST 採用理由**: 日中の人間活動 (PR merge / コードレビュー) が一巡した後に retro 集約、翌日 09:00 JST までに learning が揃う想定
+
+### 経路 3: ScheduleWakeup (継続ループ短時間追従)
+
+`/loop` skill 経由で dynamic 間隔の wakeup を予約。merge tide が来ているタイミング (例: 並列 implementation PR が複数 merge された直後) の追従に使う。
+
+```text
+# 例: 自己 pace で 20-30 分間隔の継続起動
+/loop /pr-poller route=wakeup
+```
+
+- **delaySeconds 推奨**: 1200-1800s (20-30 分)、ScheduleWakeup の cache TTL 5 分超え前提で長め設定
+- **CronCreate との重複時**: 09:00 JST の cron 起動と wakeup loop が同 lookback で重なる可能性 → `.claude/locks/pr-poller.lock` の mkdir 排他で後発側が 30 分 no-op (`.claude/rules/pr-poller.md` §3 系統 二重起動防止)
+- **明示停止**: wakeup loop を止めるときは `/loop` の停止指示で次サイクルから自動終了 (lock は正常終了で解放済)
+
+### 初回 dogfood 手順
+
+A4 PR merge 直後の本 Skill 実運用稼働を以下の手順で確認:
+
+1. **lock 取得確認**: `mkdir .claude/locks/pr-poller.lock` で原子取得、配下に `pid` / `acquired_at` / `route=manual` 配置 (Phase 1)
+2. **対象 PR 検出**: `gh pr list --state merged --search "merged:>2026-05-12" --limit 50 --json number,title,mergedAt` で直近 7 日の merge PR 列挙 (Phase 2)
+3. **dedup**: `docs/harness/learnings/YYYY-MM-DD-pr-<N>.md` を ls して処理済 set を構築、Phase 2 結果から差し引いて未処理リスト確定 (Phase 3)
+4. **dispatch**: 未処理 PR 1 件ごとに `pr-retrospective` Skill 起動 (Phase 4)
+5. **harness-meta 自動起動閾値判定**: 未処理 learning 件数 + 前回 harness-meta 実行経過日数を `harness-meta-criteria.md` §実行時パラメータ と比較、閾値超過なら `harness-meta` 起動 (Phase 4)
+6. **lock 解放**: `.claude/locks/pr-poller.last-run` 更新 → `rm -rf .claude/locks/pr-poller.lock` (Phase 5)
+7. **handoff サマリ**: 標準出力に §出力 のフォーマットで起動経路 / 検出件数 / dispatch 件数 / harness-meta 起動有無を出力
+
+### A4 dogfood 期待値 (PR #180 直後タイミング)
+
+PR #180 (4 件 retro 同時 merge: #174 / #175 / #176 / #177) の merge 直後で本 Skill を稼働させた場合の期待観測値 (実測は A4 PR merge 後の手動 dogfood で記録):
+
+| 項目 | 期待値 | 観測手順 |
+|---|---|---|
+| 未処理 learning 件数 (本 Skill 起動時点) | 0-2 件 | `ls docs/harness/learnings/2026-05-*.md | wc -l` と PR #180 集約済件数の差分 |
+| 未処理 merged PR (直近 7 日) | 0-3 件 | `gh pr list --state merged --search "merged:>2026-05-12"` の件数 - 処理済 set |
+| 前回 harness-meta 実行からの経過日数 | 7 日未満 (PR #156 から 5 月 13-15 日経過) | `git log -- .claude/rules/harness-meta-criteria.md` の最新更新日 |
+| harness-meta 自動起動 | 起動しない見込み | 未処理 learning < 10 件 + 経過日数 < 7 日 (`harness-meta-criteria.md` §実行時パラメータ デフォルト) |
+| Renovate open PR | 0-2 件 | `gh pr list --state open --label renovate --limit 30` |
+
+dogfood 結果は本 Skill PR merge 後の retro (`docs/harness/learnings/YYYY-MM-DD-pr-<A4 PR#>.md`) に「§指標」表として記録、`.claude/rules/harness-meta-criteria.md` §実行時パラメータ §dogfood 観測値 に転載する。
 
 ## Gotchas
 


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: EPIC-A4
related_specs: []
related_adrs:
  - ADR-0017
  - ADR-0024
  - ADR-0026
expected_modules:
  - .claude/skills/pr-poller/SKILL.md
  - .claude/rules/pr-poller.md
  - .claude/rules/harness-meta-criteria.md
-->

## 概要

A4 ロードマップ項目「ローカルポーリング機構の本格化」を消化。`pr-poller` Skill を 3 系統起動経路 (SessionStart hook / CronCreate / ScheduleWakeup) で実運用稼働させる手順書を SKILL.md に追加し、`harness-meta-criteria.md` §実行時パラメータ placeholder を本格化して runtime override 例 + dogfood 観測値の記録枠を確保する。`pr-poller.md` には実運用で頻発する well-known 失敗パターン 4 件の Q&A を追記。

## 関連

- Plan: なし (harness 改修系の小規模変更、A3-14 で `harness-bootstrap` archived 化と同パターン、Plan 起票省略)
- Epic: EPIC-A4 (本 PR はロードマップ A4 単独消化)
- ADR: ADR-0017 (ローカル Claude Code ポーリング駆動) / ADR-0024 (`gh` CLI 採用) / ADR-0026 (`harness-evolution` 手動起動のみ、本 Skill から自動起動しない根拠)
- 元 learnings: なし (本 PR は A4 ロードマップ項目の消化、KPT 起点ではない)
- 元 evolution-proposals: なし

## PR の種別

- [x] **rules / Skill 本格化** (A3 で active 化済の `pr-poller` Skill / `pr-poller.md` rule / `harness-meta-criteria.md` rule の実運用稼働手順 + Q&A + 実行時パラメータ本格化)
- [ ] A1 レトロ 等の即時消化フォロー PR
- [ ] ハーネス改修 PR (`harness-meta` Skill 起票、KPT ベース)
- [ ] 外部研究駆動の改修 PR (`harness-evolution` Skill 起票)
- [ ] レトロ集約 PR
- [ ] その他

## 対象 PR (KPT / 改修起点)

本 PR は KPT 起点ではなく **A4 ロードマップ項目の消化** のため、対象 PR 表は該当なし。採用根拠は §採用根拠 (A4 ロードマップ項目) 参照。

### 採用根拠 (A4 ロードマップ項目)

- **`docs/harness/roadmap.md` §A4 ローカルポーリング機構の本格化**: `pr-poller` Skill の実運用稼働開始 + `harness-meta-criteria.md` 起動閾値の dogfood が A4 完了条件
- **A3-11 (PR #168) で SKILL.md skeleton → active 本格化済** (3 系統起動経路 + `.claude/locks/` mkdir 排他)
- **A3-10 (PR #167) で `pr-retrospective` 本格化済**、A3-5 (PR #156) で `harness-meta` 本格化済 → パイプライン (pr-poller → pr-retrospective → harness-meta) を実運用で稼働させて起動閾値 / 3 分岐判定 / dry-run 6 必須条件を dogfood するのが A4 の目的

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| skill | `.claude/skills/pr-poller/SKILL.md` | §実運用稼働手順 セクション新規追加 (3 系統 setup 例 + 初回 dogfood 手順 + A4 dogfood 期待値表)、`phase: A3 → A4` / `last_updated: 2026-05-19` 更新 | — |
| rule | `.claude/rules/pr-poller.md` | §A3 / A4 で本格化する MVP 表記更新 (A4 本格化を明示) + §実運用稼働 Q&A 新規追加 (well-known 失敗パターン 4 件: lock 二重取得 / gh auth status 失敗 / dispatch 重複 / harness-meta 二重起動 + 回避策 3 段)、`last_updated: 2026-05-17 → 2026-05-19` 更新 | — |
| rule | `.claude/rules/harness-meta-criteria.md` | §実行時パラメータ placeholder を本格化 (既定値 + 上書き条件 + 上書き例の 6 行表 + dogfood 観測値 6 項目の記録枠)、`(A4 で記入)` プレースホルダを実値に置換 | — |
| settings (blocker) | `.claude/settings.json` | SessionStart hook 追加 (`pr-poller` skill auto-invoke ヒント context 注入) を試行したが classifier で **denied** (Self-Modification 判定) → §blockers 参照、SKILL.md §経路 1 に JSON 例を記載済のため人間 approve 経由で別 PR にて反映 | — |

## 3 軸定量評価 (harness-meta / harness-evolution 改修 PR は必須、ADR-0028)

本 PR は **harness-meta / harness-evolution 由来ではない** (A4 ロードマップ項目消化、harness 改修系の rule + Skill 本格化) ため §dry-run skip 該当時 に該当。

### dry-run skip 該当時

- **skip 理由**: 「既存セクションへの例示追加 (実運用稼働手順 / Q&A は既存 rule / Skill の本格化フェーズ A4 で予約済のセクション追加、既存規約の本体改定なし) + frontmatter 値更新 + placeholder セクション本格化」(`.claude/rules/harness-meta-criteria.md` §dry-run 不要条件 該当)、scope 限定 + 撤回コスト低 (3 ファイル touch、+187 / -12 行)

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

本 PR は harness-meta 起票ではないため、ハーネス改善提案の採用 / 見送り / 保留 / 撤去の集計は該当なし (A4 ロードマップ項目消化)。

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | — | — | — | — |
| `[skill]` | — | — | — | — |
| `[template]` | — | — | — | — |
| `[remove]` | — | — | — | — |

## 受け入れ基準 (AC)

- [x] **AC-01**: `.claude/skills/pr-poller/SKILL.md` §実運用稼働手順 に 3 系統 setup (SessionStart hook / CronCreate / ScheduleWakeup) の具体的コード例が記載されている
- [x] **AC-02**: `.claude/skills/pr-poller/SKILL.md` §A4 dogfood 期待値 表に 5 項目 (未処理 learning 件数 / 未処理 merged PR / 前回 harness-meta 経過日数 / harness-meta 自動起動 / Renovate open PR) が記載されている
- [x] **AC-03**: `.claude/rules/harness-meta-criteria.md` §実行時パラメータ §既定値 + 上書き例 表に 6 パラメータ (`unprocessed_learnings_threshold` / `harness_meta_interval_days` / `harness_meta_min_interval_hours` / `pr_poller_stale_threshold_minutes` / `pr_poller_lookback_default` / `dry_run`) が記載されている
- [x] **AC-04**: `.claude/rules/harness-meta-criteria.md` §dogfood 観測値 表に観測項目 6 件の記録枠 (A4 PR merge 後に追記) が用意されている
- [x] **AC-05**: `.claude/rules/pr-poller.md` §実運用稼働 Q&A に well-known 失敗パターン 4 件 (Q1-Q4) + 各 3 段の回避策が記載されている
- [x] **AC-06**: 既存 rule / Skill / 関連 ADR との不整合がない (SoT は本 rule、SKILL.md は手順書側を明示)
- [ ] **AC-07** (持ち越し / blocker): `.claude/settings.json` SessionStart hook 設定追加 → §blockers 参照

## テスト

- [x] frontmatter 配列が block 形式 (markdown.md §frontmatter 規約)
- [x] 日本語見出し (template-language.md 規約、ADR-0027)
- [x] code block に言語指定 (markdown.md §code block 規約、json / text / bash)
- [x] SoT 整合確認 (`harness-meta-criteria.md` §実行時パラメータ が `pr-poller.md` §harness-meta 起動閾値 と SKILL.md §入力 から参照される片方向 SoT)
- [ ] markdownlint-cli2 グリーン (A6 以降、現状 skeleton)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降、現状 skeleton)
- [ ] (`commit-msg` hook 変更時) 該当なし (本 PR は hook 変更なし)

## レビュー観点

ハーネス中核 Skill (`pr-poller`) の実運用稼働手順を SoT 化した最初の PR。以下を重点的に確認:

- **3 系統起動経路の setup 例が実際に動作するか**: SessionStart hook の JSON snippet / CronCreate cron 式 / ScheduleWakeup delay 設計の妥当性 (経路 1 は実 settings.json 反映が classifier denied のため別 PR に持ち越し、SKILL.md の手順書として記録)
- **harness-meta-criteria §実行時パラメータ が pr-poller.md §harness-meta 起動閾値 と整合**: 既定値 (10 件 / 7 日 / 24h) が両 rule で一致、上書き経路 2 系統 (rule 直接編集 / 起動時引数) が明示されている
- **well-known 失敗パターンの抽象度**: Q1-Q4 が「lock 二重取得 / gh auth / dispatch 重複 / harness-meta 二重起動」の 4 軸で網羅されているか、Q5 候補 (PII redaction 漏れ / キャッチアップ batch 30+ 件) を後続 PR で追加すべきか
- **撤回コスト**: 本 PR の改修は 3 ファイル touch (+187 / -12 行) で、撤回時は git revert 1 発で復旧可能 (scope 限定 + 既存規約の本体改定なし)

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した
- [x] Skill 改修は `.claude/rules/skill-authoring.md` 経由 (description trigger 明示 / Gotchas 5+ 項目 / 関連リンク双方向 / status `active` + `phase: A4`)
- [x] `auto-merge` を有効化していない (R-15、orchestrator pane 代行 merge 待ち)
- [x] PII / Secrets が diff に含まれていない (本 PR は rule / SKILL.md の Markdown 改修のみ、`.env` / `users.db` / token 等の混入なし)
- [x] (Epic 配下 PR の場合) `roadmap-tracker` での完了根拠登録は本 PR merge 後に orchestrator pane 側で実施 (本 PR は A4 ロードマップ項目消化、Epic 単位 roadmap mirror PR は別途)
- [x] (status ラベル変更時) SKILL.md `phase: A3 → A4` を明示更新、`rules-index.md` の status 語彙は不変 (本 PR では rules-index.md 編集なし、`pr-poller.md` / `harness-meta-criteria.md` の status は `stable` のまま)

## blockers

### B-01: `.claude/settings.json` SessionStart hook 追加が classifier で denied

- **試行内容**: `.claude/settings.json` の `hooks.SessionStart` に `pr-poller` lock 存在チェック + 起動候補 hint 注入の Bash command を追加
- **denied 理由 (classifier 自動回答)**: 「Editing `.claude/settings.json` to add a SessionStart hook is Self-Modification; the user did not explicitly authorize modifying this agent-config file (the task list comes from an unseen prompt file, not direct user intent).」
- **影響範囲**: `.claude/skills/pr-poller/SKILL.md` §経路 1 に JSON snippet を例として記載済のため、人間 approve 経由で別 PR にて反映可能。本 PR の主要 scope (実運用稼働手順 SoT 化 + 実行時パラメータ本格化 + Q&A 追加) には影響しない
- **持ち越し先**: orchestrator (subroh0508) が直接 `.claude/settings.json` を編集する後続 PR にて反映 (B-01 解消条件: orchestrator 明示承認 + classifier denied 迂回せず実 settings.json 編集)
- **機械的迂回はしない** (`orchestrator-criteria.md` 規範遵守、`pbcopy` / `sed` / `cat <<EOF` 等の経路で settings.json を書き換える対応は禁止)

## 完了確認

- [x] commit 分離: 2 commit (SKILL.md / rule 統合)、Conventional Commits + 60 字以内 + Co-Authored-By 必須を全 commit で遵守
- [x] push 完了
- [x] PR description は `--body-file` 経由 (本ファイル)
- [ ] code-reviewer Coordinator inline (4 aspect): Phase 6 で実施
- [ ] Ready 昇格 (`gh pr ready <PR#>`): Phase 7 で実施
- [ ] `gh pr merge` は orchestrator pane (workspace:11) 代行 (本 pane では絶対実行しない)
