### PR TITLE
harness-meta: plan.md §採番ライフサイクル を採用 (#175/#176)

### DIFF
--- a/.claude/rules/plan.md
+++ b/.claude/rules/plan.md
@@ -2,7 +2,7 @@
 id: rules-plan
 title: Plan ファイル命名規約 / 状態遷移
 status: stable
-last_updated: 2026-05-17
+last_updated: 2026-05-19
 paths:
   - "docs/plans/*.md"
   - ".claude/skills/plan-author/**"
@@ -38,6 +38,42 @@ related_adrs:
 - ファイル名: `PLAN-NNN-<kebab-case-slug>.md` (3 桁ゼロパディング、Epic と独立採番)
 - 例: `PLAN-001-adr-0001-0027-batch-draft.md` / `PLAN-007-add-search-by-brand.md`
 - 採番は `docs/plans/INDEX.md` で連番管理、欠番は実装前なら整理可
+
+## 採番ライフサイクル (予約 → 起票 → 衝突解消) (PR #175/#176 レトロ Try)
+
+並走 PR 間の Plan 番号衝突を予防する運用 SoT。`adr.md` §採番・命名・ステータス と同様の運用方針を Plan 側でも明示する。
+
+### 1. 予約 (Plan 起票前)
+
+- `plan-author` Skill 起動時 or 手動 Plan 起票時に **最初に `docs/plans/INDEX.md` の最終行 PLAN 番号 + 1** を予約番号とする
+- 予約直後に `docs/plans/INDEX.md` へ **placeholder 行を 1 commit で挿入** (`| PLAN-NNN | (起票中) | <type> | proposed | — | YYYY-MM-DD |`)
+- placeholder 行を含む commit は **Plan 本体起票 commit と同一ブランチ + 同一 PR** に含める (`docs/plans/INDEX.md` 行と Plan 本体ファイルが揃って merge される)
+
+### 2. 起票 (Plan 本体作成)
+
+- 予約番号で `docs/plans/PLAN-NNN-<slug>.md` を作成、frontmatter `id: PLAN-NNN` + `status: proposed` で記述
+- `docs/plans/INDEX.md` の placeholder 行を実体 (タイトル / type / status / 関連 Epic / 起票日) に置換
+- 同一 PR 内で **placeholder 挿入 commit → 本体起票 commit** の logical separator を分けても、まとめて 1 commit にしても可 (`implementation-workflow.md` §commit 分離規範 参照)
+
+### 3. 衝突解消 (並走 PR で同一番号取得時)
+
+並走 PR (`A8` と `A5` 等の並列 spawn) が **同時刻に同じ予約番号** を取得した場合、merge 順序によって後発 PR が rename を強制される。衝突を検知した時点で以下を実施:
+
+| 検知タイミング | 対応 |
+|---|---|
+| 先行 PR が merge される前 (Draft / Ready 両 PR open) | 後発 PR の per-task pane / orchestrator pane で **`docs/plans/INDEX.md` を rebase 取得 → 次の番号に rename** (`git mv` + frontmatter `id` 更新 + INDEX.md 行の rebuild) |
+| 先行 PR が merge された後 (後発 PR が rebase / merge 失敗) | 後発 PR を **orchestrator 代行 fix で rename**: `git fetch origin master` → `git rebase master` で INDEX.md conflict を解消 → 後発 PR の Plan 番号を最終行 + 1 に rename (`git mv docs/plans/PLAN-NNN-<slug>.md docs/plans/PLAN-MMM-<slug>.md` + frontmatter `id` 更新) |
+| 既に PR description / commit message に古い番号が混入 | rebase 中の reword 制約で commit message の旧番号表記が残る場合は、**実体ファイル名と frontmatter `id` を最終 SoT とする** (`commit-message.md` §subject 経過措置と整合)。後続 retro / harness-meta で「commit message 番号 vs 実体番号の不一致」が観測されたら learning ファイルに記録 |
+
+### 衝突予防のための運用指針
+
+- **並列 spawn 起動時に Plan 起票が複数ある場合**: orchestrator pane 側で予約番号を **事前ブロードキャスト** (per-task pane prompt に「PLAN-N1 を A8 / PLAN-N2 を A5 で予約」と明記) して衝突を予防
+- **placeholder 行を早期 push する**: per-task pane の Plan 本体作成完了を待たず、placeholder 行のみを先に小さな commit で push しても良い (`docs/plans/INDEX.md` 1 行追加 + frontmatter なしのため lightweight)
+- **連番欠番の許容**: Plan が `abandoned` で取り下げられた場合は **番号維持** (`adr.md` §採番 と同様)、欠番埋め直しは禁止 (古い PR / retro / learning の参照リンクが壊れる)
+
+### 運用例
+
+- **PR #175 (A8) と PR #176 (A5) の PLAN-003 衝突 (2026-05-19)**: 並走 spawn で 両 PR が PLAN-003 を予約 → PR #175 (A8) が先に merge され PLAN-003 を取得 → PR #176 (A5) は `git rebase master` で INDEX.md conflict を解消し、PLAN-003 → PLAN-004 へ rename (`git mv` + frontmatter `id` 更新 + INDEX.md 行 rebuild)。`commit 9290d12` の subject には rebase reword 制約で旧 PLAN-003 表記が残るが、実体は PLAN-004 で確定 (PR #176 retro Problem 参照、本セクション SoT 化の起点)
 
 ## ステータス語彙
 

--- a/docs/harness/learnings/2026-05-19-pr-174.md
+++ b/docs/harness/learnings/2026-05-19-pr-174.md
@@ -93,10 +93,20 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 | 提案 | <PR ID> での消化内容 |
 |---|---|
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19-part2 harness-meta 判定
 
-| 提案 | 見送り理由 / 移行先 |
-|---|---|
+採用 0 / 見送り 8 / 撤去 0 (本 PR scope: `plan.md §採番ライフサイクル` のみ採用、本 learning 内の 8 提案は全件後続持ち越し)
+
+| 提案 ID (本 learning 内 順序) | 判定 | 持ち越し先 / 採用根拠 | 採用判定基準 |
+|---|---|---|---|
+| #1 `[rule]` harness-meta-criteria.md §分割粒度 表脚注に逆方向 cross-link 追加 | 見送り | 補助的な改善 (即時消化基準非該当)、次回 harness-meta-criteria.md 改修と同時消化候補 | 4 |
+| #2 `[rule]` implementation-workflow.md §commit 分離規範 §例外 表に +50/+100/+200 行 3 段階境界例示 | 見送り | 補助的な例示追加 (現状規範で SoT 性確保)、運用熟成データ蓄積後 (3-5 PR 反復観測) で SoT 化推奨 | 1 |
+| #3 `[rule]` implementation-workflow.md §commit 分離規範 §機械検証 N 段階表記化 | 見送り | A6 (Gradle カスタムタスク + 閾値運用熟成) スコープ | 2 |
+| #4 `[rule]` retrospective-format.md part 分割基準 SoT 化 | 見送り | A4 (pr-poller / pr-retrospective Skill 本格化と統合) スコープ | 2 |
+| #5 `[rule]` harness-meta-criteria.md §採用判定基準 表脚注に強化条件 (5 回反復) 運用例追加 | 見送り | 補助的な運用例引用、harness-meta-criteria.md §採用判定基準 表改修 PR と同時消化推奨 | 5 |
+| #6 `[template]` harness.md PR テンプレ commit 構造セクション追加 | 見送り | template 構造変更は dry-run 必須条件該当、harness-meta-criteria.md §dry-run 必須条件「template 構造変更」に該当のため dry-run 先行で別 PR 起票 | 4 |
+| #7 `[skill]` harness-meta Skill 表記揺れ防止 rubric 追加 | 見送り | A4 (harness-meta Skill 本格化) スコープ | 2 |
+| #8 `[skill]` pr-retrospective Skill batch ブランチ集約 + week 跨り判定フェーズ追加 | 見送り | A4 (pr-poller / pr-retrospective Skill 本格化と統合) スコープ | 2 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-19-pr-175.md
+++ b/docs/harness/learnings/2026-05-19-pr-175.md
@@ -92,15 +92,27 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-19-part2 harness-meta 判定で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | 消化 PR / 消化内容 |
 |---|---|
+| #7 `[rule]` `.claude/rules/plan.md` §採番ライフサイクル (予約 → 起票 → 衝突解消) 追加 | 本 PR (harness/meta-execution-2026-W21-part2) で `.claude/rules/plan.md` に §採番ライフサイクル セクションを新規追加、PR #175/#176 の PLAN-003 番号衝突 → PR #176 rename pattern を運用例として引用。採用判定基準 1 (2 回反復観測) 該当 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19-part2 harness-meta 判定
 
-| 提案 | 見送り理由 / 移行先 |
-|---|---|
+採用 1 / 見送り 8 / 撤去 0 (本 PR scope: `plan.md §採番ライフサイクル` のみ採用、他 8 提案は後続持ち越し)
+
+| 提案 ID (本 learning 内 順序) | 判定 | 持ち越し先 / 採用根拠 | 採用判定基準 |
+|---|---|---|---|
+| #1 `[rule]` spec-living-sync.md 双方向同期 SPEC-IMASPARQL-001-basic / PLAN-003 引用追加 | 見送り | 補助的な運用例引用、spec-living-sync.md 本格改修 PR (A4 / A6 統合) と同時消化推奨 | 4 |
+| #2 `[rule]` docs-structure.md §機械検証 related_detail: [] 空配列運用 (起票予定 ID 明示形式) | 見送り | A6 (Gradle カスタムタスク warning 化) スコープ | 2 |
+| #3 `[rule]` db-protection.md §`.dockerignore` 配置 TODO 解消タイミング 3 選択肢 SoT 化 | 見送り | A6 (Dockerfile + .dockerignore 配置統合) スコープ、または別 Plan / Epic で独立判定 | 4 |
+| #4 `[template]` local-imasparql.md §10 関連 Renovate 対象一文追記 | 見送り | 補助的な runbook 追記、次回 runbook 更新 PR と同時消化推奨 | 4 |
+| #5 `[rule]` docs-structure.md §AI が読む順序 infra 系 PR 読み下し順序追加 | 見送り | 補助的な順序追加、docs-structure.md 改修 PR と同時消化推奨 | 1 / 2 |
+| #6 `[rule]` orchestrator-criteria.md §R-15 3 条件 セクションで per-task / orchestrator 責務境界明示 | 見送り | rule 本格改修 (核心セクション改修) は dry-run 必須条件該当のため、`orchestrator-criteria.md` の §R-15 例外 / §代行操作 / §責務境界 を統合した改修 PR (本 learning #6 + PR #176 #7 + PR #177 #4 を集約) として dry-run 先行で別 PR 起票 | 2 |
+| #7 `[rule]` plan.md §採番ライフサイクル (予約 → 起票 → 衝突解消) 追加 | **採用 (本 PR で消化)** | PR #175/#176 で 2 回反復観測、Plan 番号衝突は構造的課題で実運用効果が直接的、dry-run skip 妥当 (既存 rule への新規セクション追加 = additive + scope 限定 + 本体改定なし、§dry-run 不要条件 第 3 行 + 第 6 行 該当) | 1 |
+| #8 `[template]` feature.md 等 R-15 3 条件 SoT 表追加 | 見送り | A6 (PR テンプレ機械検証統合) スコープ、template 構造変更は dry-run 必須条件該当のため dry-run 先行 | 2 |
+| #9 `[skill]` feature-request Skill ADR §決定 N 項目分離 pattern rubric 追加 | 見送り | A3 完了済 (feature-request Skill active 化) だが rubric 追加は採用判定基準 / 必須条件級の核心改修で dry-run 必須、`skill-authoring.md` 100-point rubric 改修と同時 dry-run 経由起票推奨 | 4 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-19-pr-176.md
+++ b/docs/harness/learnings/2026-05-19-pr-176.md
@@ -94,15 +94,28 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 
 <!-- harness-meta が後から追記。提案 → 結果の往復ログを 1 ファイル内で完結 -->
 
-### YYYY-MM-DD <PR ID> で消化 (採用)
+### 2026-05-19-part2 harness-meta 判定で消化 (採用)
 
-| 提案 | <PR ID> での消化内容 |
+| 提案 | 消化 PR / 消化内容 |
 |---|---|
+| #1 `[rule]` `.claude/rules/plan.md` §採番ライフサイクル (予約 → 起票 → 衝突解消) 新規追加 | 本 PR (harness/meta-execution-2026-W21-part2) で `.claude/rules/plan.md` に §採番ライフサイクル セクションを新規追加、PR #175/#176 の PLAN-003 番号衝突 → PR #176 rename pattern を運用例として引用。採用判定基準 1 (PR #175/#176 で 2 回反復観測) 該当 |
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19-part2 harness-meta 判定
 
-| 提案 | 見送り理由 / 移行先 |
-|---|---|
+採用 1 / 見送り 9 / 撤去 0 (本 PR scope: `plan.md §採番ライフサイクル` のみ採用、他 9 提案は後続持ち越し)
+
+| 提案 ID (本 learning 内 順序) | 判定 | 持ち越し先 / 採用根拠 | 採用判定基準 |
+|---|---|---|---|
+| #1 `[rule]` plan.md §採番ライフサイクル (予約 → 起票 → 衝突解消) 新規追加 | **採用 (本 PR で消化)** | PR #175/#176 で 2 回反復観測、Plan 番号衝突は構造的課題で実運用効果が直接的、dry-run skip 妥当 (既存 rule への新規セクション追加 = additive + scope 限定 + 本体改定なし) | 1 |
+| #2 `[rule]` harness-meta-criteria.md §撤去判定基準 表脚注 「accumulated ADR 物理反映の例外」追加 | 見送り | harness-meta-criteria.md §撤去判定基準 (採用判定基準 / 必須条件級) 改修は dry-run 必須条件該当、別 PR で dry-run 経由起票推奨 | 4 |
+| #3 `[rule]` implementation-workflow.md Phase 3 fix loop ローカル check skip 時 CI 依存 + orchestrator 代行 fix pattern 追加 | 見送り | rule 本格改修 (核心セクション改修) は dry-run 必須条件該当、`implementation-workflow.md` 本格改修 PR で dry-run 経由起票推奨 | 1 |
+| #4 `[rule]` wasm-compat.md または roadmap.md A10 完了後 / wasmJs 統一決定後の jsMain libs 行再評価 | 見送り | A10 (Roborazzi + wasmJs 統一決定後) スコープ | 2 |
+| #5 `[skill]` 次 PR で core/common/src/jsMain/** i18next 参照 grep 確認 → 撤去判定 | 見送り | A5 後続 PR (撤去候補 PR 起票) スコープ、本 learning #10 と同根、別 PR で対応 | 4 |
+| #6 `[rule]` removed-modules.md 撤去対象一覧表 core/test/.../{FirebaseUser,FakeFirestoreClient}.kt を「残骸 (撤去進行中)」として明示追加 | 見送り | Phase B / C (Firebase test double 撤去 PR と同時) スコープ | 4 |
+| #7 `[rule]` orchestrator-criteria.md §代行操作 セクション (新設) per-task pane の漏れ → orchestrator 代行 fix pattern SoT 化 | 見送り | rule 新規セクション追加は採用判定基準 / 必須条件級の核心改修で dry-run 必須、PR #175 #6 + PR #177 #4 を集約した orchestrator-criteria.md 統合改修 PR として dry-run 先行で別 PR 起票 | 1 |
+| #8 `[template]` local-development.md JDK 25 vs AGP 8.9.0 互換性 TODO 追加 | 見送り | 補助的な runbook 追記、A6 (Spotless / ktlint / detekt 統合 + JDK 互換性確認) スコープと同時消化推奨 | 1 |
+| #9 `[rule]` plan.md §ロールバック手順 「撤去 PR の連鎖追跡」セクション追加 | 見送り | 本 PR で §採番ライフサイクル を採用済のため、plan.md §ロールバック手順 拡張は別 PR で独立対応推奨 (scope 制御) | 2 |
+| #10 `[remove]` core/common/build.gradle.kts jsMain dependencies (i18next) 撤去候補化 | 見送り | A5 後続 PR (撤去候補 PR + 2 段階運用) スコープ、`harness-meta-criteria.md` §撤去判定基準 2 段階運用 (Step 1 status 変更 + Step 2 物理削除) 適用予定 | 4 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 

--- a/docs/harness/learnings/2026-05-19-pr-177.md
+++ b/docs/harness/learnings/2026-05-19-pr-177.md
@@ -99,10 +99,21 @@ generator: pr-retrospective (skeleton、本ペインで手動代替実行)
 | 提案 | <PR ID> での消化内容 |
 |---|---|
 
-### YYYY-MM-DD <PR ID> で見送り (後続フェーズへ)
+### 2026-05-19-part2 harness-meta 判定
 
-| 提案 | 見送り理由 / 移行先 |
-|---|---|
+採用 0 / 見送り 9 / 撤去 0 (本 PR scope: `plan.md §採番ライフサイクル` のみ採用、本 learning 内 9 提案は全件後続持ち越し)
+
+| 提案 ID (本 learning 内 順序) | 判定 | 持ち越し先 / 採用根拠 | 採用判定基準 |
+|---|---|---|---|
+| #1 `[rule]` code-reviewer-aspects.md §aspect 動的選択ルール 「mirror PR Coordinator skip 可」追加 | 見送り | rule 本格改修 (核心セクション改修) は dry-run 必須条件該当、`code-reviewer-aspects.md` / `merge-readiness.md` integrate 改修 PR で dry-run 経由起票推奨 | 1 |
+| #2 `[skill]` roadmap-tracker Skill Phase 8 (mirror PR 自動起票) 本格化 | 見送り | A4 (pr-poller / roadmap-tracker Skill 本格化と統合) スコープ | 2 |
+| #3 `[rule]` roadmap.md §SLA セクション (新設) mirror PR SLA 目安 30 分以内 SoT 化 | 見送り | rule 新規セクション追加は scope 限定だが、`roadmap-tracker` Skill 本格化 (A4) と同時 SoT 化が望ましい (運用熟成データ蓄積後) | 1 |
+| #4 `[rule]` orchestrator-criteria.md §R-15 例外条件 self-merge mirror PR の境界明示 | 見送り | rule 本格改修 (R-15 3 条件 + 例外条件) は dry-run 必須条件該当、PR #175 #6 + PR #176 #7 + 本 #4 を集約した orchestrator-criteria.md 統合改修 PR として dry-run 先行で別 PR 起票 | 2 |
+| #5 `[skill]` harness-meta Skill mirror PR 集約カウント自動算出 rubric 追加 | 見送り | A4 (harness-meta Skill 本格化) スコープ | 2 |
+| #6 `[rule]` commit-message.md §subject 長制限 mirror PR 系運用例追加 | 見送り | commit-message.md §subject 長制限 改修 PR (A6 commit-msg hook 拡張) と同時消化推奨 | 1 |
+| #7 `[rule]` roadmap.md §mirror PR 最小規模 pattern セクション (新設) | 見送り | 本 #3 SLA セクションと同時 SoT 化が効率的、`roadmap-tracker` Skill 本格化 (A4) と同時起票推奨 | 4 |
+| #8 `[rule]` harness-meta-criteria.md §分割粒度 表脚注「3 並列 spawn の merge 順序依存性」追加 | 見送り | PR #175/#176/#177 で 3 回観測 (採用判定基準 1 強化条件相当) で採用候補だが、本 PR は scope 制御 (5 ファイル以内) のため見送り、次回 harness-meta 改修 PR で消化推奨 (plan.md §採番ライフサイクル と論理整合する追記内容、別 PR で集約) | 1 |
+| #9 `[skill]` roadmap-tracker Skill セクション別競合解消ポリシー機械検証 | 見送り | A6 (Gradle カスタムタスク + markdownlint-cli2 統合) スコープ | 2 |
 
 ### YYYY-MM-DD <PR ID> で保留 (要再評価)
 


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: null
related_adrs:
  - ADR-0026
  - ADR-0027
related_specs: []
expected_modules:
  - .claude/rules/plan.md
  - docs/harness/learnings/2026-05-19-pr-174.md
  - docs/harness/learnings/2026-05-19-pr-175.md
  - docs/harness/learnings/2026-05-19-pr-176.md
  - docs/harness/learnings/2026-05-19-pr-177.md
-->

## 概要

`harness-meta` 実行 (2026-W21-part2)。PR #180 batch で追加された 4 learning (#174-#177) の `🤖 ハーネス改善提案` 計 36 件を `harness-meta-criteria.md` 採用判定基準 1-5 で判定 → **採用 1 件 (`plan.md §採番ライフサイクル`、PR #175/#176 で 2 回反復観測)** + 見送り 35 件 (A4 / A6 / A10 / Phase B-C 等の後続フェーズ持ち越し)。

## 関連

- Plan: — (本 PR は harness 改修 PR で Plan 不要)
- Epic: — (横断 harness-meta 実行)
- ADR: ADR-0026 (`harness-meta` / `harness-evolution` 二系統補完) / ADR-0027 (テンプレ言語)
- 元 learnings:
  - `docs/harness/learnings/2026-05-19-pr-174.md` (harness-meta / commit 分離規範 SoT 化)
  - `docs/harness/learnings/2026-05-19-pr-175.md` (A8 im@sparql Docker)
  - `docs/harness/learnings/2026-05-19-pr-176.md` (A5 不要モジュール撤去、PLAN-003 → PLAN-004 rename)
  - `docs/harness/learnings/2026-05-19-pr-177.md` (roadmap mirror、3 並列消化)
  - `docs/harness/learnings/2026-05-19-pr-171.md` (既判定済、再判定対象なし)

## PR の種別

- [ ] A1 レトロ 等の即時消化フォロー PR
- [ ] rules / Skill 本格化
- [x] **ハーネス改修 PR** (`harness-meta` Skill 起票、KPT ベース)
- [ ] 外部研究駆動の改修 PR (`harness-evolution`)
- [ ] レトロ集約 PR
- [ ] その他

## 対象 PR (KPT / 改修起点)

| 元 PR | KPT 要点 | 本 PR で消化する提案 | 採用判定基準該当 (1-5) | mirror PR か | rebase 回数 | classifier ブロック有無 |
|---|---|---|---|---|---|---|
| #175 | A8 im@sparql Docker、PLAN-003 を予約 (先発) | `plan.md §採番ライフサイクル` 追加 (予防策) | 1 (PR #175/#176 で 2 回反復) | — | 0 | 0 |
| #176 | A5 不要モジュール撤去、PLAN-003 → PLAN-004 rename (後発) | 同上 (rename pattern を運用例として引用) | 1 (PR #175/#176 で 2 回反復) | — | 0 | 0 |
| #174 | harness-meta / commit 分離規範 SoT 化 | (本 PR は採用なし、8 提案全件後続持ち越し) | 4 / 1 / 2 / 2 / 5 / 4 / 2 / 2 | — | 0 | 0 |
| #177 | roadmap mirror、3 並列 spawn 消化 | (本 PR は採用なし、9 提案全件後続持ち越し) | 1 / 2 / 1 / 2 / 2 / 1 / 4 / 1 / 2 | — | 0 | 0 |

## 変更内容

| 区分 | パス | 変更内容 | 持ち越し Improvement |
|---|---|---|---|
| rule | `.claude/rules/plan.md` | §採番ライフサイクル (予約 → 起票 → 衝突解消) セクション新規追加 + `last_updated: 2026-05-19` 更新 | — (本 PR で完結) |
| learning | `docs/harness/learnings/2026-05-19-pr-174.md` | `📝 harness-meta フィードバック` に 2026-05-19-part2 判定表追記 (採用 0 / 見送り 8 / 撤去 0) | 全件後続持ち越し (A4 / A6 / scope 制御) |
| learning | `docs/harness/learnings/2026-05-19-pr-175.md` | 同上 (採用 1 / 見送り 8 / 撤去 0) | #7 採用以外の 8 件後続持ち越し |
| learning | `docs/harness/learnings/2026-05-19-pr-176.md` | 同上 (採用 1 / 見送り 9 / 撤去 0) | #1 採用以外の 9 件後続持ち越し |
| learning | `docs/harness/learnings/2026-05-19-pr-177.md` | 同上 (採用 0 / 見送り 9 / 撤去 0) | 全件後続持ち越し |

## 採用根拠

採用提案: **`.claude/rules/plan.md` §採番ライフサイクル (予約 → 起票 → 衝突解消) 新規セクション追加**

- **採用判定基準 1 (複数 PR で反復)**: PR #175 (A8 / PLAN-003 を先発予約) + PR #176 (A5 / PLAN-003 を後発予約 → rename 強制) で **2 回観測**、並走 PR の Plan 番号衝突は今後の並列実装 (3 並列 spawn 以上) で再発する構造的課題
- **実運用効果が直接的**: 衝突予防 (予約 placeholder 早期 push) + 衝突解消 (rename pattern + commit message reword 制約への対処) + 連番欠番の許容 (`abandoned` 取り下げ時の番号維持) を SoT 化、後続並走 PR で即時参照可能
- **dry-run skip 妥当性**: §dry-run 不要条件 第 3 行「既存セクションへの例示追加」+ 第 6 行「撤回コスト低 + scope 限定 + 既存 rule 本体改定なし」併用で skip。既存 `plan.md` への新規セクション追加 (additive) + backward compatible + 既存規範無改変

## 3 軸定量評価 (dry-run skip)

### dry-run skip 該当

**skip 理由**: dry-run 不要条件 (`harness-meta-criteria.md` §dry-run 不要条件) 第 3 行「既存セクションへの例示追加 (rule 本体ルール不変)」+ 第 6 行「撤回コスト低 + scope 限定 + 既存 rule 本体改定なし」併用で skip 妥当。

- 既存 `plan.md` への新規セクション追加のみ (additive、既存セクション無改変)
- 既存規範 (frontmatter / 命名規約 / ステータス語彙 / 本文構造 / INDEX.md 更新規約) は無変更
- 撤回コスト低 (PR revert で 1 セクション削除のみ、波及参照ゼロ)
- 採用判定基準 / 必須条件 / SoT 反転に該当しない

`harness-meta-criteria.md` §dry-run 必須条件「rule 全文書き換え」「Skill 新規追加」「template 構造変更」「SoT 反転」のいずれにも該当しない。

## ハーネス改善提案件数 (KPT / harness-meta フィードバック)

| 観点 | 採用 | 見送り | 保留 | 撤去 |
|---|---|---|---|---|
| `[rule]` | 1 | 22 | 0 | 0 |
| `[skill]` | 0 | 7 | 0 | 0 |
| `[template]` | 0 | 5 | 0 | 0 |
| `[remove]` | 0 | 1 | 0 | 0 |
| **計** | **1** | **35** | **0** | **0** |

採用しなかった 35 件は元 learning ファイル `📝 harness-meta フィードバック` セクションに「2026-05-19-part2 判定」表で持ち越し先 (A4 / A6 / A10 / Phase B-C / 別 PR 集約) を明示記録。

### 主な持ち越し先内訳

- **A4 (pr-poller / harness-meta / roadmap-tracker Skill 本格化)**: 9 件 (Skill 駆動起動 + 自動集約系)
- **A6 (Gradle カスタムタスク + markdownlint-cli2 + commit-msg hook 拡張)**: 11 件 (機械検証系)
- **A10 (Roborazzi + wasmJs 統一決定後)**: 1 件 (`kotlinx-coroutines-js` 等の jsMain libs 行再評価)
- **Phase B-C (Firebase test double 撤去 + Cloud Run / R2 / Litestream 本格化)**: 2 件
- **別 PR 集約 (orchestrator-criteria.md 統合改修 dry-run 先行)**: 3 件 (PR #175 #6 + PR #176 #7 + PR #177 #4)
- **次回 harness-meta / harness-meta-criteria.md 改修 PR と同時消化**: 9 件 (補助的な運用例 / 表脚注追記等)

## R-15 事前承認

orchestrator pane (workspace:11) の操作者 subroh0508 が本タスク全体 (harness-meta 改修 PR の Phase 0-7 含む) を out-of-band で明示的に事前承認 (R-15 該当)。

- マージは orchestrator pane が代行 (本 per-task pane は `gh pr merge` を実行しない)
- `/exit` / worktree 削除 / branch 削除 は orchestrator pane 代行
- 本 PR は **採用 1 + 見送り 35 + 撤去 0** で scope 制御 (5 ファイル以内、rule 1 + learning 4)、`harness-meta-criteria.md` §改修 PR の品質基準準拠

## 受け入れ基準 (AC)

- [x] AC-1: `.claude/rules/plan.md` に §採番ライフサイクル セクションが新規追加、frontmatter `last_updated: 2026-05-19` 更新
- [x] AC-2: 採番ライフサイクル 3 ステップ (予約 / 起票 / 衝突解消) + 衝突予防運用指針 + 運用例 (PR #175/#176 PLAN-003 衝突) が明記
- [x] AC-3: 4 learning (#174-#177) の `📝 harness-meta フィードバック` セクションに 2026-05-19-part2 判定表が追記され、採用 / 見送り / 撤去内訳が明示
- [x] AC-4: 採用提案 `plan.md §採番ライフサイクル` が PR #175/#176 の関連 learning で「採用 (本 PR で消化)」として明示
- [x] AC-5: 既存 rule (`adr.md` §採番・命名・ステータス) との整合性確認、Plan は `adr.md` と同様の運用 SoT パターンを踏襲
- [x] AC-6: `harness-meta-criteria.md` §dry-run 不要条件 第 3 行 + 第 6 行 併用で skip 妥当性を PR description に明示
- [x] AC-7: `pr-template.md` §gh pr create 必須パラメータ準拠 (`--body-file` 一択、`--template` 非併用)

## テスト

- [ ] markdownlint-cli2 グリーン (A6 以降)
- [ ] Gradle カスタムタスクの docs 検証グリーン (A6 以降)
- [x] 手動 grep: `.claude/rules/plan.md` の H2 見出し連番性 (frontmatter → `# plan.md` → `## いつ Plan を起こすか` → `## いつ Epic に昇格させるか` → `## 命名規約` → `## 採番ライフサイクル ...` → `## ステータス語彙` → ...) 確認済
- [x] `git log` で 2 commit 分離 (rule 改修 + 4 learning 追記) 確認

## レビュー観点

- `plan.md` の §採番ライフサイクル セクションが既存 `adr.md` §採番・命名・ステータス + `docs/plans/INDEX.md` 運用 + `implementation-workflow.md` §commit 分離規範 と論理的に整合しているか
- `harness-meta-criteria.md` §採用判定基準 1 (複数 PR で反復) + §dry-run 不要条件 (第 3 行 / 第 6 行) の同時適用が SoT 性を維持しているか
- 4 learning の `📝 harness-meta フィードバック` 表が `retrospective-format.md` §フィードバックフォーマット (採用 / 見送り / 保留 3 表) 規約準拠か、見送り提案ごとに採用判定基準 1-5 該当 + 持ち越し先フェーズが明示されているか
- 撤回コスト: 本改修を取り消す手順 (`.claude/rules/plan.md` §採番ライフサイクル セクション削除 + 4 learning の追記表削除) は明確、波及参照ゼロ

## チェックリスト

- [x] `.claude/rules/{rules-index,docs-structure,template-language,markdown}.md` の規約を確認した
- [x] Skill 改修なし (本 PR は rule + learning のみ、`skill-authoring.md` 該当外)
- [x] `auto-merge` を有効化していない (R-15、人間 approve 必須、orchestrator pane が `gh pr merge` 代行)
- [x] PII / Secrets が diff に含まれていない (本 PR は rule + learning のみで PII / secrets 含有なし、grep 確認済)
- [x] `rules-index.md` の status 語彙 (stable / planned / skeleton / living) は維持 (`plan.md` の `stable` 維持、本 PR は新規セクション追加のみで status 変更なし)
- [x] `harness-meta-criteria.md` §改修 PR の品質基準「rule 1 件 + 関連 docs 微修正 + rules-index 更新で 5 ファイル以内」遵守 (本 PR: rule 1 + learning 4 = 5 ファイル)
