### PR TITLE
harness: PLAN-007 implementation (Claude Code Docker CLI 分離)

### DIFF
--- a/.claude/rules/docker-cli.md
+++ b/.claude/rules/docker-cli.md
@@ -1,0 +1,111 @@
+---
+id: rules-docker-cli
+title: Docker CLI 利用規約 (Claude Code Docker CLI 分離)
+status: stable
+last_updated: 2026-05-20
+paths:
+  - ".claude/skills/**/SKILL.md"
+  - "docs/runbooks/local-imasparql.md"
+  - "docs/runbooks/local-development.md"
+  - "docs/runbooks/claude-code-docker-setup.md"
+  - "docker-compose.yml"
+  - "scripts/docker-claude.sh"
+related_adrs:
+  - ADR-0014
+  - ADR-0021
+related_plan: docs/plans/PLAN-007-claude-code-docker-cli-isolation.md
+---
+
+# Docker CLI 利用規約 (Claude Code Docker CLI 分離)
+
+> **5 行以内 summary**: Claude Code セッションから Docker を実行する場合は
+> `./scripts/docker-claude.sh` (`DOCKER_CONFIG=$HOME/.docker-claude` を export して
+> `exec docker "$@"` する wrapper) を **絶対パス強制** で叩く。macOS Docker Desktop
+> `credsStore: "desktop"` が非対話的 shell で Keychain helper を呼び出して hang する症状を
+> 回避する。通常ターミナル / 人間手元実行 / CI は影響なし (通常 `docker` のまま)。
+
+## 基本方針
+
+- **Claude Code セッションから Docker を実行する場合は `./scripts/docker-claude.sh`** を絶対パスで叩く
+- `docker` 直叩きは **禁止** (`credsStore: "desktop"` hang リスクあり)
+- 通常ターミナル / 人間手元実行 / CI は通常 `docker` を継続利用 (本 rule の対象外)
+- wrapper は repo 内 commit (`scripts/docker-claude.sh`、`chmod +x` 済)、絶対パス呼出に統一
+
+## 背景
+
+macOS Docker Desktop の `~/.docker/config.json` に `credsStore: "desktop"` が設定されると、
+`docker-credential-desktop` helper が credential 操作 (`pull` / `push` / `compose up -d` 等の
+内部 auth lookup を含む) で Keychain にアクセスしようとする。Claude Code の非対話的 shell では
+Keychain prompt が処理できず、コマンドが 0% CPU で hang する事象が PLAN-007 §背景の Step A で
+発生した。
+
+回避策として `DOCKER_CONFIG` を `~/.docker-claude` 等の代替パスに分離し、その配下に
+`credsStore` を持たない `config.json` を配置することで credential helper を bypass する。
+Docker daemon 自体は健全 (`docker info` / `docker images` は応答済) であり、credential helper
+のみが症状の原因。
+
+関連 upstream issue:
+
+| 出典 | 概要 |
+|---|---|
+| docker/for-mac #7209 | "Verifying credentials failed" hang、Docker Desktop 起動直後 |
+| docker/docker-credential-helpers #319 | macOS Sonoma + Apple Silicon、login Keychain prompt 連発 |
+| docker/docker-credential-helpers #65 | docker login が random Keychain entry を読みに行く |
+| docker/for-mac #3774 | "Securely store Docker logins in macOS keychain" 設定変更で login 失敗 |
+
+## 運用
+
+| 項目 | 確定方針 |
+|---|---|
+| wrapper 配置 | `scripts/docker-claude.sh` (repo 内 commit、`chmod +x` 済) |
+| 呼出 | **絶対パス強制** (`./scripts/docker-claude.sh ...`) |
+| PATH 通し / direnv / alias | 本 rule では言及しない (必要時に別 PR で検討) |
+| `DOCKER_CONFIG` の `.zshrc` export | しない (wrapper のみで完結、Claude Code 起動時の自動 export は副作用大) |
+| 通常ターミナル / 人間手元実行 | 通常 `docker` を継続利用 (本 rule の対象外、`credsStore: "desktop"` 温存) |
+
+## 設定手順
+
+ホスト側 `~/.docker-claude/config.json` の 1 回限り作成手順は
+`docs/runbooks/claude-code-docker-setup.md` を Single Source of Truth として参照。
+本 rule では repo 側 SoT (`scripts/docker-claude.sh` + 呼出規約) のみ扱う。
+
+## 適用範囲
+
+| 対象 | wrapper 利用 | 備考 |
+|---|---|---|
+| Claude Code セッション経由の `docker` / `docker compose` | ✅ 必須 (`./scripts/docker-claude.sh`) | 本 rule の主対象 |
+| 通常ターミナル / 人間手元実行 | ❌ 利用不要 (通常 `docker` で OK) | `credsStore: "desktop"` 温存、Docker Desktop UX は変えない |
+| CI (`.github/workflows/**`) | ❌ 利用不要 (GitHub Actions runner は Keychain なし、credsStore 影響なし) | 通常 `docker` で OK、CI で wrapper を強制しない |
+| Cloud Run / Backend サービス (本番) | ❌ 利用不要 (本番 runtime は Docker CLI を叩かない) | `cloud-run-deploy.md` 参照 |
+
+## 機械検証 (A6 で導入)
+
+本 rule の機械検証は A6 step5 / step6 で別途実装予定 (本 PR では placeholder 予約):
+
+- **step5 (frontmatter 整合検証、Gradle カスタムタスク)**:
+  - `.claude/rules/docker-cli.md` の `paths` 配列に列挙されたファイルパターンが repo 内に実在することを検証
+  - frontmatter `related_adrs` / `related_plan` のリンク先実在性検証 (`docs-structure.md` §機械検証 と統合)
+- **step6 (shellcheck CI 統合)**:
+  - `scripts/docker-claude.sh` 及び `scripts/*.sh` 全件に対し shellcheck を `.github/workflows/` で実行
+  - trufflehog (`secrets.md` §機械検証) と並列構成、`secret-scan.yml` と同 workflow か別 workflow かは A6 で決定
+- **(参考) `bash -n` syntax check は本 PR 起票時に手動実行済** (`scripts/docker-claude.sh` AC-7、`docs/plans/PLAN-007-claude-code-docker-cli-isolation.md` §受け入れ基準 参照)
+
+## Gotchas
+
+- **`./scripts/docker-claude.sh` 忘れ → 通常 `docker` が hang する**: Claude Code セッションから `docker compose up -d` 等を直叩きすると `credsStore: "desktop"` 経由の Keychain prompt で 0% CPU hang。**絶対パス強制で wrapper を叩く**
+- **private registry login 利用時は `~/.docker-claude/` 側に auth が保存される**: `./scripts/docker-claude.sh login` を実行すると `~/.docker-claude/config.json` の `auths` セクションに credentials が書き込まれる。Docker Desktop の Keychain integration は使われないため、機密度に応じて手動ローテーション必要。詳細は `docs/runbooks/claude-code-docker-setup.md` §private registry 取扱い security note 参照
+- **`~/.docker-claude/config.json` を repo に commit しない**: ホスト側のローカル設定であり `.gitignore` で除外 (auths 漏洩防止、`secrets.md` 絶対 commit 禁止リストと整合)
+- **wrapper の `set -euo pipefail`** は failure を早期検出するための定型。`exec docker "$@"` で PID 引き継ぎ + 引数 pass-through を確実に行う
+- **`DOCKER_CONFIG` の既定値 fallback**: wrapper 内 `${DOCKER_CONFIG:-$HOME/.docker-claude}` により、呼出側が `DOCKER_CONFIG` を明示 export した場合はそれを尊重 (テスト用に一時パスに切り替えるユースケース等)
+- **CI / 本番では wrapper を使わない**: 本 rule §適用範囲 参照、`credsStore: "desktop"` は Docker Desktop 固有の症状であり Linux runner / Cloud Run には存在しない
+- **本 rule は shell コマンド例示を許容** (`docs-structure.md` §4.6.1 コード禁止原則は `docs/{requirements,specifications}/**` のみ対象、rule / runbook は対象外)
+
+## 関連
+
+- `docs/runbooks/claude-code-docker-setup.md` (ホスト側 setup 手順 SoT、`~/.docker-claude/config.json` 作成 / private registry 取扱い)
+- `docs/runbooks/local-imasparql.md` (Fuseki Docker 運用、Claude Code 経由実行時の wrapper 利用注記)
+- `docs/plans/PLAN-007-claude-code-docker-cli-isolation.md` (本 rule の起票 Plan、AC-1〜AC-8)
+- ADR-0014 (Fuseki Docker 採用、`docker-compose.yml` 配置根拠)
+- ADR-0021 (Secrets 管理ポリシー、private registry login 取扱いで参照)
+- `.claude/rules/{sparql,cloud-run-deploy,db-protection,secrets,pii}.md` (Docker 関連 rule、SoT cross-link で本 rule を参照する想定、gradual rollout は別 PR)
+- `scripts/docker-claude.sh` (wrapper 実体、`chmod +x` 済)

--- a/.claude/rules/rules-index.md
+++ b/.claude/rules/rules-index.md
@@ -2,7 +2,7 @@
 id: rules-index
 title: rules 索引
 status: living
-last_updated: 2026-05-19
+last_updated: 2026-05-20
 # 注意: 索引そのものは小さく、AI が他 rule を発見する起点として
 # 起動時に常時ロードしておくのが望ましいため `paths` を意図的に未設定。
 ---
@@ -141,6 +141,7 @@ last_updated: 2026-05-19
 | `merge-readiness.md` | stable (A2-3) | Merge 可否判定 (CI green + Critical 0 + 人間 approve の 3 条件) |
 | `pr-draft-policy.md` | stable (A2-3) | Draft → Ready 昇格条件、Draft 中の WIP commit ポリシー |
 | `spec-living-sync.md` | stable (A2-3) | 実装中の仕様変更時の双方向同期 (基本設計 / 詳細設計 ⇄ 実装コード) |
+| `docker-cli.md` | stable (Phase A、本 PR で起票) | Claude Code Docker CLI 分離 (DOCKER_CONFIG + wrapper script)、絶対パス強制 |
 
 ### ハーネス改善ループ
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@
 | `.claude/skills/orchestrator/**` | orchestrator-criteria.md, skill-authoring.md, harness-meta-criteria.md, implementation-workflow.md, pr-poller.md, branch-naming.md, merge-readiness.md |
 | `.claude/locks/**` | pr-poller.md |
 | `scripts/install-git-hooks.sh` | commit-message.md, branch-naming.md |
+| `scripts/docker-claude.sh`, `docs/runbooks/{local-imasparql,claude-code-docker-setup}.md`, `docker-compose.yml` | docker-cli.md |
 | `.claude/rules/**` | rules-index.md, docs-structure.md, template-language.md |
 
 ## グローバルルール
@@ -98,6 +99,7 @@
 - **IDE 操作は JetBrains MCP**、ライブラリ docs は **Context7 MCP**、Cloudflare 操作は **Cloudflare MCP**
 - **`@example.com` 以外のメールアドレスを fixture に書かない** (`.claude/rules/pii.md`)
 - **`.gitignore` 対象のファイルを絶対追跡しない** (`.env*` / `data/users.db*` / `*-credentials.json` 等)
+- **Claude Code から Docker 実行する場合は `./scripts/docker-claude.sh`** (DOCKER_CONFIG 分離 wrapper、絶対パス強制、`.claude/rules/docker-cli.md` SoT、PLAN-007 / ADR-0014)
 
 ## Worktree 運用 (implementation-workflow)
 

--- a/docs/runbooks/claude-code-docker-setup.md
+++ b/docs/runbooks/claude-code-docker-setup.md
@@ -1,0 +1,157 @@
+---
+id: runbook-claude-code-docker-setup
+title: Claude Code Docker CLI 分離 setup runbook
+status: stable
+last_updated: 2026-05-20
+related_plan: docs/plans/PLAN-007-claude-code-docker-cli-isolation.md
+related_rules:
+  - .claude/rules/docker-cli.md
+related_adrs:
+  - ADR-0014
+  - ADR-0021
+related_specs: []
+---
+
+# Claude Code Docker CLI 分離 setup runbook
+
+> **5 行以内 summary**: macOS Docker Desktop `credsStore: "desktop"` の Claude Code 非対話的 shell
+> hang を回避する setup 手順 (PLAN-007)。ホスト側 `~/.docker-claude/config.json` の 1 回限り作成
+> + repo 内 wrapper (`scripts/docker-claude.sh`) の **絶対パス強制** で呼出 (`./scripts/docker-claude.sh ...`)。
+> 通常ターミナル / 人間手元実行は影響なし (`credsStore: "desktop"` 温存)。`~/.docker-claude/config.json`
+> は git 管理外、private registry 利用時は §7 security note 参照。
+
+## 1. 前提
+
+| 項目 | 要求 | 確認コマンド |
+|---|---|---|
+| OS | macOS (Apple Silicon / Intel) | `uname -sm` |
+| Docker Desktop | インストール済 + 起動済 | `docker info` (通常ターミナルで応答すれば OK) |
+| Claude Code | v2.x (本リポジトリで利用) | `claude --version` (該当時) |
+| repo clone | `colormaster` (本 repo) を clone 済 | `git rev-parse --show-toplevel` |
+| `scripts/docker-claude.sh` | 本 PR-B merge 後の master に含まれる | `ls -l scripts/docker-claude.sh` で executable bit (`-rwxr-xr-x`) 確認 |
+
+## 2. ホスト側 setup (1 回限り)
+
+ホスト側 `~/.docker-claude/config.json` を 1 回限り作成する。`credsStore` を持たない
+最小 config を配置することで credential helper を bypass する。
+
+```bash
+# 1. ディレクトリ作成 (既存なら no-op)
+mkdir -p "$HOME/.docker-claude"
+
+# 2. 最小 config.json 配置 (credsStore なし、auths 空)
+cat > "$HOME/.docker-claude/config.json" <<'EOF'
+{
+  "auths": {}
+}
+EOF
+
+# 3. 配置確認
+cat "$HOME/.docker-claude/config.json"
+ls -la "$HOME/.docker-claude/"
+```
+
+- **`~/.docker/config.json` (Docker Desktop の本来 config) には触らない** (`credsStore: "desktop"` 温存、通常ターミナル / Docker Desktop UI への影響ゼロ)
+- **`~/.docker-claude/config.json` は git 管理外**: 本 runbook の手順は repo clone 後に各ホストで個別実行する初期 setup、commit / push 対象ではない
+- **PC 復旧後 / 新マシン setup 時は本 §2 を毎回実施**: 自動化スクリプトの起票は本 PR scope 外 (将来別 PR で検討)
+
+## 3. wrapper 利用方法
+
+Claude Code セッションから Docker を実行する場合は repo 内 wrapper を **絶対パス** で叩く:
+
+```bash
+# repo root にいる前提
+./scripts/docker-claude.sh ps
+./scripts/docker-claude.sh pull stain/jena-fuseki:4.10.0
+./scripts/docker-claude.sh compose up -d fuseki
+./scripts/docker-claude.sh compose down
+./scripts/docker-claude.sh compose logs fuseki
+```
+
+- **絶対パス強制** (`./scripts/docker-claude.sh ...` を repo root から実行): `.claude/rules/docker-cli.md` §運用 参照
+- **PATH 通し / direnv / alias は本 runbook では言及しない**: 必要時は個人選択 / 別 PR で検討 (絶対パス確定で運用上は不要)
+- **wrapper の中身は `DOCKER_CONFIG=$HOME/.docker-claude exec docker "$@"`**: 引数を完全 pass-through する単純な薄い shim
+- **通常ターミナル / 人間手元実行は通常 `docker`**: wrapper を介さず Docker Desktop の Keychain integration を継続利用可
+
+## 4. Claude Code への指示文例
+
+Claude Code への prompt / Skill / rule 内記述で Docker 実行を指示する場合は、以下のような表現で
+`./scripts/docker-claude.sh` を SoT 化する:
+
+```text
+Docker は ./scripts/docker-claude.sh で叩いてください (絶対パス)。
+docker 直叩きは macOS Docker Desktop credsStore: "desktop" の hang を引き起こすため禁止。
+詳細: .claude/rules/docker-cli.md
+```
+
+- **prompt 中で「`docker compose up -d`」と書く場合も「`./scripts/docker-claude.sh compose up -d`」に置換**
+- **rule / Skill / SKILL.md 内で Docker 例示を書く場合**: 「Claude Code 経由実行時は `./scripts/docker-claude.sh` を使う」注記を入れる (`local-imasparql.md` §3 / §6 / §7 の注記が参考)
+- **runbook 内の例示**: 人間手元実行も対象とする runbook では `docker compose` 直叩きの例示を残し、注記で「Claude Code 経由のみ wrapper」を明示 (`local-imasparql.md` の運用方針と整合)
+
+## 5. 切り分けコマンド
+
+wrapper が期待通り動作しているかの手動検証手順:
+
+```bash
+# 1. ~/.docker/config.json (Docker Desktop 本来 config) の credsStore を確認
+cat "$HOME/.docker/config.json"
+# 期待: "credsStore": "desktop" が設定されている (Docker Desktop 既定)
+
+# 2. ~/.docker-claude/config.json (wrapper 用 config) を確認
+cat "$HOME/.docker-claude/config.json"
+# 期待: { "auths": {} } のみで credsStore は含まれない
+
+# 3. wrapper を介して docker ps を実行 (Keychain prompt が出ないこと)
+./scripts/docker-claude.sh ps
+# 期待: 通常 ps 出力、hang なし
+
+# 4. 手動で DOCKER_CONFIG を export して動作確認
+DOCKER_CONFIG="$HOME/.docker-claude" docker ps
+# 期待: wrapper と同様に hang なしで応答
+
+# 5. wrapper の syntax check (CI 統合は A6 で予定、現状は手動)
+bash -n scripts/docker-claude.sh
+```
+
+- **`docker info` / `docker images` が応答する** = Docker daemon 自体は健全 (Step A 観測済)
+- **`docker pull` / `docker compose up -d` が 0% CPU で hang する** = credential helper 経由の Keychain prompt が原因 (本 setup の対象症状)
+
+## 6. トラブルシュート
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `./scripts/docker-claude.sh: No such file or directory` | repo clone 直後 / cwd が repo root 外 | `git rev-parse --show-toplevel` で repo root に `cd`、`ls -l scripts/docker-claude.sh` で executable bit 確認 |
+| `./scripts/docker-claude.sh: Permission denied` | `chmod +x` が外れている (commit 時の executable bit 漏れ等) | `chmod +x scripts/docker-claude.sh` で再付与、本 PR-B では `git update-index --chmod=+x` 不要 (commit 時に bit 込みで `git add`) |
+| wrapper 経由でも `docker pull` が hang | `~/.docker-claude/config.json` 未作成 / `credsStore` が混入 | 本 runbook §2 を再実施、`cat ~/.docker-claude/config.json` で `credsStore` キーが含まれないことを確認 |
+| `DOCKER_CONFIG` が読まれない (wrapper 介しても通常 `~/.docker/` が参照される) | shell 環境で `DOCKER_CONFIG` が unset 以外の値で上書きされている | `unset DOCKER_CONFIG` 後に wrapper を再実行、または `DOCKER_CONFIG="$HOME/.docker-claude" docker ps` で手動指定して切り分け |
+| private registry に `docker login` が必要 | `~/.docker-claude/` 側に auth が保存される (§7 参照) | `./scripts/docker-claude.sh login <registry>` で実行、`~/.docker-claude/config.json` の `auths` セクションに credentials が書き込まれる |
+| 通常ターミナルでの `docker` が遅い / hang | wrapper とは別の Docker Desktop 側既存症状 | 本 runbook の対象外。Docker Desktop 再起動 / `docker logout` 等の標準対応を参照 |
+
+## 7. private registry 取扱い security note
+
+`./scripts/docker-claude.sh login <registry>` を実行すると `~/.docker-claude/config.json` の
+`auths` セクションに credentials が書き込まれる (`credsStore` を持たないため Keychain には
+保存されず、**plaintext base64 encoded** で書き込まれる)。
+
+| 項目 | 取扱い |
+|---|---|
+| 保存先 | `~/.docker-claude/config.json` (`auths.<registry>.auth` フィールド、base64 encoded plaintext) |
+| Keychain との関係 | wrapper 経由は Keychain を使わない (本 setup の目的)、通常ターミナルの `docker login` のみ Keychain 保存 |
+| git 管理 | `~/.docker-claude/` 配下は **絶対に commit しない** (`.gitignore` 対象外だが、本 runbook の手順で repo 外に配置しているため commit リスクは構造的に低い) |
+| ローテーション | `secrets.md` §ローテーション 参照、Cloudflare / GitHub PAT / GCP service account 等の token は 90 日 / 180 日周期、private registry token も同等の運用を推奨 |
+| 漏洩検出 | `~/.docker-claude/config.json` を誤って repo に commit した場合は即時 `git filter-repo` 等で history rewrite + token ローテーション (`secrets.md` §漏洩検出 参照) |
+| Claude Code への共有 | `~/.docker-claude/config.json` の `auths` セクションを Claude Code prompt / Skill 出力に含めない (`pii.md` / `secrets.md` redaction 強制と整合、`auth` フィールド値は `[REDACTED-SECRET]` に置換) |
+
+- **`.docker/credentials` や `.docker-claude/credentials` 等の追加 credential ファイルは現状作成しない**: wrapper は `config.json` の `auths` のみ参照
+- **本 setup で `credsStore` を意図的に外している**: Keychain integration を諦める代償として hang 回避を実現、機密度が高い private registry を頻繁に使う場合は通常ターミナル + Docker Desktop の Keychain integration を併用する運用も可 (Claude Code 経由のみ wrapper)
+
+## 8. 関連
+
+- `.claude/rules/docker-cli.md` (本 runbook の repo 側 SoT、wrapper 利用規約)
+- `docs/runbooks/local-imasparql.md` (Fuseki Docker 運用、Claude Code 経由実行時の wrapper 注記)
+- `docs/plans/PLAN-007-claude-code-docker-cli-isolation.md` (本 runbook の起票 Plan、AC-3)
+- ADR-0014 (Fuseki Docker 採用、`docker-compose.yml` 配置根拠)
+- ADR-0021 (Secrets 管理ポリシー、private registry token ローテーション)
+- `.claude/rules/secrets.md` §ローテーション / §漏洩検出 (private registry token 取扱い)
+- `.claude/rules/pii.md` §redaction (Skill 出力前の `auths` 漏洩防止)
+- `scripts/docker-claude.sh` (wrapper 実体、`chmod +x` 済)

--- a/docs/runbooks/local-imasparql.md
+++ b/docs/runbooks/local-imasparql.md
@@ -2,7 +2,7 @@
 id: runbook-local-imasparql
 title: im@sparql ローカル Fuseki Docker 環境
 status: living
-last_updated: 2026-05-19
+last_updated: 2026-05-20
 related_adrs:
   - ADR-0007
   - ADR-0014
@@ -66,6 +66,11 @@ docker compose up -d fuseki
 - 2 回目以降は数秒で起動完了
 - 起動完了は `docker compose ps` の `STATUS` が `Up (healthy)` になるまで
 
+> **注 (Claude Code 経由実行時)**: 上記コマンドを Claude Code セッションから実行する場合は
+> **`./scripts/docker-claude.sh`** で叩く (絶対パス、PLAN-007 / `.claude/rules/docker-cli.md` 参照)。
+> `docker` 直叩きは macOS Docker Desktop `credsStore: "desktop"` 経由の Keychain helper で
+> 0% CPU hang するリスクあり。人間手元実行 / 通常ターミナルは影響なし (通常 `docker` のまま)。
+
 ## 4. 接続確認
 
 ### 4.1. 管理 UI
@@ -124,7 +129,16 @@ docker compose down
 - in-memory dataset (default) は停止で揮発、再起動時は再投入が必要
 - TDB2 永続化を有効化していれば `data/imasparql/tdb2/` 配下にデータが残る (TDB2 設定は本 runbook §8 オプションを参照)
 
+> **注 (Claude Code 経由実行時)**: 上記コマンドを Claude Code セッションから実行する場合は
+> **`./scripts/docker-claude.sh`** で叩く (絶対パス、PLAN-007 / `.claude/rules/docker-cli.md` 参照)。
+> `docker` 直叩きは `credsStore: "desktop"` hang リスクあり。人間手元実行は影響なし。
+
 ## 7. トラブルシュート
+
+> **注 (Claude Code 経由実行時)**: 下表の対処コマンド (`docker compose logs` / `docker compose ps`
+> / `docker logout` / `docker login` 等) を Claude Code セッションから実行する場合は
+> **`./scripts/docker-claude.sh`** で叩く (絶対パス、PLAN-007 / `.claude/rules/docker-cli.md` 参照)。
+> `docker` 直叩きは `credsStore: "desktop"` hang リスクあり。人間手元実行は影響なし。
 
 | 症状 | 原因 | 対処 |
 |---|---|---|
@@ -174,6 +188,9 @@ A8 後続 Plan で `IMASPARQL_ENDPOINT_URL` 等の環境変数経由の切替を
 - `data/imasparql/README.md` (RDF データ取得 / ライセンス注意)
 - `.claude/rules/sparql.md` (SPARQL クエリ実装規約)
 - `.claude/rules/secrets.md` (`.env` / `.env.example` 規約)
+- `.claude/rules/docker-cli.md` (Claude Code 経由実行時の wrapper 利用規約、PLAN-007)
+- `docs/runbooks/claude-code-docker-setup.md` (`scripts/docker-claude.sh` の host setup 手順)
+- `docs/plans/PLAN-007-claude-code-docker-cli-isolation.md` (本 runbook §3 / §6 / §7 注記追加の Plan)
 - `docs/runbooks/local-development.md` §6 (本 runbook へのリンク元)
 - Apache Jena Fuseki: https://jena.apache.org/documentation/fuseki2/
 - stain/jena-fuseki Docker image: https://hub.docker.com/r/stain/jena-fuseki

--- a/scripts/docker-claude.sh
+++ b/scripts/docker-claude.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Claude Code Docker CLI 分離 wrapper
+# PLAN-007: macOS Docker Desktop credsStore: "desktop" の Claude Code 非対話的 shell hang 回避
+# 詳細: docs/runbooks/claude-code-docker-setup.md / .claude/rules/docker-cli.md
+set -euo pipefail
+export DOCKER_CONFIG="${DOCKER_CONFIG:-$HOME/.docker-claude}"
+exec docker "$@"


### PR DESCRIPTION
<!-- pr-frontmatter
type: harness
related_plan: PLAN-007
related_epic: null
related_adrs:
  - ADR-0014
  - ADR-0021
related_specs: []
expected_modules:
  - scripts/docker-claude.sh
  - .claude/rules/docker-cli.md
  - docs/runbooks/claude-code-docker-setup.md
  - docs/runbooks/local-imasparql.md
  - CLAUDE.md
  - .claude/rules/rules-index.md
-->

## 概要

PLAN-007 の implementation PR。macOS Docker Desktop の `credsStore: "desktop"` が
Claude Code 非対話的 shell で Keychain helper 呼出により hang する症状を解消するため、
`DOCKER_CONFIG` 分離 + wrapper script (案 A+A2) を採用。`scripts/docker-claude.sh` を
repo 内 commit し、**絶対パス強制** (`./scripts/docker-claude.sh ...`) で運用する。
Step A (im@sparql Docker 実環境動作確認) の blocker 解消の repo 側 SoT 化までを本 PR で完結し、
host setup + dogfood 検証は PC 復旧後の後続 Step。

## 関連

- Plan: [PLAN-007](../blob/master/docs/plans/PLAN-007-claude-code-docker-cli-isolation.md) (本 PR の起票 Plan、AC-1〜AC-8)
- ADR: ADR-0014 (Fuseki Docker 採用、`docker-compose.yml` 配置根拠) / ADR-0021 (Secrets 管理ポリシー、private registry login 取扱い)
- 直接トリガ: PR #175 (A8 Docker Fuseki 配置、Step A blocker の発生源)
- 直接前段: PR #186 (PLAN-006 im@sparql RDF loading、Step B 計画立案)
- 連携: PR #184 (`implementation-workflow` Phase 8 拡張、本 PR merge 後の Plan frontmatter 自動同期)
- 起票 PR: PR #187 (PLAN-007 起票、本 PR の前段)

## PR の種別

- [x] **ハーネス改修 PR** (PLAN-007 implementation、`harness/claude-code-docker-cli-isolation` ブランチ)
- [ ] A1 レトロ 等の即時消化フォロー PR
- [ ] rules / Skill 本格化
- [ ] レトロ集約 PR
- [ ] 外部研究駆動の改修 PR
- [ ] その他

## 変更内容 (6 ファイル touch)

| 区分 | パス | 変更内容 | AC |
|---|---|---|---|
| script | `scripts/docker-claude.sh` (新規) | `DOCKER_CONFIG=$HOME/.docker-claude exec docker "$@"` の 7 行 wrapper、`chmod +x` 済、`bash -n` syntax check pass | AC-1 / AC-7 |
| rule | `.claude/rules/docker-cli.md` (新規) | wrapper 利用規約・背景・運用・適用範囲・Gotchas・関連リンクを SoT 化、`paths` で自動ロード対象限定、§機械検証 (A6 で導入) placeholder | AC-2 |
| rule (索引) | `.claude/rules/rules-index.md` | プロセスカテゴリ末尾に `docker-cli.md` 行追加、`last_updated: 2026-05-20` に更新 | AC-6 |
| runbook | `docs/runbooks/claude-code-docker-setup.md` (新規) | host 側 `~/.docker-claude/config.json` の 1 回限り setup + wrapper 利用方法 + 切り分けコマンド + private registry security note | AC-3 |
| runbook | `docs/runbooks/local-imasparql.md` | §3 / §6 / §7 トラブルシュート 3 箇所に「Claude Code 経由は wrapper を叩く」注記追加、§10 関連リンク追加、`last_updated` 更新 | AC-4 |
| 起点 | `CLAUDE.md` | グローバルルール末尾に Docker wrapper 利用ルール 1 行追加、lookup table に `docker-cli.md` エントリ挿入 | AC-5 |

### 受け入れ基準充足チェックリスト (PLAN-007 AC-1〜AC-8)

- [x] **AC-1**: `scripts/docker-claude.sh` 新規起票 (`set -euo pipefail` + `DOCKER_CONFIG` export + `exec docker "$@"`、`chmod +x` 済、`bash -n` syntax check pass)
- [x] **AC-2**: `.claude/rules/docker-cli.md` 新規起票 (frontmatter `paths` 適用範囲指定、wrapper 利用規約 + `DOCKER_CONFIG` 分離方針 + 絶対パス強制呼出 SoT + §機械検証 (A6 で導入) placeholder)
- [x] **AC-3**: `docs/runbooks/claude-code-docker-setup.md` 新規起票 (`~/.docker-claude/config.json` 作成手順 + wrapper 利用 + Claude Code 指示文例 + 切り分けコマンド + private registry security note)
- [x] **AC-4**: `docs/runbooks/local-imasparql.md` 3 箇所注記追加 (§3 / §6 / §7 トラブルシュート)
- [x] **AC-5**: `CLAUDE.md` グローバルルール末尾 + lookup table 更新
- [x] **AC-6**: `.claude/rules/rules-index.md` プロセスカテゴリに `docker-cli` 行追加
- [x] **AC-7**: `scripts/docker-claude.sh` 動作確認 (`bash -n` syntax check pass、shellcheck CI 統合は A6 step6 で別途)
- [x] **AC-8**: 設計書本文は Markdown + shell コマンド例のみ、Kotlin / Gradle コード断片なし (`docs-structure.md` §4.6.1 整合、runbook の shell 例は許容)

## 3 軸定量評価

`harness-meta` / `harness-evolution` 由来の改修 PR ではない (PLAN-007 implementation = blocker 解消)
ため、ADR-0028 §dry-run 必須条件には該当しない。`harness-meta-criteria.md` §dry-run 不要条件
(典型的 typo / 表記揺れ / 1-2 行補正等の category) には完全該当しないが、新規 rule + runbook の
3 軸定量評価は計測コストに見合わない (Generator/Evaluator サイクル不要、SoT 化のみ) ため skip。

| 軸 | 計測 | 判定 |
|---|---|---|
| 改善度 | Step A blocker (PR #175 / im@sparql Fuseki Docker 動作確認) の解消 SoT 化 | N/A (Generator/Evaluator サイクル外、検証は dogfood = 後続 Step 3) |
| 再現性 | wrapper の決定的動作 (`DOCKER_CONFIG` export + `exec`) | N/A (CV / Jaccard 計測対象外、shell 仕様で確定的) |
| 副作用 | 通常ターミナル / 人間手元実行 / CI に影響なし (`credsStore: "desktop"` 温存) | N/A (退化率計測対象外、適用範囲が Claude Code 経由のみ) |

## レビュー観点

- **spec-conformance**: PLAN-007 AC-1〜AC-8 全充足、`.claude/rules/docker-cli.md` frontmatter (`paths` / `related_adrs` / `related_plan`) 整合、`docs/runbooks/claude-code-docker-setup.md` セクション完整 (§1〜§8)
- **architecture**: `implementation-workflow` Phase 8 拡張 (PR #184) との連携 (本 PR merge 後の Phase 8 Step 2 で PLAN-007 frontmatter が `status: completed` + `related_pr: <PR#>` + `completed_at: 2026-05-20` に同期)、`rules-index.md` プロセスカテゴリ配置整合、`CLAUDE.md` lookup table 並び保持 (既存テーブル末尾の `scripts/install-git-hooks.sh` 行と `.claude/rules/**` 行の間に挿入)
- **security**: PII / Secrets 漏洩なし (本 PR 内 `auths` / token / credential 等は記述なし、`~/.docker-claude/config.json` は git 管理外で repo 側に値を持たない)、private registry note の整合 (`secrets.md` ローテーション規約と link)、wrapper の `set -euo pipefail` + `exec docker "$@"` で shell injection リスクなし (引数 pass-through のみ)
- **code-quality**: 5 行 summary / 日本語見出し / Gotchas / 関連リンク双方向 (`docker-cli.md` ⇄ `claude-code-docker-setup.md` ⇄ `local-imasparql.md` ⇄ `CLAUDE.md` ⇄ `rules-index.md` の cross-link 完全閉路、PLAN-007 ⇄ ADR-0014 / ADR-0021 の参照確立)

## Test Plan

- [x] `bash -n scripts/docker-claude.sh` syntax check pass
- [x] `chmod +x scripts/docker-claude.sh` 後の executable bit (`-rwxr-xr-x`) が git index に反映 (commit `5dbb8f86`)
- [x] commit-msg hook (Conventional Commits 検証) を 4 commit 全てで pass
- [x] frontmatter block 形式遵守 (`paths` / `related_adrs` / `related_plan` 等、`docs-structure.md` §frontmatter 規約)
- [x] 日本語見出し (`template-language.md` ADR 0027 整合、frontmatter キーは英語のまま)
- [ ] shellcheck CI 統合 (A6 step6 で別途、本 PR では `bash -n` のみ AC-7、`docker-cli.md` §機械検証 (A6 で導入) placeholder で予約)
- [ ] dogfood 検証 (PC 復旧後 + host setup 後の `./scripts/docker-claude.sh pull stain/jena-fuseki:4.10.0` + Fuseki 起動確認 + `curl localhost:3030`) = PLAN-007 §後続 Step 3 で別途、Step A blocker を completed 昇格させる

## 後続 Step

PLAN-007 §後続 Step 引用:

| Step | 内容 | 実行タイミング |
|---|---|---|
| Step 1 | ホスト側 `~/.docker-claude/config.json` 作成 (1 回限り、`{ "auths": {} }`) | PC 復旧後、人手で実行 (`docs/runbooks/claude-code-docker-setup.md` §2 参照) |
| Step 2 (本 PR) | repo 側 PR-A (Plan 起票 = #187) → PR-B (本 PR、実装 6 ファイル) | PR-A merge 済、本 PR は本 PR-B |
| Step 3 | dogfood 検証 (`./scripts/docker-claude.sh pull` + Fuseki 起動確認 + `curl localhost:3030`) | 本 PR merge 後、Step A 再実行で Task #11 completed 昇格 |

## スコープ外 (本 PR で touch しないもの)

- **PR #175 Improvement 4** (`docker-compose.yml` image tag の Renovate 対応): 別 Plan で対応 (本 PR scope 外)
- **その他 Docker 言及 rule** (`sparql.md` / `cloud-run-deploy.md` / `db-protection.md` / `pii.md` / `secrets.md` / `r2-litestream.md` / `network-client.md` / `sqlite-data-file.md` / `sql-delight.md` / `firebase-boundary.md` / `no-firebase.md` / `removed-modules.md`): SoT cross-link で `docker-cli.md` 参照する gradual rollout は別 PR
- **shellcheck CI 統合**: A6 step6 (`trufflehog` と並列で `secret-scan.yml` 統合検討)、本 PR では `bash -n` syntax check のみ
- **`alias docker-claude='./scripts/docker-claude.sh'`** を `~/.zshrc` に書く運用: 絶対パス確定により不要、個人選択
- **`DOCKER_CONFIG` の `.zshrc` export**: wrapper のみで完結 (Claude Code 起動時の自動 export は副作用大)
- **`docker-compose.yml` 自体の書き換え**: `paths` で Read 対象として列挙のみ、本 PR では touch しない

## ロールバック

`git revert <本 PR squash merge commit>` で 6 ファイル変更を完全 revert。host 側
`~/.docker-claude/config.json` は別 Step で人手作成のため repo 側 touch なし、通常ターミナルの
Docker Desktop 利用は影響を受けない (`credsStore: "desktop"` 温存)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
