### PR TITLE
feat(infra): im@sparql RDF loading 計画立案 (REQ-002 + SPEC-002-basic + PLAN-006)

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -20,6 +20,7 @@ last_updated: 2026-05-19
 | [PLAN-003](PLAN-003-a8-imasparql-docker.md) | A8 im@sparql ローカル Docker 環境構築 (Fuseki container) | feature-request | completed | — | 2026-05-19 |
 | [PLAN-004](PLAN-004-A5-removed-modules.md) | A5 不要モジュール撤去 (js / kotlin-js-store / Firebase Hosting 設定) | refactor | completed | — | 2026-05-19 |
 | [PLAN-005](PLAN-005-A6-lint-format-foundation-step1.md) | A6 Lint/Format 基盤 step1 = Spotless + ktlint 最小統合 | harness | completed | — | 2026-05-19 |
+| [PLAN-006](PLAN-006-imasparql-rdf-loading.md) | im@sparql RDF データ取得と Fuseki への load 計画立案 | feature-request | proposed | — | 2026-05-19 |
 
 ## ステータス語彙
 

--- a/docs/plans/PLAN-006-imasparql-rdf-loading.md
+++ b/docs/plans/PLAN-006-imasparql-rdf-loading.md
@@ -1,0 +1,136 @@
+---
+id: PLAN-006
+title: im@sparql RDF データ取得と Fuseki への load 計画立案
+type: feature-request
+status: proposed
+related_pr: null
+related_epic: null
+related_specs:
+  - SPEC-IMASPARQL-002-basic
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+  - ADR-0021
+expected_modules:
+  - docs/requirements/REQ-002-imasparql-rdf-loading.md
+  - docs/specifications/basic/SPEC-IMASPARQL-002-basic.md
+  - docs/plans/PLAN-006-imasparql-rdf-loading.md
+  - docs/requirements/INDEX.md
+  - docs/plans/INDEX.md
+created_at: 2026-05-19
+completed_at: null
+promoted_to: null
+---
+
+# im@sparql RDF データ取得と Fuseki への load 計画立案
+
+> **5 行以内 summary**: REQ-002 / SPEC-IMASPARQL-002-basic を起票し、im@sparql RDF データ
+> 取得 → Fuseki load → SPARQL クエリ動作確認の一連プロセスを計画立案する単一 PR。
+> 実体実装 (スクリプト / runbook 拡充 / Kotlin code touch) は **本 PR scope 外** で、
+> 後続 Plan-A / Plan-B / Plan-C に分離。新規 5 ファイル (REQ + SPEC + 本 Plan + INDEX 2 件)、
+> 既存 docs touch ゼロで 1 PR 完結を保ち、ロールバックは `git revert` で完全復元可能。
+
+## 目的
+
+REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 (PR #175) で Docker Fuseki 構成は配置済だが
+dataset placeholder のため、実 RDF データ取得 / load / 動作確認の一連プロセスを **計画立案** で
+固める。本 PR は REQ-002 + SPEC-IMASPARQL-002-basic + 本 Plan の 3 docs を起票し、後続実装は
+別 Plan に分離する。
+
+## 背景
+
+PR #175 (A8、merge commit `7add15b`) で配置済の構成:
+
+- `docker-compose.yml` (Fuseki container `stain/jena-fuseki:4.10.0`、port `127.0.0.1:3030` 限定 bind)
+- `data/imasparql/.gitkeep` + `data/imasparql/README.md` (RDF 取得手順 + ライセンス注意の placeholder)
+- `docs/runbooks/local-imasparql.md` (§1-§10 で起動 / 接続確認 / 停止 / トラブルシュート)
+- REQ-001 + SPEC-IMASPARQL-001-basic + PLAN-003
+
+未確立 (本 Plan で計画立案するべき領域):
+
+1. **実 RDF データ取得手段**: upstream URL + ライセンス遵守 + 取得スクリプト (`scripts/fetch-imasparql-data.sh`)
+2. **Fuseki への data load 方式**: bind mount 自動 load (推奨) / Admin API 経由 upload (補足) / TDB2 変換 (将来)
+3. **接続テスト + SPARQL query 動作確認**: 検証スクリプト (`scripts/test-imasparql-query.sh`) と `ASK` / `SELECT` 最小クエリ
+
+本 Plan は **計画立案のみ** (§4.6 コード禁止原則)、実体スクリプト / runbook 拡充 / Kotlin code touch は
+後続 Plan に委ねる。Step A (実環境 `docker compose up -d` 動作確認) は orchestrator pane 側で
+Docker Desktop credential helper hang 復旧後に並行進行、Step B (本 Plan) は Step A 結果に
+関わらず先行して計画立案する。
+
+## アプローチ
+
+1. **REQ-002 起票**: `docs/requirements/REQ-002-imasparql-rdf-loading.md` に WHY / WHAT (FR-1〜FR-7、UC-1〜UC-4、NFR) を記述、`docs/requirements/INDEX.md` に行追加
+2. **SPEC-IMASPARQL-002-basic 起票**: `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` にデータフロー (Mermaid)、取得スクリプト / 検証スクリプトの **識別子レベル定義** (§7.1 / §7.2)、Fuseki load 方式選定 (§7.3、bind mount 自動 load 推奨)、動作確認クエリ (`ASK` + `SELECT` LIMIT 5、`.claude/rules/sparql.md` prefix 整合) を記述
+3. **本 Plan 起票**: `docs/plans/PLAN-006-imasparql-rdf-loading.md` (本ファイル) を新規作成、`docs/plans/INDEX.md` に行追加 (`plan.md` §採番ライフサイクル §1 予約 → §2 起票 SoT 準拠、PLAN-005 の次 = PLAN-006)
+4. **詳細設計 SPEC-IMASPARQL-002-detail は本 Plan scope 外**: 本 PR は docs 起票のみ / Kotlin module touch ゼロのため対象なし。後続 Plan-A / Plan-B 完走後または Phase C5 着手時に起票
+5. **既存 docker-compose.yml / data/imasparql/README.md / docs/runbooks/local-imasparql.md / backend/** は touch しない**: 本 Plan scope 外、後続 Plan-A / Plan-B が `docs/runbooks/local-imasparql.md` に § RDF データ取得 / § 動作確認 セクションを追加する
+6. **commit 分離**: `implementation-workflow.md` §commit 分離規範 + PR #174 §commit 分離規範 準拠で 3 commit (REQ / SPEC / Plan)
+
+## 受け入れ基準
+
+- [ ] AC-1: `docs/requirements/REQ-002-imasparql-rdf-loading.md` が 11 セクション (概要 / アクター / スコープ / UC / FR / NFR / 制約 / 用語 / トレーサビリティ / AC / Open Questions) で起票される
+- [ ] AC-2: `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` が 11 セクションで起票され、upstream URL 候補 + 取得スクリプト / 検証スクリプト識別子レベル定義 + Fuseki load 方式選定 (bind mount 推奨) を含む
+- [ ] AC-3: `docs/plans/PLAN-006-imasparql-rdf-loading.md` (本ファイル) が起票され、後続 Plan-A / Plan-B / Plan-C を placeholder で列挙する
+- [ ] AC-4: `docs/requirements/INDEX.md` に REQ-002 行が追加され、`docs/plans/INDEX.md` に PLAN-006 行が追加される
+- [ ] AC-5: ライセンス CC BY-NC-SA 4.0 が REQ-002 / SPEC-IMASPARQL-002-basic の双方で明示される (`grep -c "CC BY-NC-SA"` で REQ + SPEC 合算 4 以上)
+- [ ] AC-6: 設計書本文 (`docs/requirements/REQ-002-*.md` / `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md`) にコード断片が含まれない (§4.6.1、Mermaid と表のみ)
+- [ ] AC-7: 本 PR では `docker-compose.yml` / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md` / `backend/**` を一切 touch しない (`git diff` で確認)
+- [ ] AC-8: REQ-002 / SPEC-IMASPARQL-002-basic / PLAN-006 の frontmatter `related_*` が **block 形式** で記述され、双方向リンクが整合する (`docs-structure.md` §frontmatter 規約)
+
+## スコープ外
+
+- 取得スクリプト (`scripts/fetch-imasparql-data.sh`) の実体実装 → **後続 Plan-A**
+- 検証スクリプト (`scripts/test-imasparql-query.sh`) の実体実装 → **後続 Plan-B**
+- `docs/runbooks/local-imasparql.md` の § RDF データ取得 / § 動作確認 セクション追加 → **後続 Plan-A / Plan-B**
+- Backend / CLI `ImasparqlApiClient` の endpoint 切替実装 (`IMASPARQL_ENDPOINT_URL`) → **後続 Plan-C**
+- Testcontainers 統合 / CI での Fuseki 自動起動 → Phase B-C で本格化、別 Plan
+- 公開 endpoint と Fuseki の自動 fallback ロジック
+- 詳細設計 `SPEC-IMASPARQL-002-detail` の起票 → 後続 Plan-A / Plan-B 完走後 or Phase C5
+- A8 PR #175 で残された Improvement (SPEC-001 `related_detail: []` の更新、Testcontainers / endpoint 切替の後続 Plan backlink、`.dockerignore` 配置 TODO、`docker-compose.yml` image tag Renovate 対応注記) → 本 Plan は計画立案のみのため touch しない、後続 Plan / A6 / C7 で扱う
+
+## ロールバック手順
+
+外部依存ゼロ。本 PR は docs 5 ファイル追加のみ (REQ + SPEC + Plan + INDEX 2 件)。
+
+1. `git revert <pr-merge-commit>` で本 PR の commit 群を打ち消し
+2. `docs/requirements/REQ-002-*.md` / `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` / `docs/plans/PLAN-006-*.md` が削除される
+3. `docs/requirements/INDEX.md` / `docs/plans/INDEX.md` の REQ-002 / PLAN-006 行が removed
+4. backend / runbook / docker-compose / data/imasparql/ は本 PR で touch していないため復元対象なし
+5. revert 後、後続 Plan-A / Plan-B / Plan-C は再起票が必要 (placeholder 参照が失われるため)
+
+## 後続 Plan placeholder
+
+本 Plan の `completed` 後に起票する後続 Plan を以下に列挙する (各 Plan の expected_modules
+は non-overlap、独立 PR で merge 可能、`plan.md` §採番ライフサイクル §1 予約に従って起票時に
+連番採番)。
+
+### 後続 Plan-A: RDF データ取得スクリプト実装 + runbook § RDF データ取得 セクション追加
+
+- expected_modules: `scripts/fetch-imasparql-data.sh` / `docs/runbooks/local-imasparql.md` (§ RDF データ取得 追記)
+- 主タスク: upstream URL の確定 (SPEC-002-basic §7 候補 1 を Phase 1 で実走、配布元廃止時は候補 2 にフォールバック) / retry / timeout / ライセンス確認対話 / 動作確認結果 (RDF サイズ / 取得時間) の SPEC NFR 表反映
+- AC 例: スクリプトを `scripts/fetch-imasparql-data.sh` として実装、`data/imasparql/imasparql.ttl` が配置される、runbook §5 dataset 投入手順を § RDF データ取得 / § dataset 投入 に分割 / 拡充
+- 起票判定: 本 Plan merge 後、SPEC-002-basic §11 Open Question (upstream URL 確定 / bind mount 自動 load 設定) の resolve タイミングで起票
+
+### 後続 Plan-B: 検証スクリプト実装 + runbook § 動作確認 セクション追加 + Step A 動作確認結果
+
+- expected_modules: `scripts/test-imasparql-query.sh` / `docs/runbooks/local-imasparql.md` (§ 動作確認 追記)
+- 主タスク: `ASK` / `SELECT` LIMIT 5 クエリ実装 (`.claude/rules/sparql.md` prefix 整合) / Fuseki dataset 件数検証 / Step A (orchestrator pane で実環境 `docker compose up -d` 動作確認) の結果反映
+- AC 例: スクリプトを `scripts/test-imasparql-query.sh` として実装、`docker compose up -d fuseki` + bind mount load + 検証スクリプト exit 0 までを runbook §動作確認 で記述
+- 起票判定: 後続 Plan-A merge 後、Step A 完走 (Docker Desktop credential helper 復旧後の `docker compose up -d` 成功) のタイミング
+
+### 後続 Plan-C: Backend Kotlin module への接続実装 (`ImasparqlApiClient` endpoint 切替)
+
+- expected_modules: `backend/cli/src/main/kotlin/net/subroh0508/colormaster/backend/cli/imasparql/Constants.kt` / `gradle/libs.versions.toml` (環境変数化向け) / 関連テスト
+- 主タスク: hardcode された `HOSTNAME = "sparql.crssnky.xyz"` を `IMASPARQL_ENDPOINT_URL` 環境変数化、ローカル Fuseki と公開 endpoint の切替実装
+- AC 例: integration test で Fuseki / 公開 endpoint を切替可能、Testcontainers 統合の足掛かりを作る
+- 起票判定: Phase C5 (Litestream 本格運用) と合わせて Epic 化判定、touch ファイル数 > 30 / 仕様波及が複数 SPEC に及ぶ場合は `plan.md` §Epic 昇格条件 4 行表に従って Epic 化
+
+## メモ
+
+- 本 Plan は **計画立案のみ** (§4.6 コード禁止原則、`feature-request` Skill SoT 準拠): 設計書本文 (REQ-002 / SPEC-IMASPARQL-002-basic) にコード断片を一切書かない、Mermaid と表で表現。`file_path:line` 参照のみ許容
+- 既存 5 docs (REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md`) は本 PR で **touch しない**: 後続 Plan-A / Plan-B が runbook を拡充する責務を負う
+- A8 PR #175 で残された Improvement (SPEC-001 `related_detail: []` の更新、Testcontainers / endpoint 切替の後続 Plan backlink、`.dockerignore` 配置 TODO、`docker-compose.yml` image tag Renovate 対応注記) は本 Plan の SoT 外 (`feature-request` Skill SoT 準拠の計画立案のみ)、後続 Plan-A / A6 (Lint / Format 本格化) / C7 (Cloud Run デプロイ) で扱う
+- `docs/requirements/INDEX.md` / `docs/plans/INDEX.md` は本 PR で 1 行ずつ追記 (placeholder 予約 → 本体起票を 1 PR 内で完結、`plan.md` §採番ライフサイクル §2 起票)
+- 詳細設計 `SPEC-IMASPARQL-002-detail` を本 PR で起票しない判断: SPEC-IMASPARQL-001-basic §9 と同じ基準 (本 PR は docs 起票のみ / Kotlin module touch ゼロ / モジュール責務 / 状態遷移 / 例外パターンを Kotlin 視点で記述する対象が存在しないため)
+- ライセンス遵守: CC BY-NC-SA 4.0 を REQ / SPEC で明示、`data/imasparql/` の git 追跡除外維持を確認 (REQ-001 / PLAN-003 で配置済の `.gitignore` を本 PR で touch しない)
+- code-reviewer 重点 aspect: spec-conformance (§4.6 コード禁止原則遵守 / REQ ⇄ SPEC ⇄ Plan 双方向リンク整合) / architecture (Fuseki load 方式選定の SoT 整合) / security (ライセンス遵守記述 / `data/imasparql/` git 追跡除外 / credentials 漏洩なし) / code-quality (5 行 summary / 日本語見出し / Mermaid / 関連リンク)

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -17,6 +17,7 @@ last_updated: 2026-05-19
 | REQ ID | タイトル | status | related_specs | related_plans | 起票日 |
 |---|---|---|---|---|---|
 | [REQ-001](REQ-001-imasparql-local-docker.md) | im@sparql ローカル Docker 環境 | proposed | SPEC-IMASPARQL-001-basic | PLAN-003 | 2026-05-19 |
+| [REQ-002](REQ-002-imasparql-rdf-loading.md) | im@sparql RDF データ取得と Fuseki への load | proposed | SPEC-IMASPARQL-002-basic | PLAN-006 | 2026-05-19 |
 
 ## ステータス語彙
 

--- a/docs/requirements/REQ-002-imasparql-rdf-loading.md
+++ b/docs/requirements/REQ-002-imasparql-rdf-loading.md
@@ -1,0 +1,170 @@
+---
+id: REQ-002
+title: im@sparql RDF データ取得と Fuseki への load
+status: proposed
+related_specs:
+  - SPEC-IMASPARQL-002-basic
+related_epics: []
+related_plans:
+  - PLAN-006
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+created_at: 2026-05-19
+updated_at: 2026-05-19
+---
+
+# im@sparql RDF データ取得と Fuseki への load
+
+> **5 行以内 summary**: REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 で配置済の Docker Fuseki
+> 構成 (`docker-compose.yml` + `data/imasparql/` + `docs/runbooks/local-imasparql.md`) は
+> dataset placeholder のため、実 RDF データの取得・Fuseki への load・SPARQL クエリ動作確認の
+> 一連プロセスが未確立。本要件は upstream URL とライセンス確認、取得スクリプトと load 方式と
+> 動作確認手順を ADR-0014 に従って整理する計画立案レイヤ。実装は本要件後続の Plan に分離。
+
+## 1. 概要 / 目的 / 背景
+
+ADR-0014 は im@sparql ローカル Fuseki の意思決定済 (2026-05-17)、REQ-001 / SPEC-IMASPARQL-001-basic
+で Docker container 配置済 (PR #175)。ただし `data/imasparql/` は placeholder (空) のままで、
+開発者と AI Coding Agent が **「ゼロから 5 分で Fuseki 起動 + SPARQL クエリ実行まで」を再現**
+するための実 RDF データ取得 / load プロセスが未整備のため、本要件で計画立案を行う。
+
+| 項目 | 内容 |
+|---|---|
+| 目的 | im@sparql RDF データを upstream から取得し、Fuseki container に load し、SPARQL クエリで参照確認できる開発フローを確立する |
+| 背景 | REQ-001 / SPEC-IMASPARQL-001-basic で Docker 構成は配置済 (PR #175)、dataset placeholder のままで実データ取得・load 方式が未確定 (`data/imasparql/README.md` で手動配置と注意喚起のみ) |
+| 期待効果 | ローカル integration test の deterministic 化、AI Coding Agent によるクエリ起草・検証の再現性向上、im@sparql 公開 endpoint への倫理的負荷低減 |
+
+## 2. ステークホルダー / アクター
+
+| アクター | 役割 | 主要なゴール |
+|---|---|---|
+| Backend 開発者 (subroh0508) | SPARQL クエリ起草 / Backend integration test 実装 | 公開 endpoint 非依存で実 RDF データに対するクエリ動作確認 |
+| AI Coding Agent (Claude Code) | implementation-workflow Phase 3 でクエリ起草・検証 | runbook と取得スクリプトから再現可能に Fuseki load まで到達 |
+| im@sparql upstream maintainer | RDF データ提供者 | CC BY-NC-SA 4.0 ライセンス遵守の下での二次利用 |
+
+## 3. スコープ
+
+### 含む
+
+- im@sparql RDF dump の upstream 取得元 (URL / repository / Releases asset 等) と取得手段の明文化
+- 取得スクリプト (`scripts/fetch-imasparql-data.sh` 想定、本要件では識別子のみ、実装は後続 Plan) の仕様定義
+- Fuseki への dataset load 方式 (bind mount 自動 load / Admin API 経由 upload / TDB2 変換) の比較と方針確定
+- SPARQL クエリ動作確認手順 (`ASK` / `SELECT` の最小サンプル) と検証スクリプト (`scripts/test-imasparql-query.sh` 想定、識別子のみ) の仕様定義
+- ライセンス遵守 (CC BY-NC-SA 4.0) の明文化と `data/imasparql/` の git 追跡除外維持
+
+### 含まない (スコープ外)
+
+- 取得スクリプト / 検証スクリプトの実体実装 (本要件 merge 後の後続 Plan-A / Plan-B)
+- `docs/runbooks/local-imasparql.md` の § RDF データ取得 / § 動作確認 セクション追加 (後続 Plan)
+- Backend / CLI (`ImasparqlApiClient`) の endpoint 切替実装 (`IMASPARQL_ENDPOINT_URL`、別 Plan-C)
+- Testcontainers 統合 / CI での Fuseki 自動起動 (Phase B-C で本格化、別 Plan)
+- 公開 endpoint と Fuseki の自動 fallback ロジック
+- RDF データそのものの git commit (ライセンス上 `.gitignore` で除外維持)
+
+## 4. ユースケース概要
+
+```mermaid
+graph LR
+    Dev((Backend 開発者))
+    Agent((AI Coding Agent))
+    UC1[UC-1 RDF データ取得]
+    UC2[UC-2 Fuseki への load]
+    UC3[UC-3 SPARQL クエリ動作確認]
+    UC4[UC-4 ライセンス確認 / 遵守]
+    Dev --> UC1
+    Dev --> UC2
+    Dev --> UC3
+    Dev --> UC4
+    Agent --> UC1
+    Agent --> UC2
+    Agent --> UC3
+```
+
+| UC ID | 名称 | 事前条件 | 事後条件 |
+|---|---|---|---|
+| UC-1 | RDF データ取得 | `docker compose up -d fuseki` 完了 (REQ-001) / upstream URL 解決 | `data/imasparql/*.ttl` 等が配置される (git 追跡対象外) |
+| UC-2 | Fuseki への load | UC-1 完了 / dataset 名 (`imasparql`) 設定済 | Fuseki dataset にトリプルが load 済、件数 > 0 |
+| UC-3 | SPARQL クエリ動作確認 | UC-2 完了 | `SELECT` / `ASK` 等のクエリが期待件数で応答する |
+| UC-4 | ライセンス確認 / 遵守 | upstream URL 解決 | CC BY-NC-SA 4.0 を runbook / README で明示、git 追跡除外維持 |
+
+## 5. 機能要件 (FR)
+
+| FR ID | 機能名 | 説明 | 優先度 | 関連 UC |
+|---|---|---|---|---|
+| FR-1 | upstream URL 解決 | im@sparql RDF dump の upstream (GitHub repository / Releases asset / 公式配布パス) を解決し、SPEC-IMASPARQL-002-basic に明文化する | must | UC-1, UC-4 |
+| FR-2 | 取得スクリプト仕様定義 | `scripts/fetch-imasparql-data.sh` (識別子のみ、実装は後続 Plan) の入出力 / retry / 保存先 / 失敗時挙動を SPEC-IMASPARQL-002-basic で定義する | must | UC-1 |
+| FR-3 | Fuseki load 方式の選定 | bind mount 自動 load / Admin API 経由 upload / TDB2 変換の 3 方式を比較し、本要件用に 1 方式を SPEC で選定する | must | UC-2 |
+| FR-4 | 動作確認クエリ仕様定義 | `ASK { ?s ?p ?o }` および `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5` 等の最小クエリ仕様を SPEC で定義する | must | UC-3 |
+| FR-5 | 検証スクリプト仕様定義 | `scripts/test-imasparql-query.sh` (識別子のみ、実装は後続 Plan) の入出力 / 期待応答を SPEC で定義する | should | UC-3 |
+| FR-6 | ライセンス記述の明示 | CC BY-NC-SA 4.0 を REQ / SPEC / 後続 runbook に明示し、`.gitignore` による git 追跡除外を維持する | must | UC-4 |
+| FR-7 | 後続 Plan placeholder の列挙 | 後続 Plan-A (取得スクリプト実装 + runbook 拡充) / Plan-B (検証スクリプト実装 + 動作確認結果記載) / Plan-C (Backend 接続実装) を PLAN-006 内に placeholder 列挙する | should | UC-1, UC-2, UC-3 |
+
+## 6. 非機能要件 (NFR)
+
+IPA 非機能要求グレード 6 大項目に沿った表。
+
+| 区分 | 指標 | 目標値 | 計測方法 |
+|---|---|---|---|
+| 可用性 | ローカル開発限定、CI / production 非対象 | — | `docker-compose.yml` (REQ-001) は dev profile 相当 |
+| 性能・拡張性 | RDF 取得時間 (目安) | 5 分以内 (RDF サイズ 100MB 想定、開発者帯域依存) | `time scripts/fetch-imasparql-data.sh` (実装後) |
+| 性能・拡張性 | Fuseki load 完了時間 (目安) | 1 分以内 (bind mount 方式) | runbook 手順実走、後続 Plan-A で計測 |
+| 運用・保守性 | 後続 Plan の独立性 | Plan-A / Plan-B / Plan-C を独立 PR で merge 可能 | 各 Plan の expected_modules が non-overlap |
+| 移行性 | 既存 docker-compose.yml / data/imasparql/README.md / docs/runbooks/local-imasparql.md 非破壊 | 本要件 PR では一切 touch しない | `git diff` で確認 |
+| セキュリティ | RDF データの git 追跡除外維持 | `.gitignore` で `data/imasparql/*.ttl` 等を除外 (REQ-001 で配置済) | `git check-ignore data/imasparql/sample.ttl` |
+| セキュリティ | ライセンス遵守 (CC BY-NC-SA 4.0) | upstream 元データのライセンス文言を REQ / SPEC で明示 | 手動 review |
+| システム環境・エコロジー | im@sparql 公開 endpoint への負荷 | 1 回限り取得 (CDN / Releases asset 経由想定)、re-evaluation loop なし | upstream 取得元の選定で担保 |
+
+## 7. 制約 / 前提
+
+- REQ-001 / SPEC-IMASPARQL-001-basic / PLAN-003 (PR #175) で Docker Fuseki 構成 + `data/imasparql/` placeholder + `docs/runbooks/local-imasparql.md` が配置済
+- im@sparql RDF データのライセンスは **CC BY-NC-SA 4.0** (`data/imasparql/README.md` で placeholder として明記済)、二次配布 / 商用利用は upstream 規約に従う
+- `data/imasparql/*.ttl` / `*.nq` / `*.rdf` / `*.nt` は `.gitignore` 対象 (REQ-001 / PLAN-003 で配置済)、本要件でも維持
+- 本要件は **計画立案レイヤ**: 実体スクリプト / runbook 拡充 / Kotlin code touch は **全て本要件のスコープ外**、後続 Plan-A / Plan-B / Plan-C に分離
+- `.claude/rules/sparql.md` の prefix 規約 / `LIMIT` 必須 / injection 対策と整合 (動作確認クエリは prefix セットを必須含)
+- `Backend` Kotlin module への接続実装は Phase C5 / Litestream 連動の後続 Epic / Plan で扱う (本要件のスコープ外)
+
+## 8. 用語定義
+
+| 用語 | 説明 | 関連 |
+|---|---|---|
+| im@sparql | THE iDOLM@STER ドメイン RDF + SPARQL endpoint (https://sparql.crssnky.xyz/) | ADR-0007 / `.claude/rules/sparql.md` |
+| RDF dump | im@sparql の triple を一括取得した Turtle / N-Quads / RDF/XML / N-Triples 形式のファイル群 | W3C RDF 1.1 |
+| Apache Jena Fuseki | Java 実装の SPARQL 1.1 サーバ、本リポジトリは `stain/jena-fuseki:4.10.0` を使用 (REQ-001) | https://jena.apache.org/documentation/fuseki2/ |
+| TDB2 | Jena の永続化バックエンド、in-memory より起動コスト高、再起動間でデータ保持 | Fuseki configuration |
+| bind mount 自動 load | docker-compose の `volumes` 経由で staging ディレクトリを container に mount、Fuseki 起動時に `*.ttl` を読み込む方式 | docker-compose v2 |
+| CC BY-NC-SA 4.0 | Creative Commons 表示 - 非営利 - 継承 4.0 ライセンス | https://creativecommons.org/licenses/by-nc-sa/4.0/ |
+
+ドメイン用語の追加は `docs/glossary.md` を参照。
+
+## 9. トレーサビリティ
+
+| FR ID | 関連 SPEC | 関連 EPIC | 関連 PLAN | 関連 ADR |
+|---|---|---|---|---|
+| FR-1 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0007 / ADR-0014 |
+| FR-2 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0014 |
+| FR-3 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0014 |
+| FR-4 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0014 |
+| FR-5 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0014 |
+| FR-6 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | ADR-0014 / ADR-0021 |
+| FR-7 | SPEC-IMASPARQL-002-basic | — | PLAN-006 | — |
+
+## 10. 受け入れ基準 (AC)
+
+- [ ] AC-1: `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` が起票され、FR-1 / FR-3 の選定結果 (upstream URL 候補 / Fuseki load 方式) が明示される (FR-1 / FR-3)
+- [ ] AC-2: SPEC 内で `scripts/fetch-imasparql-data.sh` および `scripts/test-imasparql-query.sh` の入出力 / 失敗時挙動 / 保存先が **識別子レベル** で定義される (実体は本要件 PR では作成しない) (FR-2 / FR-5)
+- [ ] AC-3: 動作確認クエリ仕様 (`ASK { ?s ?p ?o }` および `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5`) が SPEC に記載され、`.claude/rules/sparql.md` prefix セットと整合する (FR-4)
+- [ ] AC-4: ライセンス CC BY-NC-SA 4.0 が REQ-002 / SPEC-IMASPARQL-002-basic の双方で明示され、`data/imasparql/` の git 追跡除外維持を SPEC 内で確認する (FR-6)
+- [ ] AC-5: `docs/plans/PLAN-006-imasparql-rdf-loading.md` が起票され、後続 Plan-A / Plan-B / Plan-C を placeholder で列挙する (FR-7)
+- [ ] AC-6: `docs/requirements/INDEX.md` および `docs/plans/INDEX.md` に REQ-002 / PLAN-006 の行が追加される
+- [ ] AC-7: 本 PR では `docker-compose.yml` / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md` / `backend/**` を一切 touch しない (`git diff` で確認)
+
+## 11. Open Questions
+
+| 起票日 | 内容 | 暫定方針 | 解決状態 |
+|---|---|---|---|
+| 2026-05-19 | im@sparql RDF dump の upstream URL 確定 (`imas/imasparql` GitHub repository / Releases asset / 公式配布パス) | SPEC-IMASPARQL-002-basic §7 (外部 I/F) で候補列挙 + 本要件後続 Plan-A の Phase 1 で確定 | open |
+| 2026-05-19 | RDF データ実体サイズと取得時間の実測値 | 後続 Plan-A 完走時に実測、SPEC NFR 表を更新 | open |
+| 2026-05-19 | Fuseki load 方式 (bind mount 自動 load vs Admin API upload) の最終選定 | SPEC-IMASPARQL-002-basic §2 で bind mount 自動 load を default として記述、Admin API 経由は補足 | open |
+| 2026-05-19 | TDB2 永続化の本格採用タイミング | 後続 Plan-B 完走後に再評価 (in-memory での起動時 load 時間が許容範囲内か計測) | open |
+| 2026-05-19 | 後続 Plan-C (Backend Kotlin module 接続実装) の起票時期 | Phase C5 / Litestream 連動と合わせて再評価、本要件では placeholder 列挙のみ | open |

--- a/docs/specifications/basic/SPEC-IMASPARQL-002-basic.md
+++ b/docs/specifications/basic/SPEC-IMASPARQL-002-basic.md
@@ -1,0 +1,259 @@
+---
+id: SPEC-IMASPARQL-002-basic
+title: im@sparql RDF データ取得と Fuseki への load 基本設計
+type: spec-basic
+status: proposed
+related_requirements:
+  - REQ-002
+related_detail: []
+related_epics: []
+related_plans:
+  - PLAN-006
+related_adrs:
+  - ADR-0007
+  - ADR-0014
+  - ADR-0021
+created_at: 2026-05-19
+updated_at: 2026-05-19
+---
+
+# im@sparql RDF データ取得と Fuseki への load 基本設計
+
+> **5 行以内 summary**: REQ-002 を実体化する基本設計。upstream RDF 取得元 / 取得スクリプト
+> (`scripts/fetch-imasparql-data.sh`) / Fuseki load 方式 (bind mount 自動 load 推奨) /
+> 動作確認クエリ (`ASK` + `SELECT` LIMIT 5) / 検証スクリプト (`scripts/test-imasparql-query.sh`)
+> の仕様を定義する。本 SPEC は **識別子レベル定義** で実体実装は後続 Plan-A / Plan-B に分離、
+> 詳細設計 (`SPEC-IMASPARQL-002-detail`) は本 PR では起票しない (`related_detail: []`)。
+
+## 1. 概要 (5 行以内サマリ)
+
+REQ-001 / SPEC-IMASPARQL-001-basic で配置済の Docker Fuseki 構成に、実 RDF データを upstream
+から取得し dataset として load して SPARQL クエリで参照確認するまでの一連プロセスを定義する。
+upstream は CC BY-NC-SA 4.0 ライセンス遵守、取得スクリプトと検証スクリプトは識別子レベル定義
+(実体実装は後続 Plan)、Fuseki load 方式は既設 `data/imasparql:/staging` bind mount を流用する
+方針で、`docs/runbooks/local-imasparql.md` の §5 dataset 投入手順を後続 Plan で拡充する形に
+段階移行する。
+
+## 2. システム構成
+
+```mermaid
+graph LR
+    Upstream[upstream RDF<br/>CC BY-NC-SA 4.0]
+    Fetch[scripts/fetch-imasparql-data.sh<br/>後続 Plan-A で実装]
+    Staging[data/imasparql/*.ttl<br/>.gitignore 対象]
+    Mount[bind mount<br/>data/imasparql -> /staging:ro]
+    Fuseki[(Fuseki container<br/>stain/jena-fuseki:4.10.0)]
+    Dataset[Fuseki dataset<br/>name: imasparql]
+    Endpoint[SPARQL endpoint<br/>127.0.0.1:3030/imasparql/query]
+    Test[scripts/test-imasparql-query.sh<br/>後続 Plan-B で実装]
+    Upstream --> Fetch
+    Fetch --> Staging
+    Staging --> Mount
+    Mount --> Fuseki
+    Fuseki --> Dataset
+    Dataset --> Endpoint
+    Test --> Endpoint
+```
+
+| 構成要素 | 役割 | 関連 ADR / 関連 SPEC |
+|---|---|---|
+| upstream RDF 配布元 | im@sparql RDF dump の取得元 (GitHub repository / Releases asset / 公式配布パス) | ADR-0007 |
+| `scripts/fetch-imasparql-data.sh` | upstream から `*.ttl` を取得し `data/imasparql/` に配置する取得スクリプト (本 SPEC では識別子のみ、実装は後続 Plan-A) | ADR-0014 |
+| `data/imasparql/` (staging) | RDF データの配置先、`.gitignore` で git 追跡除外 (REQ-001 / PLAN-003 で配置済) | SPEC-IMASPARQL-001-basic |
+| Fuseki container | SPARQL 1.1 endpoint + 管理 UI を `127.0.0.1:3030` で提供 (REQ-001 で配置済) | SPEC-IMASPARQL-001-basic / ADR-0014 |
+| Fuseki dataset (`imasparql`) | `FUSEKI_DATASET_1=imasparql` (REQ-001 で配置済) で公開される SPARQL dataset | SPEC-IMASPARQL-001-basic |
+| `scripts/test-imasparql-query.sh` | `ASK` / `SELECT` 最小クエリで Fuseki dataset の non-empty を検証する (識別子のみ、実装は後続 Plan-B) | `.claude/rules/sparql.md` |
+
+## 3. 機能一覧と要件マッピング
+
+| SPEC-ID | 機能名 | 関連 FR ID | 関連 AC ID |
+|---|---|---|---|
+| SPEC-IMASPARQL-002-1 | upstream URL 解決と SPEC 記述 | FR-1 | AC-1 |
+| SPEC-IMASPARQL-002-2 | 取得スクリプト (`fetch-imasparql-data.sh`) 仕様定義 | FR-2 | AC-2 |
+| SPEC-IMASPARQL-002-3 | Fuseki load 方式選定 (bind mount 自動 load 推奨) | FR-3 | AC-1 |
+| SPEC-IMASPARQL-002-4 | 動作確認クエリ仕様定義 (`ASK` / `SELECT` LIMIT 5) | FR-4 | AC-3 |
+| SPEC-IMASPARQL-002-5 | 検証スクリプト (`test-imasparql-query.sh`) 仕様定義 | FR-5 | AC-2 |
+| SPEC-IMASPARQL-002-6 | ライセンス CC BY-NC-SA 4.0 遵守の明示 | FR-6 | AC-4 |
+| SPEC-IMASPARQL-002-7 | 後続 Plan placeholder 列挙 | FR-7 | AC-5 |
+
+## 4. 業務フロー
+
+```mermaid
+sequenceDiagram
+    actor Dev as 開発者 / AI Agent
+    participant Fetch as scripts/fetch-imasparql-data.sh<br/>(後続 Plan-A)
+    participant Upstream as upstream RDF<br/>CC BY-NC-SA 4.0
+    participant Staging as data/imasparql/
+    participant Compose as docker compose
+    participant Fuseki as Fuseki container
+    participant Endpoint as SPARQL endpoint
+    participant Test as scripts/test-imasparql-query.sh<br/>(後続 Plan-B)
+
+    Dev->>Fetch: 起動 (引数: upstream URL / 保存先)
+    Fetch->>Upstream: HTTP GET (retry + timeout)
+    Upstream-->>Fetch: *.ttl レスポンス
+    Fetch->>Staging: data/imasparql/imasparql.ttl 書き出し
+    Dev->>Compose: docker compose up -d fuseki (REQ-001 既設)
+    Compose->>Fuseki: container 起動
+    Fuseki->>Staging: bind mount で /staging:ro 経由 load
+    Fuseki-->>Endpoint: dataset (imasparql) を公開
+    Dev->>Test: 起動 (引数: endpoint URL)
+    Test->>Endpoint: ASK { ?s ?p ?o }
+    Endpoint-->>Test: HTTP 200 + boolean: true
+    Test->>Endpoint: SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5
+    Endpoint-->>Test: HTTP 200 + 5 件の triple
+    Test-->>Dev: 検証結果 (exit code 0 / 非 0)
+```
+
+## 5. 画面遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoData: 初期状態 (data/imasparql/ 空)
+    NoData --> Fetching: fetch-imasparql-data.sh 起動
+    Fetching --> Staged: 取得成功 (*.ttl 配置完了)
+    Fetching --> NoData: 取得失敗 (retry 上限 / ライセンス確認失敗)
+    Staged --> Loaded: docker compose up -d fuseki (bind mount load)
+    Loaded --> Verified: test-imasparql-query.sh が ASK / SELECT 成功
+    Loaded --> LoadFailed: dataset 空 / 起動失敗
+    LoadFailed --> Staged: 修正 + 再起動
+    Verified --> [*]: 動作確認完了
+```
+
+| 状態 | 説明 | 遷移トリガー |
+|---|---|---|
+| NoData | 初期状態、`data/imasparql/` が `.gitkeep` + `README.md` のみ | 取得スクリプト起動 |
+| Fetching | upstream から RDF 取得中 | HTTP GET 完了 / 失敗 |
+| Staged | RDF が `data/imasparql/*.ttl` 等として配置済 (git 追跡対象外) | Fuseki container 起動 |
+| Loaded | Fuseki dataset にトリプル load 完了 | 動作確認スクリプト起動 |
+| LoadFailed | dataset 件数 0 / 起動失敗 | 修正 → 再起動 |
+| Verified | `ASK` / `SELECT` クエリ成功 | — |
+
+## 6. データモデル (論理)
+
+```mermaid
+erDiagram
+    UPSTREAM_RDF ||--o{ RDF_FILE : "produces"
+    RDF_FILE ||--o{ RDF_TRIPLE : "contains"
+    RDF_FILE {
+      string filename
+      string format "ttl / nq / rdf / nt"
+      int size_bytes
+      string license "CC BY-NC-SA 4.0"
+    }
+    RDF_TRIPLE {
+      string subject
+      string predicate
+      string object
+    }
+    UPSTREAM_RDF {
+      string source_url
+      string version_or_commit
+      string license
+    }
+    FUSEKI_DATASET ||--o{ RDF_TRIPLE : "indexes"
+    FUSEKI_DATASET {
+      string name "imasparql"
+      string type "in-memory or TDB2"
+      int triple_count
+    }
+```
+
+| エンティティ | 属性 | 制約 | 説明 |
+|---|---|---|---|
+| UPSTREAM_RDF | source_url / version_or_commit / license | license = CC BY-NC-SA 4.0、source_url は SPEC §7 で候補列挙 | im@sparql RDF dump の upstream 識別子 |
+| RDF_FILE | filename / format / size_bytes / license | format ∈ {ttl, nq, rdf, nt}、`data/imasparql/` 配下、`.gitignore` 対象 | 取得スクリプトが配置する RDF ファイル |
+| RDF_TRIPLE | subject / predicate / object | RDF 1.1 準拠 | Fuseki dataset の triple 単位 |
+| FUSEKI_DATASET | name / type / triple_count | name = `imasparql` (REQ-001 既設)、type は in-memory default | Fuseki が hosting する SPARQL dataset |
+
+物理的な `*.ttl` フォーマット / Fuseki configuration 詳細は upstream 配布物 + `docker-compose.yml` (REQ-001) を SoT として参照。
+
+## 7. 外部 I/F 一覧
+
+詳細リクエスト / レスポンス JSON は SPARQL 1.1 Protocol (https://www.w3.org/TR/sparql11-protocol/) を Single Source of Truth として参照。
+
+| I/F 名 | 種別 | エンドポイント / パス | 入力概要 | 出力概要 | 関連 ADR |
+|---|---|---|---|---|---|
+| upstream RDF 取得 (候補 1) | HTTP GET | `imas/imasparql` GitHub repository の raw / Releases asset (要確認、PLAN-006 後続 Plan-A の Phase 1 で確定) | URL | `*.ttl` バイナリ | ADR-0007 |
+| upstream RDF 取得 (候補 2、フォールバック) | HTTP GET | im@sparql 公開 endpoint (https://sparql.crssnky.xyz) への `CONSTRUCT { ?s ?p ?o } WHERE { ... }` クエリ | SPARQL CONSTRUCT | Turtle | ADR-0007 |
+| Fuseki SPARQL Query | HTTP GET / POST | `http://127.0.0.1:3030/imasparql/query` | `ASK` / `SELECT` | SPARQL Results JSON / boolean | ADR-0014 |
+| Fuseki Admin Data Upload (代替) | HTTP POST | `http://127.0.0.1:3030/imasparql/data` | RDF (`text/turtle` 等) | 204 No Content | ADR-0014 / SPEC-IMASPARQL-001-basic |
+| Fuseki Ping | HTTP GET | `http://127.0.0.1:3030/$/ping` | — | `pong\n` 相当 | SPEC-IMASPARQL-001-basic |
+
+### 7.1. 取得スクリプト仕様 (識別子レベル、SPEC-IMASPARQL-002-2)
+
+| 項目 | 内容 |
+|---|---|
+| パス | `scripts/fetch-imasparql-data.sh` (本 PR では識別子のみ、実装は後続 Plan-A) |
+| 入力 | `--source-url <URL>` (default: upstream 候補 1) / `--dest <path>` (default: `data/imasparql/imasparql.ttl`) |
+| 出力 | RDF ファイル 1 つ以上を `data/imasparql/` 配下に配置、exit code 0 (成功) / 非 0 (失敗) |
+| retry | HTTP 取得失敗時に exponential backoff で 3 回 retry |
+| timeout | 1 回あたり 60 秒、合計 5 分以内 |
+| ライセンス確認 | スクリプト起動時に標準出力で「CC BY-NC-SA 4.0 を確認しましたか? (y/n)」確認 (将来は環境変数 `IMASPARQL_LICENSE_ACK=1` で skip 可) |
+
+### 7.2. 検証スクリプト仕様 (識別子レベル、SPEC-IMASPARQL-002-5)
+
+| 項目 | 内容 |
+|---|---|
+| パス | `scripts/test-imasparql-query.sh` (本 PR では識別子のみ、実装は後続 Plan-B) |
+| 入力 | `--endpoint <URL>` (default: `http://127.0.0.1:3030/imasparql/query`) |
+| 出力 | 検証結果を標準出力に表示、exit code 0 (成功) / 非 0 (失敗) |
+| 試行クエリ 1 | `ASK { ?s ?p ?o }` → 期待: HTTP 200 + boolean: true |
+| 試行クエリ 2 | `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5` → 期待: HTTP 200 + 5 件の triple |
+| prefix | `.claude/rules/sparql.md` の必須 prefix セット (`rdf` / `rdfs` / `schema` / `imas` / `imass`) を含む |
+| HTTP Accept | `application/sparql-results+json` |
+
+### 7.3. Fuseki load 方式選定 (SPEC-IMASPARQL-002-3)
+
+| 方式 | 採用 | 理由 |
+|---|---|---|
+| **bind mount 自動 load** (推奨) | ✅ default | REQ-001 で既に `data/imasparql:/staging` mount が配置済、Fuseki container 起動時の environment / 起動オプション (`FUSEKI_DATASET_1=imasparql` + staging ディレクトリ参照) で自動 load 可能、開発者操作が最小 |
+| Admin API 経由 upload | △ 補足 | runbook `§5.2` (`docs/runbooks/local-imasparql.md`) で既に手順記載済、bind mount 自動 load が失敗した場合のフォールバック |
+| TDB2 直接配置 / 変換 | ✗ 現時点不採用 | TDB2 永続化は REQ-001 §8 オプション扱い、本 SPEC では in-memory + bind mount を default。再評価は後続 Plan-B 完走時 |
+
+## 8. エラーケース / 例外パターン
+
+| ケース | 発生条件 | UX | ログ | メトリクス |
+|---|---|---|---|---|
+| upstream URL 解決失敗 | upstream repository が存在しない / 廃止 | 後続 Plan-A の Phase 1 で再選定、SPEC §7 の候補 2 (公開 endpoint からの CONSTRUCT 抽出) にフォールバック | 取得スクリプト stderr | — |
+| ライセンス確認 NG | 取得スクリプト起動時の対話で `n` 応答 | スクリプト exit code 非 0、データ取得中断 | stderr に「CC BY-NC-SA 4.0 を確認してから再実行してください」 | — |
+| RDF 取得 timeout | 60 秒以内 / 3 回 retry 後も失敗 | スクリプト exit code 非 0、ネットワーク状況 / proxy 設定を runbook §トラブルシュートで確認 | stderr に retry 履歴 | — |
+| RDF format 不一致 | upstream が Turtle 以外の形式で配布 | 取得スクリプトが Turtle 以外を検出した場合 stderr で警告、Fuseki 側で load 成否を切り分け | stderr | — |
+| bind mount load 失敗 | Fuseki が `/staging` を認識できない / dataset 空 | Fuseki 管理 UI で dataset 件数 0 を確認、Admin API 経由 upload にフォールバック (runbook §5.2) | Fuseki ログ | — |
+| 検証クエリ 0 件応答 | dataset 件数 0 (load 失敗) | 検証スクリプト exit code 非 0、bind mount / upload を再試行 | stderr | — |
+| 検証クエリ 4xx / 5xx | endpoint URL 誤り / Fuseki 停止 | 検証スクリプト exit code 非 0、Fuseki container 起動状態を `docker compose ps` で確認 | stderr | — |
+
+## 9. 受け入れ基準 (AC) ↔ テストマップ
+
+| AC ID | 内容 | 対応 SPEC-ID-detail | 期待テスト種別 |
+|---|---|---|---|
+| AC-1 | SPEC 内で upstream URL 候補 + Fuseki load 方式選定が明示される | (詳細設計なし / 本 PR のみで完結) | 手動 review (§2 / §7 / §7.3 を確認) |
+| AC-2 | 取得スクリプト / 検証スクリプトの入出力 / 失敗時挙動 / 保存先が識別子レベルで定義される | 同上 | 手動 review (§7.1 / §7.2 を確認) |
+| AC-3 | 動作確認クエリ仕様が `.claude/rules/sparql.md` prefix セットと整合する | 同上 | 手動 review (§7.2 prefix 行を確認) |
+| AC-4 | ライセンス CC BY-NC-SA 4.0 が SPEC §1 / §7 / §11 に明示される | 同上 | 手動 (`grep -c "CC BY-NC-SA"` で 2 以上) |
+| AC-5 | 後続 Plan-A / Plan-B / Plan-C を placeholder で列挙する | (PLAN-006 メモセクションで列挙) | 手動 review (PLAN-006 を確認) |
+| AC-6 | `docs/requirements/INDEX.md` / `docs/plans/INDEX.md` に REQ-002 / PLAN-006 行が追加される | — | 手動 (`git diff docs/{requirements,plans}/INDEX.md` で差分確認) |
+| AC-7 | 本 PR では `docker-compose.yml` / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md` / `backend/**` を一切 touch しない | — | 手動 (`git diff` で確認) |
+
+詳細設計 (`SPEC-IMASPARQL-002-detail`) は本 SPEC では作成しない (本 PR は docs 起票のみ / 実体スクリプト / Kotlin module touch ゼロのため、モジュール責務 / 状態遷移 / 例外パターンを Kotlin 視点で記述する対象が存在しない、SPEC-IMASPARQL-001-basic §9 の判断と同一基準)。後続 Plan-A / Plan-B 完走後、または Phase B-C の Backend integration test 本格化時に詳細設計を起こす方針。
+
+## 10. 関連 ADR / リスク
+
+- ADR-0007 (im@sparql upstream-driven 同期、本 SPEC は取得側)
+- ADR-0014 (Apache Jena Fuseki Docker 採用、本 SPEC は REQ-001 の dataset load 拡張)
+- ADR-0021 (Secrets 管理、`.env` / `FUSEKI_ADMIN_PASSWORD` 規約と整合)
+- リスク 1: upstream RDF 配布元の長期メンテナンス継続性 (`imas/imasparql` の運用状況に依存)。配布元廃止時は公開 endpoint からの CONSTRUCT 抽出 (§7 候補 2) にフォールバック
+- リスク 2: RDF データの実体サイズが想定 (100MB) を大きく超える場合、bind mount + in-memory load の起動時間が悪化。後続 Plan-B 完走時に実測して TDB2 永続化 (SPEC-IMASPARQL-001-basic §11 Open Question) を再評価
+- リスク 3: CC BY-NC-SA 4.0 の二次配布制約により、`data/imasparql/` の git 追跡除外 / repository commit 禁止を継続。商用利用 / fork 時は upstream 規約を再確認
+- リスク 4: upstream 取得が公開 endpoint への倫理的負荷を生まないよう、配布元 (GitHub Releases asset 等) の優先度を高く保ち、CONSTRUCT 抽出は最小限・キャッシュ前提に留める
+
+## 11. Open Questions
+
+| 起票日 | 内容 | 暫定方針 | 解決状態 |
+|---|---|---|---|
+| 2026-05-19 | upstream URL 確定 (`imas/imasparql` GitHub repository / Releases asset / 公式配布パス) | 後続 Plan-A の Phase 1 で確定、本 SPEC §7 候補 1 + 候補 2 (フォールバック) を列挙 | open |
+| 2026-05-19 | bind mount 自動 load の Fuseki 設定 (`FUSEKI_DATASET_1` のみで startup hook が staging ディレクトリを読むか、追加 env / startup script が必要か) | 後続 Plan-A の Phase 2 で `stain/jena-fuseki:4.10.0` のドキュメントを再確認、必要なら `docker-compose.yml` 拡張 (本 SPEC scope 外、後続 Plan-A) | open |
+| 2026-05-19 | RDF データ実体サイズの実測値と取得時間 | 後続 Plan-A 完走時に実測、SPEC NFR 表 (REQ-002 §6) を更新 | open |
+| 2026-05-19 | TDB2 永続化の本格採用タイミング | 後続 Plan-B 完走後に再評価 (in-memory での起動時 load 時間が許容範囲内か計測)、SPEC-IMASPARQL-001-basic §11 Open Question と統合判断 | open |
+| 2026-05-19 | 詳細設計 `SPEC-IMASPARQL-002-detail` の起票時期 | 後続 Plan-A / Plan-B 完走後、または Phase C5 / Backend integration test 本格化時 | open |
+| 2026-05-19 | 後続 Plan-C (Backend Kotlin module 接続実装) の起票時期と Epic 化判定 | Phase C5 / Litestream 連動と合わせて Epic 化判定、本 SPEC では Plan placeholder のみ列挙 | open |


### PR DESCRIPTION
<!-- pr-frontmatter
type: feature
related_plan: PLAN-006
related_epic: null
related_specs:
  - SPEC-IMASPARQL-002-basic
related_adrs:
  - ADR-0007
  - ADR-0014
  - ADR-0021
expected_modules:
  - docs/requirements/REQ-002-imasparql-rdf-loading.md
  - docs/specifications/basic/SPEC-IMASPARQL-002-basic.md
  - docs/plans/PLAN-006-imasparql-rdf-loading.md
  - docs/requirements/INDEX.md
  - docs/plans/INDEX.md
-->

## 概要

PR #175 (A8) で配置済の Docker Fuseki 構成 (`docker-compose.yml` + `data/imasparql/` + `docs/runbooks/local-imasparql.md`) は dataset placeholder のため、実 RDF データ取得 → Fuseki load → SPARQL クエリ動作確認の一連プロセスが未確立。本 PR は `feature-request` Skill SoT 準拠で **REQ-002 + SPEC-IMASPARQL-002-basic + PLAN-006** を起票し計画立案を完結する (§4.6 コード禁止原則、実装は本 PR merge 後の後続 Plan-A / Plan-B / Plan-C に分離)。

## 関連

- Plan: [PLAN-006](docs/plans/PLAN-006-imasparql-rdf-loading.md) (新規)
- Spec: [SPEC-IMASPARQL-002-basic](docs/specifications/basic/SPEC-IMASPARQL-002-basic.md) (新規)
- Req: [REQ-002](docs/requirements/REQ-002-imasparql-rdf-loading.md) (新規)
- Epic: — (1 PR 完結の計画立案、Epic 化なし)
- ADR: ADR-0007 (im@sparql upstream-driven 同期) / ADR-0014 (Fuseki Docker) / ADR-0021 (Secrets 管理)
- 直接前段 PR: [#175](https://github.com/subroh0508/colormaster/pull/175) (A8 Docker Fuseki 配置)

## 変更内容

| 区分 | パス | 変更 |
|---|---|---|
| docs (requirements) | `docs/requirements/REQ-002-imasparql-rdf-loading.md` | 新規。WHY / WHAT (FR-1〜FR-7、UC-1〜UC-4、NFR、AC-1〜AC-7) を 11 セクションで記述 |
| docs (specifications) | `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` | 新規。upstream URL 候補 + 取得スクリプト / 検証スクリプト識別子レベル定義 + Fuseki load 方式選定 (bind mount 自動 load 推奨) + 動作確認クエリ (`ASK` / `SELECT` LIMIT 5、`.claude/rules/sparql.md` prefix 整合) を Mermaid と表で記述 |
| docs (plans) | `docs/plans/PLAN-006-imasparql-rdf-loading.md` | 新規。AC-1〜AC-8 + 後続 Plan-A / Plan-B / Plan-C を placeholder で列挙 |
| docs (index) | `docs/requirements/INDEX.md` | REQ-002 行追加 |
| docs (index) | `docs/plans/INDEX.md` | PLAN-006 行追加 |

合計 5 ファイル (新規 3 + 既存 2 touch)。`docker-compose.yml` / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md` / `backend/**` は **一切 touch していない**。

## 受け入れ基準 (AC)

- [x] AC-1: `docs/requirements/REQ-002-imasparql-rdf-loading.md` が 11 セクション (概要 / アクター / スコープ / UC / FR / NFR / 制約 / 用語 / トレーサビリティ / AC / Open Questions) で起票される
- [x] AC-2: `docs/specifications/basic/SPEC-IMASPARQL-002-basic.md` が 11 セクションで起票され、upstream URL 候補 + 取得スクリプト / 検証スクリプト識別子レベル定義 + Fuseki load 方式選定 (bind mount 推奨) を含む
- [x] AC-3: `docs/plans/PLAN-006-imasparql-rdf-loading.md` が起票され、後続 Plan-A / Plan-B / Plan-C を placeholder で列挙する
- [x] AC-4: `docs/requirements/INDEX.md` に REQ-002 行が追加され、`docs/plans/INDEX.md` に PLAN-006 行が追加される
- [x] AC-5: ライセンス CC BY-NC-SA 4.0 が REQ-002 / SPEC-IMASPARQL-002-basic の双方で明示される
- [x] AC-6: 設計書本文にコード断片が含まれない (§4.6.1、Mermaid と表のみ)
- [x] AC-7: 本 PR では `docker-compose.yml` / `data/imasparql/README.md` / `docs/runbooks/local-imasparql.md` / `backend/**` を一切 touch しない (`git diff` で確認)
- [x] AC-8: REQ-002 / SPEC-IMASPARQL-002-basic / PLAN-006 の frontmatter `related_*` が block 形式で記述され、双方向リンクが整合する

## テスト

- [ ] `./gradlew check` グリーン (docs-only PR のため type 検証のみ、A6 機械検証は未導入)
- [ ] 三層指標差分: `N/A (Kover/Konsist Spec/PITest 未導入、A7 で導入予定)`
- [ ] Roborazzi baseline 比較グリーン or 承認済: `N/A (UI 変更なし、A10 完了まで skip 妥当)`

### 手動検証

- [x] `docs-structure.md` §frontmatter 必須キー表に従い、REQ-002 / SPEC-002-basic / PLAN-006 の frontmatter 必須キーを確認
- [x] `.claude/rules/sparql.md` の必須 prefix セット (`rdf` / `rdfs` / `schema` / `imas` / `imass`) との整合を SPEC §7.2 で確認
- [x] CC BY-NC-SA 4.0 の文言を REQ-002 / SPEC-002-basic 双方に含めることを確認
- [x] `data/imasparql/` git 追跡除外維持を SPEC §1 / §10 で確認 (本 PR で `.gitignore` を touch せず、REQ-001 / PLAN-003 で配置済の設定を引き継ぐ)
- [x] commit 3 件が `feature-request` Skill SoT (`feat(infra)` PR を `docs(requirements)` / `docs(specifications)` / `docs(plans)` の 3 commit で構成) と PR #174 §commit 分離規範 に整合

## レビュー観点

`code-reviewer` Coordinator で以下 4 aspect を inline 評価予定:

- **spec-conformance**: `feature-request` Skill SoT 準拠 (§4.6 コード禁止原則遵守 / docs 11 セクション完備) / REQ ⇄ SPEC ⇄ Plan の双方向 frontmatter リンク整合 / 後続 Plan placeholder の独立性 (expected_modules non-overlap)
- **architecture**: Fuseki load 方式選定の SoT 整合 (SPEC-002-basic §7.3 bind mount 自動 load 推奨 + REQ-001 既設 `data/imasparql:/staging` mount 流用) / `.claude/rules/sparql.md` prefix 規約整合 / 取得スクリプト / 検証スクリプトの責務分離
- **security**: ライセンス CC BY-NC-SA 4.0 の REQ + SPEC 双方明示 / `data/imasparql/` git 追跡除外維持 / credentials / secrets 漏洩なし (本 PR は docs のみ、原典 URL とライセンス文言の引用は OK)
- **code-quality**: 5 行 summary / 日本語見出し / Mermaid 図数 (REQ-002: 1 図 / SPEC-002-basic: 4 図) / 関連リンクの実在性 / 表の列構造

## スクリーンショット (UI 変更時)

`N/A (UI 変更なし、docs-only PR)`

## 新規 API エンドポイント (該当時)

`N/A (本 PR は計画立案のみ、Fuseki SPARQL API は SPEC-IMASPARQL-001-basic §7 で既定義済を流用)`

## チェックリスト

- [x] `.claude/rules/` の関連規約を確認した (`feature-request` Skill SoT / `plan` / `docs-structure` / `template-language` / `markdown` / `sparql`)
- [x] 要件 (REQ-002) / 基本設計 (SPEC-IMASPARQL-002-basic) を起票・更新済 (詳細設計 `SPEC-IMASPARQL-002-detail` は本 PR scope 外、SPEC-IMASPARQL-001-basic §9 と同じ判断基準)
- [x] `@Spec("SPEC-NNN-N")` annotation 付きテストは本 PR scope 外 (docs-only PR、A7 以降 / Kotlin code touch ゼロのため対象なし)
- [x] PII / Secrets が diff に含まれていない (本 PR は docs のみ、ライセンス文言 / 公開 endpoint URL のみ引用)
- [x] roadmap-tracker は Plan 対象外 (R-34、本 PR は Plan で完結、roadmap への mirror なし)

## 補足

- 本 PR は **計画立案のみ**。スクリプト実装 (`scripts/fetch-imasparql-data.sh` / `scripts/test-imasparql-query.sh`) / runbook 拡充 / Kotlin code touch は **本 PR scope 外**、PLAN-006 内 placeholder の後続 Plan-A / Plan-B / Plan-C に分離。
- A8 PR #175 で残された Improvement (SPEC-001 `related_detail: []` の更新、Testcontainers / endpoint 切替の後続 Plan backlink、`.dockerignore` 配置 TODO、`docker-compose.yml` image tag Renovate 対応注記) は本 PR で扱わない (`feature-request` Skill SoT に基づく計画立案 scope 外、後続 Plan-A / A6 / C7 で扱う)。
- Step A (orchestrator pane で実環境 `docker compose up -d` 動作確認) は Docker Desktop credential helper hang 復旧後に並行進行。Step B (本 PR) は Step A 結果に関わらず先行して計画立案する。
