### PR TITLE
harness: implementation-workflow Phase 8 拡張 (Plan/Epic frontmatter 同期責務追加)

### DIFF
--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -29,7 +29,7 @@ related_plan: docs/harness/plan.md §5.3 / §5.4.2 / R-14 / R-15
 | 5 | Draft PR 作成 | `gh pr create --draft --body-file <path>` (`--template` と排他、本格 description 起草必須) | PR URL 取得 |
 | 6 | code-reviewer 呼出 | Coordinator レビューコメント | Critical = 0 (fix loop 後) |
 | 7 | 人間 approve → squash merge | merge commit | 3 条件充足 (CI/Critical/approve) |
-| 8 | pr-poller + roadmap-tracker | learning ファイル + roadmap 更新 | (該当時) mirror PR 起票 |
+| 8 | pr-poller + Plan/Epic frontmatter 同期 + roadmap-tracker | learning ファイル + Plan/Epic frontmatter 同期 + roadmap 更新 | (該当時) mirror PR 起票 |
 | 9 | Worktree 削除 | worktree クリーンアップ | branch -d 成功 |
 
 ## Phase 0: Worktree 作成 + master fetch (PR #121 レトロ Try 反映)
@@ -197,12 +197,111 @@ orchestrator 事前承認下でも、classifier (auto mode safety layer) は別 
 
 詳細パターンは `.claude/rules/harness-meta-criteria.md` の「classifier ブロック対応 迂回パターン辞典」を参照。
 
-## Phase 8: pr-poller 即時起動 + roadmap-tracker
+## Phase 8: pr-poller 即時起動 + 関連 Plan / Epic frontmatter 同期 + roadmap-tracker
+
+merge 直後に以下 3 step を順次実行する。各 step の責務は独立、step 2 は本 rule の **新責務** (`roadmap-tracker` 片方向ミラー R-34 を侵さない設計)。
+
+### Step 1: pr-poller 即時起動 (learning ファイル生成 trigger)
 
 - `pr-poller` を即時起動して `pr-retrospective` を駆動 → learning ファイル生成 (`docs/harness/learnings/YYYY-MM-DD-pr-<N>.md`)
+- learning ファイルは `harness/learnings-batch-YYYY-WW` ブランチに集約、週次 / 件数閾値到達時に PR 起票
+- 詳細は `.claude/rules/pr-poller.md` / `.claude/rules/retrospective-format.md` 参照
+
+### Step 2: 関連 Plan / Epic frontmatter 同期 (本 rule の新責務、R-34 非侵犯)
+
+`roadmap-tracker` は R-34 で **Plan 対象外 + Epic 本体 (`README.md`) への逆同期も禁止** (`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 専用の片方向ミラー)。merge 後の Plan / Epic frontmatter 同期はこれまで責務空白 (Skill suite 構造的 gap) となっていたため、本 rule で **`implementation-workflow` Phase 8 Step 2** に責務を新規付与する。
+
+#### 2-1. 関連 ID 抽出 (3 source 統合)
+
+| Source | 抽出方法 | 例 |
+|---|---|---|
+| PR description | `gh pr view <PR#> --json body` の出力から `<!-- pr-frontmatter ... -->` ブロックを grep し `related_plan:` / `related_epic:` 行を取得 | `related_plan: PLAN-007` / `related_epic: EPIC-A3` |
+| branch 名 | `gh pr view <PR#> --json headRefName` の出力から prefix 別に正規表現抽出 (`^feature/(PLAN-\d{3})-`, `^feature/(EPIC-[A-Z0-9-]+)-pr-\d+$`, `^feature/(A\d+-\d+)-` 等) | `feature/PLAN-007-add-search` → `PLAN-007`、`feature/A2-3-rules-process` → `A2-3` |
+| merge commit subject | `gh pr view <PR#> --json mergeCommit` の `mergeCommit.messageHeadline` から `(PLAN-NNN)` / `(EPIC-NNN)` / `(A2-3)` 等の言及を抽出 | `harness: A2-3 process rules (PLAN-005)` → `PLAN-005` + `A2-3` |
+
+3 source の結果を集約 → 重複 ID を除去 → 抽出 ID 集合を確定。
+
+**no-op 条件**: 3 source 全てから ID 抽出不能 (例: branch 名が `harness/<purpose>` で PR description `related_plan: null` + `related_epic: null` + commit subject に ID 言及なし) ならば本 step は no-op で抜ける (`harness/<purpose>` 系の純粋ハーネス改修 PR / mirror PR 等は通常該当)。
+
+#### 2-2. 対応 Plan / Epic ファイルの frontmatter 更新
+
+**Plan** (`docs/plans/PLAN-NNN-*.md`):
+
+- 現値 `status: in-progress` の場合のみ以下を実行:
+  - `status: in-progress → completed`
+  - `related_pr: null → <PR#>` (整数)
+  - `completed_at: null → <YYYY-MM-DD>` (`gh pr view --json mergedAt` の日付部、UTC → JST 変換)
+- 現値が `proposed` / `abandoned` / `promoted` の場合は **本 Skill では絶対に書き換えない** (誤検知防止、warning 出力で人間判断を仰ぐ)
+
+**Plan INDEX.md** (`docs/plans/INDEX.md`):
+
+- 対応行 (`| PLAN-NNN | タイトル | type | status | related_epic | 起票日 |`) の **status 列を `in-progress → completed`** に更新
+- 行構造は `.claude/rules/plan.md` §INDEX.md 更新規約 と整合、列追加は本 step ではしない
+
+**Epic README** (`docs/epics/EPIC-NNN-*/README.md`):
+
+- 配下構成 PR 全件 merge 済の場合のみ:
+  - `status: in-progress` 維持 + **`completed_at` 候補としてフラグ立て** (人間レビューで最終確定)
+  - 全 PR merge 済の判定は `gh pr list --search "label:epic:EPIC-NNN" --state all --json state,number,mergedAt` で全件 `state: MERGED` 確認 (label 運用が確立していない場合は構成 PR 番号を README から手動取得して全件確認)
+- 部分完了時 (構成 PR の一部が未 merge / open) は **Epic README に手を付けない** (Phase 8 Step 2 では status を `in-progress` 維持)
+- **本 Skill は Epic 本体への直接書き戻しを最小化**: 配下全 PR merge 済の確定状態のみ更新、それ以外は人間レビュー / orchestrator 判断で確定
+
+**Epic INDEX.md** (`docs/epics/INDEX.md`):
+
+- Epic 配下全 PR merge 済確定時のみ更新 (status 列 + 完了日列)
+- 部分完了時は手を付けない (構成 PR 数列は本 step では更新しない、別 PR で構成 PR 増減時に更新)
+
+#### 2-3. 複数 ID 該当時 / 双方向リンク
+
+- 1 PR が複数 Plan / Epic に紐づく場合 (例: Epic 配下 PR + 関連 Plan): **全件更新** (重複適用)
+- Plan が `related_epic: EPIC-NNN` を持つ場合は Epic 配下 PR とみなし、Epic README + Plan の両方を 2-2 ルールで更新
+- frontmatter `related_pr` / `related_epic` 等の双方向リンク整合は本 step 完了後に再確認 (`.claude/rules/spec-living-sync.md` 参照)
+
+#### 2-4. 更新方法の 2 通り (inline 同期 vs mirror PR)
+
+| 方法 | 内容 | 推奨基準 | branch 命名例 |
+|---|---|---|---|
+| **inline 同期** | merge した PR の **同一 PR** に Plan/Epic frontmatter 更新 commit を含める (Phase 5 で本体実装と一緒に commit、`git add -p` で hunk 分離) | 本体 PR の touch ファイル数が **30 以下**、Plan/Epic 更新を含めても影響範囲が増えない場合 | (該当 PR と同一 branch、別 branch 不要) |
+| **mirror PR** | merge 後に **別 mirror PR** で Plan/Epic frontmatter 更新を別起票 | 本体 PR が **30 ファイル超** (A5/A6 100+ ファイル等)、Plan/Epic 更新を分離した方が rebase 容易な場合 | `harness/plan-epic-sync-<id>` または `harness/mirror-<phase-id>` |
+
+判定基準は touch ファイル数 > 30 で mirror PR、それ以下なら inline 同期を推奨。**ただし orchestrator 判断で柔軟に切替可**: 並走 spawn 環境では mirror PR がトラブル少ない経験則あり (本セッション 2026-05-19 A5/A6 100+ ファイル並走で stale 化が発生した事例)。
+
+#### 2-5. status 遷移条件 (誤検知防止の安全網)
+
+| 現値 | 抽出 ID 該当 PR merge 済時の動作 | 根拠 |
+|---|---|---|
+| `proposed` | **書き換えない** (warning 出力) | 着手前に merge は通常起きない、想定外状態のため人間判断 |
+| `in-progress` | `completed` に遷移 + `related_pr` / `completed_at` 更新 | 正常系 |
+| `completed` | **書き換えない** (no-op) | 既に完了済、重複適用しない |
+| `abandoned` | **書き換えない** (warning 出力) | 取り下げ済の Plan が PR merge と関連 = 想定外、人間判断 |
+| `promoted` | **書き換えない** (warning 出力) | Epic 昇格済、Plan ファイルは履歴保持、Epic 側で更新 |
+| `blocked` | **書き換えない** (warning 出力) | 障壁解消の確認が必要、人間判断 |
+
+#### 2-6. roadmap-tracker との責務分離 (R-34 維持)
+
+- 本 Skill (`implementation-workflow` Phase 8 Step 2): **Plan / Epic 本体 frontmatter + INDEX.md** を更新 (双方向同期、必要時のみ)
+- `roadmap-tracker` (Phase 8 Step 3): **`docs/harness/roadmap.md` + `docs/epics/<id>/roadmap.md`** を Read-only で取り込み片方向ミラー (R-34)
+- 本 Skill から **`docs/harness/plan.md` への書き戻しは禁止** (`docs/harness/plan.md` は Single Source of Truth、本 Skill は読み取りのみ)
+- `roadmap-tracker` は本 Skill が更新した Plan / Epic frontmatter を Read で取り込んで roadmap.md 完了根拠表に反映 (順序依存: Step 2 → Step 3)
+
+### Step 3: roadmap-tracker 起動 (片方向ミラー、既存責務、R-34 維持)
+
 - `roadmap-tracker` を起動 (**Epic 配下 PR / B-A-C フェーズ項目に該当時のみ**、Plan 単体は対象外、R-34)
 - mirror PR が必要な場合 (`implementation-workflow` を経由しないマージ + Epic / フェーズ項目該当) は `harness/roadmap-mirror-<phase-id>` ブランチで mirror PR 起票 (`roadmap.md` §手動マージ時の同 PR 更新ルール 参照)
-- learning ファイルは `harness/learnings-batch-YYYY-WW` ブランチに集約、週次 / 件数閾値到達時に PR 起票
+
+### 本拡張責務の起点 (運用例)
+
+本セッション (2026-05-19) で発覚した実運用 gap (本拡張責務の起点):
+
+| 対象 | merge 済 PR | 当時の frontmatter | 本拡張で目指す動作 |
+|---|---|---|---|
+| PLAN-001 (ADR 0001-0027) | PR #119 (2026-05-17) | `in-progress` / `related_pr: null` | Step 2-2 で `status: completed` + `related_pr: 119` + `completed_at: 2026-05-17` に同期、INDEX.md 行更新 |
+| PLAN-003 (A8 im@sparql Docker) | PR #175 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 (`related_pr: 175` / `completed_at: 2026-05-19`) |
+| PLAN-004 (A5 不要モジュール撤去) | PR #176 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 (`related_pr: 176`) |
+| PLAN-005 (A6 Lint/Format step1) | PR #182 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 (`related_pr: 182`) |
+| EPIC-A3 (Skill 群実装) | 全 15 PR merge 済 | `in-progress` | Step 2-2 で配下全 PR merge 済確定後 `completed` 候補としてフラグ立て、人間レビューで `completed` + `completed_at` 確定 |
+
+stale 5 件の実 frontmatter 更新は本拡張責務の **初回適用 (段 1 dogfood) として別 PR で消化**、本 PR は Skill / rule 改修のみ。
 
 ## Phase 9: Worktree 削除
 
@@ -342,6 +441,12 @@ git commit -F /tmp/<prefix>-commit-msg-2.txt
 - **Phase 7 で auto-merge 禁止** (R-15)、orchestrator 明示承認テキストでの代替パスは許可
 - **Phase 7 で classifier ブロック発生時は迂回せず人間判断を仰ぐ** (PR #125 / #129 レトロ Try): denied メッセージ全文報告 → ユーザー指示待ち、機械的迂回は禁止
 - **Phase 8 で `roadmap-tracker` を呼ぶのは Epic 配下 PR / B-A-C フェーズ項目のみ**、Plan 単体は対象外 (R-34)
+- **Phase 8 Step 2 (Plan/Epic frontmatter 同期) は本 rule の新責務、R-34 を侵さない**: `roadmap-tracker` は Plan 対象外 + Epic 本体逆同期禁止のため、`docs/plans/PLAN-NNN-*.md` / `docs/plans/INDEX.md` / Epic 配下全 PR merge 済時の `docs/epics/EPIC-NNN-*/README.md` の frontmatter 同期は本 Skill が担う。`roadmap-tracker` 片方向ミラー (`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 専用) との責務分離を明示し、本 Skill から `docs/harness/plan.md` への書き戻しは禁止
+- **Phase 8 Step 2 の関連 ID 抽出は 3 source 統合** (PR description `<!-- pr-frontmatter ... -->` の `related_plan` / `related_epic` + branch 名 prefix + merge commit subject 言及): いずれか 1 source から抽出できれば更新、3 source 全てから抽出不能な場合のみ no-op で抜ける (`harness/<purpose>` 系の純粋ハーネス改修 PR / mirror PR 等は通常 no-op)
+- **Phase 8 Step 2 で書き換える status は `in-progress → completed` のみ** (誤検知防止の安全網): 現値が `proposed` / `abandoned` / `promoted` / `completed` / `blocked` の場合は本 Skill では絶対に書き換えず warning 出力、人間判断を仰ぐ
+- **Phase 8 Step 2 の inline 同期 vs mirror PR 判定は touch ファイル数 > 30 が基準**: 並走 spawn 環境では mirror PR がトラブル少ない経験則あり (本セッション 2026-05-19 A5/A6 100+ ファイル並走で stale 5 件発生した事例、本拡張責務の起点)、orchestrator 判断で柔軟に切替可
+- **Phase 8 Step 2 → Step 3 の順序依存**: `roadmap-tracker` は本 Skill が更新した Plan / Epic frontmatter を Read で取り込んで roadmap.md 完了根拠表に反映するため、必ず Step 2 完了後に Step 3 を起動 (順序逆転で frontmatter stale 状態を取り込むと roadmap.md 反映漏れが発生)
+- **Phase 8 Step 2 で Epic README を更新するのは配下全 PR merge 済確定時のみ**: 部分完了時 (構成 PR 一部 open / Draft) は Epic 本体 frontmatter を触らない (`status: in-progress` 維持)、`completed_at` 候補フラグも全 PR merge 済 + 人間レビュー後に確定
 - **Phase 9 の `branch -d` を先にトライし、失敗時のみ `-D` に切替** (PR #123 / #135 レトロ Try): squash merge / merge commit のいずれも `--merged origin/master` で検出されないケースがある。`gh pr view --json state=MERGED` 確認後に `-D` 許容、PR state 未確認のまま `-D` は禁止 (未マージ work 消滅リスク)
 - **worktree path の slug は `branch-naming.md` 規約に厳密に従う**: スラッシュをハイフンに置換、特殊文字なし
 - **並走中の rules-index.md / roadmap.md / progress.md の rebase 競合** は EPIC-A2 で頻発、mirror PR で統合解消するパターンを A2-2 / A2-4 / A2-5 で確立

--- a/.claude/rules/rules-index.md
+++ b/.claude/rules/rules-index.md
@@ -2,7 +2,7 @@
 id: rules-index
 title: rules 索引
 status: living
-last_updated: 2026-05-17
+last_updated: 2026-05-19
 # 注意: 索引そのものは小さく、AI が他 rule を発見する起点として
 # 起動時に常時ロードしておくのが望ましいため `paths` を意図的に未設定。
 ---
@@ -157,7 +157,7 @@ last_updated: 2026-05-17
 
 | ファイル | 状態 | 主な責務 |
 |---|---|---|
-| `implementation-workflow.md` | stable (A2-3、Skill 本格実装は A3) | 10 フェーズ手順、Phase 0 で `git fetch origin master`、fix loop 上限 3、worktree 未マージ検知 |
+| `implementation-workflow.md` | stable (A2-3、Skill 本格実装は A3、Phase 8 拡張は 2026-05-19) | 10 フェーズ手順、Phase 0 で `git fetch origin master`、fix loop 上限 3、worktree 未マージ検知、Phase 8 で Plan/Epic frontmatter 同期 + roadmap-tracker (R-34 非侵犯) |
 | `code-reviewer-aspects.md` | stable (A2-3、Skill 本格実装は A3) | 8 aspect の binary eval checklist (各 5-7 項目)、Coordinator 形式 |
 
 ### 並列 orchestration (実装ワークフローを per-task pane に委譲する上位レイヤ)

--- a/.claude/skills/implementation-workflow/SKILL.md
+++ b/.claude/skills/implementation-workflow/SKILL.md
@@ -9,7 +9,7 @@ description: |
   per-task pane に Phase 0-9 自走を委譲したときに本 Skill に従って動作する。
 status: active
 phase: A3
-last_updated: 2026-05-18
+last_updated: 2026-05-19
 related_plan: docs/harness/plan.md §5.3 / §5.4.2 / ADR 0018
 related_rules:
   - .claude/rules/implementation-workflow.md
@@ -33,7 +33,7 @@ related_adrs:
 
 > **5 行以内 summary**: Plan / Epic 確定後の実装着手から worktree 削除までを 10 フェーズで統合管理する Skill。
 > Phase 0 worktree 作成 + master fetch / Phase 1-4 実装 + Self-Verification / Phase 5 Draft PR 起票 /
-> Phase 6 code-reviewer 並列 / Phase 7 R-15 3 条件 merge / Phase 8 pr-poller + roadmap-tracker /
+> Phase 6 code-reviewer 並列 / Phase 7 R-15 3 条件 merge / Phase 8 pr-poller + Plan/Epic frontmatter 同期 + roadmap-tracker /
 > Phase 9 worktree cleanup を順守。fix loop 上限 3 回 (R-14)、auto-merge 禁止 (R-15)、
 > Generator/Evaluator 独立性 (R-13) を維持。詳細手順 SoT は `.claude/rules/implementation-workflow.md`。
 
@@ -62,7 +62,7 @@ related_adrs:
 - **Draft PR**: Phase 5 で `gh pr create --draft --body-file <path>` (`--template` と排他、`--body-file` 一択、改修候補 #8 SoT)
 - **code-reviewer Coordinator レビューコメント**: Phase 6 で `code-reviewer` Skill 起動 → PR に構造化レビューコメント post
 - **merge commit**: Phase 7 で 3 条件充足後 `gh pr merge --squash` (または `--merge`)
-- **learning ファイル + roadmap 更新**: Phase 8 で `pr-poller` / `pr-retrospective` 経由 `docs/harness/learnings/YYYY-MM-DD-pr-<N>.md`、Epic 配下 PR は `roadmap-tracker` で `docs/epics/<id>/roadmap.md` 完了根拠表に PR# + マージ日追記
+- **learning ファイル + Plan/Epic frontmatter + roadmap 更新**: Phase 8 で `pr-poller` / `pr-retrospective` 経由 `docs/harness/learnings/YYYY-MM-DD-pr-<N>.md` 生成 + 関連 Plan/Epic frontmatter 同期 (`docs/plans/PLAN-NNN-*.md` の `status: completed` + `related_pr` + `completed_at`、`docs/plans/INDEX.md` 行更新、Epic 配下全 PR merge 済時のみ `docs/epics/EPIC-NNN-*/README.md` 同期、本 Skill の新責務、R-34 は侵さない) + Epic 配下 PR は `roadmap-tracker` で `docs/epics/<id>/roadmap.md` 完了根拠表に PR# + マージ日追記 (片方向ミラー)
 - **副作用**: Phase 9 で `git worktree remove` + `git branch -D` (squash merge 後は強制削除許容、PR state MERGED 確認後のみ)
 
 ## フェーズ別動作 (10 フェーズ)
@@ -210,12 +210,61 @@ orchestrator 事前承認下でも classifier (auto mode safety layer) が別 la
 - per-task pane: `gh pr ready` で Ready 昇格 → orchestrator pane に完了報告 (`cmux send` で 200 字未満直送、または touch file `/tmp/orchestrator-status-<task>-ready.txt`)
 - orchestrator pane: Ready 昇格を確認 → `gh pr merge --squash` を直接実行 (R-15 事前承認に基づく代行)
 
-### Phase 8: pr-poller 即時起動 + roadmap-tracker
+### Phase 8: pr-poller 即時起動 + Plan/Epic frontmatter 同期 + roadmap-tracker
+
+merge 直後に以下 3 step を順次実行 (各 step の責務は独立、step 2 で R-34 を侵さない設計):
+
+#### Step 1: pr-poller 即時起動 (learning ファイル生成 trigger)
 
 - `pr-poller` を即時起動 → `pr-retrospective` 駆動 → learning ファイル生成 (`docs/harness/learnings/YYYY-MM-DD-pr-<N>.md`)
-- `roadmap-tracker` を起動 (**Epic 配下 PR / B-A-C フェーズ項目に該当時のみ**、Plan 単体は対象外、R-34)
-- mirror PR が必要な場合 (`implementation-workflow` を経由しないマージ + Epic / フェーズ項目該当) は `harness/roadmap-mirror-<phase-id>` ブランチで mirror PR 起票 (`roadmap.md` §手動マージ時の同 PR 更新ルール 参照)
 - learning ファイルは `harness/learnings-batch-YYYY-WW` ブランチに集約、週次 / 件数閾値到達時に PR 起票
+
+#### Step 2: 関連 Plan / Epic frontmatter 同期 (R-34 を侵さない、本 Skill の新責務)
+
+`roadmap-tracker` は R-34 で Plan 対象外 + Epic 本体 (`README.md`) への逆同期も禁止のため、merge 後の Plan / Epic frontmatter 同期は本 Skill が担う (詳細手順 SoT は `.claude/rules/implementation-workflow.md` §Phase 8 関連 Plan / Epic frontmatter 同期)。
+
+1. **関連 ID 抽出 (3 source 統合)**:
+   - **PR description**: `<!-- pr-frontmatter ... -->` 内の `related_plan: PLAN-NNN` / `related_epic: EPIC-NNN` 行を `gh pr view <PR#> --json body` から grep
+   - **branch 名**: `feature/PLAN-NNN-*` / `feature/EPIC-NNN-*-pr-NN` / `feature/<phase-id>-*` 等から ID 抽出
+   - **merge commit message subject**: `(PLAN-NNN)` / `(EPIC-NNN)` / `(A2-3)` 等の言及から ID 抽出
+   - **重複排除 + null skip**: 3 source 統合後に重複 ID を除去、`related_plan: null` / `related_epic: null` の場合は本 step を no-op で抜ける
+
+2. **対応 Plan / Epic ファイルの frontmatter 更新** (現値が `in-progress` の場合のみ):
+   - `docs/plans/PLAN-NNN-*.md` frontmatter: `status: in-progress → completed` + `related_pr: <PR#>` + `completed_at: <YYYY-MM-DD>` (merge 日)
+   - `docs/epics/EPIC-NNN-*/README.md` frontmatter: `status: in-progress` 維持 + `completed_at` は配下全 PR merge 済の場合のみ `completed` 候補としてフラグ立て (最終決定は orchestrator / 人間レビュー)
+   - `docs/plans/INDEX.md`: 対応行の status 列を `in-progress → completed` に更新、`related_pr` 列に PR# 追記
+   - `docs/epics/INDEX.md`: Epic 配下全 PR merge 済確定時のみ更新 (部分完了時は手を付けない)
+   - **誤検知防止**: 現値が `proposed` / `abandoned` / `promoted` 等の他状態の場合は本 Skill では絶対に書き換えない (人間判断が必要なため warning 出力)
+   - **複数 ID 該当時**: 1 PR が複数 Plan / Epic に紐づく場合は全件更新
+
+3. **更新方法の判定 (inline 同期 vs mirror PR)**:
+
+| 方法 | 内容 | 推奨基準 |
+|---|---|---|
+| **inline 同期** | merge した PR の **同一 PR** に Plan/Epic frontmatter 更新 commit を含める (Phase 5 で本体実装と一緒に commit) | 本体 PR の touch ファイル数が 30 以下、Plan/Epic 更新を含めても影響範囲が増えない場合 |
+| **mirror PR** | merge 後に **別 mirror PR** (`harness/mirror-<phase-id>` または `harness/plan-epic-sync-<id>` ブランチ) で Plan/Epic frontmatter 更新を別起票 | 本体 PR が 30 ファイル超 (本セッションの A5/A6 のような 100+ ファイル) で Plan/Epic 更新を分離した方が rebase 容易な場合 |
+
+判定基準は touch ファイル数 > 30 で mirror PR、それ以下なら inline 同期を推奨。並走 spawn 環境では mirror PR がトラブル少ない経験則あり (本セッション A5/A6 事例)、orchestrator 判断で柔軟に切替可。
+
+#### Step 3: roadmap-tracker 起動 (片方向ミラー、既存責務、R-34 維持)
+
+- `roadmap-tracker` を起動 (**Epic 配下 PR / B-A-C フェーズ項目に該当時のみ**、Plan 単体は対象外、R-34)
+- `docs/harness/roadmap.md` (全体) + `docs/epics/<id>/roadmap.md` (Epic 別) を Read-only で取り込み → 完了根拠表 / 着手順変更履歴 / 次の推奨着手を更新 (R-34 片方向ミラー)
+- mirror PR が必要な場合 (`implementation-workflow` を経由しないマージ + Epic / フェーズ項目該当) は `harness/roadmap-mirror-<phase-id>` ブランチで mirror PR 起票 (`roadmap.md` §手動マージ時の同 PR 更新ルール 参照)
+
+#### Phase 8 stale 事例 (運用例)
+
+本セッション (2026-05-19) で発覚した実運用 gap (本拡張責務の起点):
+
+| 対象 | merge 済 PR | 当時の frontmatter | 本拡張で目指す動作 |
+|---|---|---|---|
+| PLAN-001 (ADR 0001-0027) | PR #119 (2026-05-17) | `in-progress` / `related_pr: null` | Step 2 で `completed` + `related_pr: 119` + `completed_at: 2026-05-17` に同期 |
+| PLAN-003 (A8 im@sparql Docker) | PR #175 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 |
+| PLAN-004 (A5 不要モジュール撤去) | PR #176 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 |
+| PLAN-005 (A6 Lint/Format step1) | PR #182 (2026-05-19) | `in-progress` / `related_pr: null` | 同上 |
+| EPIC-A3 (Skill 群実装) | 全 15 PR merge 済 | `in-progress` | Step 2 で配下全 PR merge 済確定後 `completed` 候補としてフラグ立て、人間レビューで `completed` 確定 |
+
+stale 5 件の実 frontmatter 更新は本 PR スコープ外、別 dogfood PR で消化予定 (本拡張責務の初回適用テスト)。
 
 ### Phase 9: Worktree 削除 (orchestrator 経由時は改修候補 #4 SoT)
 
@@ -285,6 +334,10 @@ git branch -d <branch-name>  # 未検出時は -D
 - **Phase 7 で classifier ブロック発生時は迂回せず人間判断を仰ぐ** (PR #125 / #129 レトロ Try): denied メッセージ全文報告 → ユーザー指示待ち、機械的迂回禁止
 - **Phase 7 で per-task pane は `gh pr merge` を実行しない** (改修候補 #3 SoT、orchestrator skill 経由時): Ready 昇格まで per-task pane、merge は orchestrator pane が代行
 - **Phase 8 で `roadmap-tracker` を呼ぶのは Epic 配下 PR / B-A-C フェーズ項目のみ** (R-34): Plan 単体は対象外
+- **Phase 8 Step 2 (Plan/Epic frontmatter 同期) は本 Skill の新責務、R-34 を侵さない** (本セッション 2026-05-19 stale 5 件起点): `roadmap-tracker` は Plan 対象外 + Epic 本体逆同期禁止のため、`docs/plans/PLAN-NNN-*.md` / `docs/plans/INDEX.md` / Epic 配下全 PR merge 済時の `docs/epics/EPIC-NNN-*/README.md` の frontmatter 同期は本 Skill が担う。`roadmap-tracker` の片方向ミラー (`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 専用) との責務分離を明示し、本 Skill から `docs/harness/plan.md` への書き戻しは禁止
+- **Phase 8 Step 2 の ID 抽出は 3 source 統合** (PR description / branch / commit subject): いずれか 1 source からでも抽出できれば更新、`related_plan: null` + `related_epic: null` + branch 名 prefix が `harness/<purpose>` 等 ID 抽出不能ならば本 step は no-op で抜ける
+- **Phase 8 Step 2 で書き換える status は `in-progress → completed` のみ** (誤検知防止): 現値が `proposed` / `abandoned` / `promoted` 等の場合は本 Skill では絶対に書き換えず warning 出力、人間判断を仰ぐ
+- **Phase 8 Step 2 の inline 同期 vs mirror PR 判定は touch ファイル数 > 30 が基準**: 並走 spawn 環境では mirror PR がトラブル少ない経験則あり (本セッション A5/A6 100+ ファイル事例)、orchestrator 判断で柔軟に切替可
 - **Phase 9 の `branch -d` を先にトライし、失敗時のみ `-D` に切替** (PR #123 / #135 レトロ Try): squash merge / merge commit のいずれも `--merged origin/master` で検出されないケースがある、`gh pr view --json state=MERGED` 確認後に `-D` 許容
 - **Phase 9 で per-task pane は `/exit` を実行しない** (改修候補 #4 SoT、orchestrator skill 経由時): orchestrator pane が `cmux close-workspace` で代行
 - **worktree path の slug は `branch-naming.md` 規約に厳密に従う**: スラッシュをハイフンに置換、特殊文字なし


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: null
related_epic: null
related_specs: []
related_adrs:
  - ADR-0017
  - ADR-0018
expected_modules:
  - .claude/skills/implementation-workflow/SKILL.md
  - .claude/rules/implementation-workflow.md
  - .claude/rules/rules-index.md
-->

## 概要

`implementation-workflow` Skill / rule の **Phase 8 (Merge 直後)** に「**関連 Plan / Epic frontmatter 同期**」を新責務として追加するハーネス改修 PR。本セッション (2026-05-19) で発覚した **Skill suite の構造的 gap** (merge 後の Plan / Epic frontmatter 同期を担う Skill が空白だった問題) を `roadmap-tracker` の片方向ミラー原則 (R-34) を侵さずに解消する。

## 背景: 本セッションで発覚した Skill suite gap

本セッションでマージ済の 4 Plan + 1 Epic が **frontmatter / INDEX が in-progress のまま stale** な状態に放置されていた:

| 対象 | 現状 | 実態 |
|---|---|---|
| PLAN-001 (ADR 0001-0027) | `in-progress` / `related_pr: null` | PR #119 merge 済 (2026-05-17) |
| PLAN-003 (A8 im@sparql Docker) | `in-progress` / `related_pr: null` | PR #175 merge 済 (2026-05-19) |
| PLAN-004 (A5 不要モジュール撤去) | `in-progress` / `related_pr: null` | PR #176 merge 済 (2026-05-19) |
| PLAN-005 (A6 Lint/Format step1) | `in-progress` / `related_pr: null` | PR #182 merge 済 (2026-05-19) |
| EPIC-A3 (Skill 群実装) | `in-progress` | 全 15 PR merge 済、roadmap.md では `completed` |

**原因**: 現状の Skill suite で「merge 後の Plan / Epic frontmatter 同期」を担う Skill が無い:

- `roadmap-tracker` は R-34 で **Plan 対象外** (片方向ミラー、`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 専用)、Epic 本体 (`README.md`) への逆同期も禁止
- `plan-author` / `epic-author` は起票専任 (新規作成)
- `implementation-workflow` Phase 8 は `roadmap-tracker` 起動のみで Plan/Epic 本体は触らない
- `pr-retrospective` / `harness-meta` も対象外

これは **Skill suite の構造的 gap**。本 PR で `implementation-workflow` Phase 8 の責務を拡張して解消する。

## 改修方針 (案 A、R-34 を侵さず本 Skill 側に責務追加)

`implementation-workflow` Phase 8 (Merge 直後) の動作に「**関連 Plan / Epic frontmatter 同期**」を追加。R-34 (roadmap-tracker 片方向ミラー、Plan 対象外) は維持し、Plan / Epic 本体の frontmatter 更新は別責務として本 Skill が担う。

### Phase 8 の新 3 step 構成

merge 直後に以下を順に実行 (各 step の責務は独立):

| Step | 内容 | 責務担当 | 既存/新規 |
|---|---|---|---|
| Step 1 | pr-poller 即時起動 → learning ファイル生成 trigger | `pr-poller` / `pr-retrospective` | 既存 |
| Step 2 | **関連 Plan / Epic frontmatter 同期** (本 PR で新規追加) | `implementation-workflow` (本 Skill) | **新責務** |
| Step 3 | `roadmap-tracker` 起動 → `docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 片方向ミラー | `roadmap-tracker` (R-34 維持) | 既存 |

### Step 2 の詳細 (本 PR で新規追加)

#### 2-1. 関連 ID 抽出 (3 source 統合)

| Source | 抽出方法 |
|---|---|
| PR description | `gh pr view <PR#> --json body` の `<!-- pr-frontmatter ... -->` から `related_plan` / `related_epic` 行を grep |
| branch 名 | `feature/PLAN-NNN-*` / `feature/EPIC-NNN-*-pr-NN` / `feature/<phase-id>-*` から正規表現抽出 |
| merge commit subject | `gh pr view <PR#> --json mergeCommit` の `messageHeadline` から `(PLAN-NNN)` / `(EPIC-NNN)` 言及を抽出 |

3 source 統合後に重複 ID を除去 → 抽出 ID 集合を確定。3 source 全てから抽出不能なら no-op で抜ける。

#### 2-2. frontmatter 更新 (現値 `in-progress` の場合のみ)

- `docs/plans/PLAN-NNN-*.md`: `status: in-progress → completed` + `related_pr: <PR#>` + `completed_at: <YYYY-MM-DD>`
- `docs/plans/INDEX.md`: 対応行 status 列を `in-progress → completed`
- `docs/epics/EPIC-NNN-*/README.md`: 配下全 PR merge 済確定時のみ `completed` 候補としてフラグ立て (最終決定は人間レビュー)
- `docs/epics/INDEX.md`: 同上、Epic 配下全 PR merge 済時のみ更新

**status 遷移条件 (誤検知防止の安全網)**: 現値が `proposed` / `abandoned` / `promoted` / `completed` / `blocked` の場合は **本 Skill では絶対に書き換えず warning 出力** (人間判断を仰ぐ)。

#### 2-3. 更新方法の 2 通り (inline 同期 vs mirror PR)

| 方法 | 判定基準 |
|---|---|
| **inline 同期** | 本体 PR の touch ファイル数 **≤ 30** で Plan/Epic 更新を含めても影響範囲が増えない場合 |
| **mirror PR** | 本体 PR が **> 30 ファイル** (A5/A6 100+ ファイル等)、Plan/Epic 更新を分離した方が rebase 容易な場合 |

並走 spawn 環境では mirror PR がトラブル少ない経験則あり (本セッション A5/A6 stale 5 件事例)、orchestrator 判断で柔軟に切替可。

### R-34 維持の確認

| 項目 | 確認 |
|---|---|
| `roadmap-tracker` の責務範囲 | 不変 (`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 片方向ミラー専用) |
| `roadmap-tracker` が触る対象 | 不変 (Plan は対象外、Epic 本体逆同期禁止) |
| 本拡張で `implementation-workflow` が触る対象 | **新規**: `docs/plans/PLAN-NNN-*.md` / `docs/plans/INDEX.md` / `docs/epics/EPIC-NNN-*/README.md` / `docs/epics/INDEX.md` |
| 本拡張で `docs/harness/plan.md` への書き戻し | **禁止** (`docs/harness/plan.md` は SoT、本 Skill は読み取りのみ) |
| Step 2 → Step 3 の順序依存 | 必須 (`roadmap-tracker` が本 Skill 更新済 frontmatter を Read で取り込む) |

`.claude/rules/roadmap.md` / `.claude/skills/roadmap-tracker/SKILL.md` は本 PR で touch しない。

## 変更内容 (touch ファイル 3 件)

| ファイル | 変更内容 |
|---|---|
| `.claude/skills/implementation-workflow/SKILL.md` | Phase 8 セクションを 3 step 構成に拡張、出力セクション / Gotchas / 5 行 summary に Step 2 言及追加 |
| `.claude/rules/implementation-workflow.md` | Phase 8 SoT に Step 2 詳細手順を反映 (ID 抽出 / 更新ロジック / status 遷移条件 6 値 / inline vs mirror PR / R-34 維持の責務分離) + Gotchas に 6 項目追加 |
| `.claude/rules/rules-index.md` | `last_updated: 2026-05-19` 更新 + `implementation-workflow.md` 行の状態列に Phase 8 拡張追記 |

差分規模: +168 / -10 / 3 files、inline 同期可能 (touch < 30)。

## 受け入れ基準 (AC)

- [x] Phase 8 セクションが 3 step 構成に拡張され、Step 2 (Plan/Epic frontmatter 同期) の責務が SKILL.md / rule の両方に SoT として記述されている
- [x] Step 2 の ID 抽出 3 source (PR description / branch / commit subject) が rule に明示されている
- [x] status 遷移条件 6 値 (`proposed` / `in-progress` / `completed` / `abandoned` / `promoted` / `blocked`) が rule に明示され、`in-progress → completed` のみ書き換える誤検知防止安全網が記述されている
- [x] inline 同期 vs mirror PR の判定基準 (touch ファイル数 > 30 で mirror PR) が rule に明示されている
- [x] R-34 (`roadmap-tracker` 片方向ミラー、Plan 対象外) を侵さず、`roadmap-tracker` の責務との分離が rule に明示されている
- [x] `.claude/rules/roadmap.md` / `.claude/skills/roadmap-tracker/SKILL.md` を本 PR で touch していない (R-34 維持)
- [x] 本セッション stale 5 件 (PLAN-001/003/004/005 + EPIC-A3) が運用例として SKILL.md / rule に引用されている
- [x] `rules-index.md` の `last_updated` が更新されている
- [x] 3 commit logical separator (Skill / rule / index) で分離されている

## 三層指標差分

N/A (Kover/Konsist Spec/PITest 未導入、A7 で導入予定)。本 PR は Markdown のみ (rule / Skill 系) のため Line/Branch coverage / Mutation 適用外。

## スコープ外 (後続 PR / dogfood で消化)

- **stale 5 件の実 frontmatter 更新は別 PR (段 1 dogfood) で実施**: 本 PR は Skill / rule 改修のみ。段 1 dogfood で本拡張責務の初回適用テストとして PLAN-001/003/004/005 + EPIC-A3 の frontmatter を更新
- **機械検証 (A6 Gradle カスタムタスク)**: Plan / Epic frontmatter と INDEX.md と merge commit の整合検証は A6 step5 後続 Plan で扱う
- **`docs/harness/plan.md` の R-XX 番号採番**: 本改修に対応する R-37 等の新規 R 追加は本 PR スコープ外、roadmap.md の R 一覧整理時に別途

## レビュー観点

- Phase 8 SoT の Step 2 が R-34 を侵していないか (`docs/harness/roadmap.md` / `docs/epics/<id>/roadmap.md` 片方向ミラー原則の維持)
- 3 source ID 抽出ロジックが正規表現として注入リスクを含まないか (security aspect)
- status 遷移条件 6 値が plan.md / epic.md frontmatter 必須キー仕様と整合しているか (spec-conformance aspect)
- inline 同期 vs mirror PR 判定基準 (touch > 30) が `harness-meta-criteria.md` §分割粒度 + `implementation-workflow.md` §commit 分離規範 と整合しているか (architecture aspect)
- SKILL.md / rule の Gotchas が Phase 8 拡張に必要な罠 / 注意点を網羅しているか (code-quality aspect)

## 関連

- ADR-0017 (ローカル Claude Code ポーリング駆動、Generator/Evaluator 分離)
- ADR-0018 (10 フェーズ設計)
- `.claude/rules/roadmap.md` (R-34 片方向ミラー原則、本 PR では touch せず参照のみ)
- `.claude/rules/plan.md` (Plan frontmatter 必須キー + 採番ライフサイクル PR #175/#176 SoT)
- `.claude/rules/epic.md` (Epic README frontmatter 必須キー)
- `.claude/skills/roadmap-tracker/SKILL.md` (roadmap-tracker 責務 SoT、本改修と分離)
- 本セッション stale 5 件: PLAN-001 (PR #119) / PLAN-003 (PR #175) / PLAN-004 (PR #176) / PLAN-005 (PR #182) / EPIC-A3 (15 PR)

## R-15 事前承認 (orchestrator)

orchestrator pane (workspace:11) の操作者 subroh0508 が本タスク全体 (implementation-workflow Phase 8 拡張 Skill 改修 PR の Phase 0-7 含む) を out-of-band human approval (R-15 該当) で明示的に事前承認済み。マージは orchestrator pane が代行 (本 PR では per-task pane は `gh pr merge` 不実行)。
