### PR TITLE
docs(plans): PLAN-007 frontmatter sync mirror (PR #188 dogfood 補完)

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -21,7 +21,7 @@ last_updated: 2026-05-20
 | [PLAN-004](PLAN-004-A5-removed-modules.md) | A5 不要モジュール撤去 (js / kotlin-js-store / Firebase Hosting 設定) | refactor | completed | — | 2026-05-19 |
 | [PLAN-005](PLAN-005-A6-lint-format-foundation-step1.md) | A6 Lint/Format 基盤 step1 = Spotless + ktlint 最小統合 | harness | completed | — | 2026-05-19 |
 | [PLAN-006](PLAN-006-imasparql-rdf-loading.md) | im@sparql RDF データ取得と Fuseki への load 計画立案 | feature-request | proposed | — | 2026-05-19 |
-| [PLAN-007](PLAN-007-claude-code-docker-cli-isolation.md) | Claude Code Docker CLI 分離 (DOCKER_CONFIG + wrapper script) | harness | proposed | — | 2026-05-20 |
+| [PLAN-007](PLAN-007-claude-code-docker-cli-isolation.md) | Claude Code Docker CLI 分離 (DOCKER_CONFIG + wrapper script) | harness | completed | — | 2026-05-20 |
 
 ## ステータス語彙
 

--- a/docs/plans/PLAN-007-claude-code-docker-cli-isolation.md
+++ b/docs/plans/PLAN-007-claude-code-docker-cli-isolation.md
@@ -2,8 +2,8 @@
 id: PLAN-007
 title: Claude Code Docker CLI 分離 (DOCKER_CONFIG + wrapper script)
 type: harness
-status: proposed
-related_pr: null
+status: completed
+related_pr: 188
 related_epic: null
 related_specs: []
 related_adrs:
@@ -17,7 +17,7 @@ expected_modules:
   - CLAUDE.md
   - .claude/rules/rules-index.md
 created_at: 2026-05-20
-completed_at: null
+completed_at: 2026-05-20
 promoted_to: null
 ---
 


### PR DESCRIPTION
## サマリ

PR [#188](https://github.com/subroh0508/colormaster/pull/188) (PLAN-007 implementation、merge commit `6071fe9`、6 ファイル) で実装完了したため、**PLAN-007 本体 + INDEX.md の frontmatter / 行を同期** する mirror PR。

## 反映内容

| 対象 | 旧 | 新 |
|---|---|---|
| `docs/plans/PLAN-007-claude-code-docker-cli-isolation.md` frontmatter `status` | `proposed` | `completed` |
| 同 `related_pr` | `null` | `188` |
| 同 `completed_at` | `null` | `2026-05-20` |
| `docs/plans/INDEX.md` PLAN-007 行 `status` 列 | `proposed` | `completed` |

差分 2 ファイル / +4 / -4 行、frontmatter / INDEX 行のみ、本文 touch ゼロ。

## 経緯 (PR #184 dogfood の learning)

PR [#184](https://github.com/subroh0508/colormaster/pull/184) で `implementation-workflow` Phase 8 に「関連 Plan/Epic frontmatter (status / related_pr / completed_at) 同期」責務を追加したが、本セッションの **PR-B (PR #188) prompt template が Phase 8 拡張前に起草された旧版** だったため、per-task pane が新責務を認識せず PLAN-007 を `proposed` のまま終了させた。本 mirror PR は PR #185 (bulk sync) と同パターンで補完。

### harness-meta 改修候補 (本 mirror PR の retro Try)

- `.claude/skills/orchestrator/SKILL.md` Phase 2 §Step 2-C の **per-task pane 起動 prompt テンプレ** に「Phase 8 で Plan/Epic frontmatter 同期 (inline or mirror PR)」明示を追加
- 採用判定基準 1 (反復観測): PR #184 dogfood で初回観測、後続 implementation PR で再発しないように SoT 反映

## R-15 事前承認

orchestrator pane (subroh0508) が本 mirror PR (self-merge を含む) を本セッション一括承認 (「A 実行で」指示) で out-of-band human approval 済み。

## Test Plan

- [x] `docs/plans/PLAN-007-*.md` frontmatter 4 行更新 (`status` / `related_pr` / `completed_at` + 関連)
- [x] `docs/plans/INDEX.md` PLAN-007 行 status 列更新
- [x] markdown syntax 確認 (frontmatter block 形式維持)
- [ ] CI green (Test / Android + Lint / Format Check、Markdown only)

## 関連

- PR [#188](https://github.com/subroh0508/colormaster/pull/188) (PLAN-007 implementation、本 PR が同期対象)
- PR [#187](https://github.com/subroh0508/colormaster/pull/187) (PLAN-007 起票、本 PR の前々段)
- PR [#185](https://github.com/subroh0508/colormaster/pull/185) (stale 5 件 bulk sync、本 PR の参考 pattern)
- PR [#184](https://github.com/subroh0508/colormaster/pull/184) (implementation-workflow Phase 8 拡張、本 PR で dogfood retro 提案)
- `.claude/rules/plan.md` (Plan status 遷移)
- `.claude/rules/implementation-workflow.md` Phase 8 §関連 Plan / Epic frontmatter 同期
